### PR TITLE
tests: Fix DSO Linking error when built with --as-needed

### DIFF
--- a/libappstream-builder/Makefile.am
+++ b/libappstream-builder/Makefile.am
@@ -101,6 +101,7 @@ check_PROGRAMS =						\
 asb_self_test_SOURCES =						\
 	asb-self-test.c
 asb_self_test_LDADD =						\
+	$(AS_GLIB_LIBS)						\
 	$(GLIB_LIBS)						\
 	$(GDKPIXBUF_LIBS)					\
 	$(SOUP_LIBS)						\


### PR DESCRIPTION
Fix Build error in tests

make[3]: Entering directory '/media/src/jhbuild-checkout/source/appstream-glib/libappstream-builder'
  CC       asb_self_test-asb-self-test.o
  CCLD     asb-self-test
/usr/bin/ld.bfd.real: asb_self_test-asb-self-test.o: undefined reference to symbol 'as_store_from_file'
/opt/gnome/lib/libappstream-glib.so.7: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:885: recipe for target 'asb-self-test' failed
make[3]: *** [asb-self-test] Error 1
 