### PR TITLE
Fix FTBFS on GNU/Hurd

### DIFF
--- a/client/as-util.c
+++ b/client/as-util.c
@@ -825,15 +825,15 @@ static gboolean
 as_util_install_icons (const gchar *filename, const gchar *origin, GError **error)
 {
 	const gchar *destdir;
-	const gchar *tmp;
+	const gchar *tmp, *pathname;
 	gboolean ret = TRUE;
-	gchar buf[PATH_MAX];
 	gsize len;
 	int r;
 	struct archive *arch = NULL;
 	struct archive_entry *entry;
 	_cleanup_free_ gchar *data = NULL;
 	_cleanup_free_ gchar *dir = NULL;
+	_cleanup_free_ gchar *buf = NULL;
 
 	destdir = g_getenv ("DESTDIR");
 	dir = g_strdup_printf ("%s/usr/share/app-info/icons/%s",
@@ -875,25 +875,25 @@ as_util_install_icons (const gchar *filename, const gchar *origin, GError **erro
 		}
 
 		/* no output file */
-		if (archive_entry_pathname (entry) == NULL)
+		pathname = archive_entry_pathname (entry);
+		if (pathname == NULL)
 			continue;
 
 		/* update output path */
-		g_snprintf (buf, PATH_MAX, "%s/%s",
-			    dir, archive_entry_pathname (entry));
+		buf = g_build_filename (dir, pathname, NULL);
 		archive_entry_update_pathname_utf8 (entry, buf);
 
 		/* update hardlinks */
 		tmp = archive_entry_hardlink (entry);
 		if (tmp != NULL) {
-			g_snprintf (buf, PATH_MAX, "%s/%s", dir, tmp);
+			buf = g_build_filename (dir, tmp, NULL);
 			archive_entry_update_hardlink_utf8 (entry, buf);
 		}
 
 		/* update symlinks */
 		tmp = archive_entry_symlink (entry);
 		if (tmp != NULL) {
-			g_snprintf (buf, PATH_MAX, "%s/%s", dir, tmp);
+			buf = g_build_filename (dir, tmp, NULL);
 			archive_entry_update_symlink_utf8 (entry, buf);
 		}
 

--- a/libappstream-builder/asb-utils.c
+++ b/libappstream-builder/asb-utils.c
@@ -234,10 +234,10 @@ static gboolean
 asb_utils_explode_file (struct archive_entry *entry, const gchar *dir)
 {
 	const gchar *tmp;
-	gchar buf[PATH_MAX];
 	guint symlink_depth;
 	_cleanup_free_ gchar *back_up = NULL;
 	_cleanup_free_ gchar *path = NULL;
+	_cleanup_free_ gchar *buf = NULL;
 
 	/* no output file */
 	if (archive_entry_pathname (entry) == NULL)
@@ -246,7 +246,7 @@ asb_utils_explode_file (struct archive_entry *entry, const gchar *dir)
 	/* update output path */
 	tmp = archive_entry_pathname (entry);
 	path = asb_utils_sanitise_path (tmp);
-	g_snprintf (buf, PATH_MAX, "%s%s", dir, path);
+	buf = g_build_filename (dir, path, NULL);
 	archive_entry_update_pathname_utf8 (entry, buf);
 
 	/* update hardlinks */
@@ -254,7 +254,7 @@ asb_utils_explode_file (struct archive_entry *entry, const gchar *dir)
 	if (tmp != NULL) {
 		_cleanup_free_ gchar *path_link = NULL;
 		path_link = asb_utils_sanitise_path (tmp);
-		g_snprintf (buf, PATH_MAX, "%s%s", dir, path_link);
+		buf = g_build_filename (dir, path_link, NULL);
 		if (!g_file_test (buf, G_FILE_TEST_EXISTS)) {
 			g_warning ("%s does not exist, cannot hardlink", tmp);
 			return FALSE;
@@ -271,7 +271,7 @@ asb_utils_explode_file (struct archive_entry *entry, const gchar *dir)
 		back_up = asb_utils_get_back_to_root (symlink_depth);
 		if (tmp[0] == '/')
 			tmp++;
-		g_snprintf (buf, PATH_MAX, "%s%s", back_up, tmp);
+		buf = g_build_filename (back_up, tmp, NULL);
 		archive_entry_update_symlink_utf8 (entry, buf);
 	}
 	return TRUE;

--- a/libappstream-builder/plugins/asb-plugin-gstreamer.c
+++ b/libappstream-builder/plugins/asb-plugin-gstreamer.c
@@ -111,9 +111,10 @@ static const AsbGstreamerDescData data[] = {
 static gboolean
 asb_utils_is_file_in_tmpdir (const gchar *tmpdir, const gchar *filename)
 {
-	gchar tmp[PATH_MAX];
-	g_snprintf (tmp, PATH_MAX, "%s/%s", tmpdir, filename);
-	return g_file_test (tmp, G_FILE_TEST_EXISTS);
+	_cleanup_free_ gchar *tmp = NULL;
+	g_build_filename (tmpdir, filename, NULL);
+	gboolean ret = g_file_test (tmp, G_FILE_TEST_EXISTS);
+	return ret;
 }
 
 /**


### PR DESCRIPTION
Currently appstream-glib FTBFS on GNU/Hurd due to usage of PATH_MAX,
which is not defined. The attached patch solves this problem by
dynamically allocating strings of required length, and free them after
usage if needed.

Many thanks to Svante Signell svante.signell@gmail.com for the patch!

Reference: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766333
(patch modified to apply on the current Git master)
