### PR TITLE
Build: link libasb_plugin_font.la with GTK3

### DIFF
--- a/libappstream-builder/plugins/Makefile.am
+++ b/libappstream-builder/plugins/Makefile.am
@@ -125,7 +125,7 @@ libasb_plugin_ibus_xml_la_LDFLAGS = -module -avoid-version
 libasb_plugin_ibus_xml_la_CFLAGS = $(GLIB_CFLAGS) $(WARNINGFLAGS_C)
 
 libasb_plugin_font_la_SOURCES = asb-plugin-font.c
-libasb_plugin_font_la_LIBADD = $(GLIB_LIBS) $(FREETYPE_LIBS) $(GDKPIXBUF_LIBS)
+libasb_plugin_font_la_LIBADD = $(GLIB_LIBS) $(FREETYPE_LIBS) $(GDKPIXBUF_LIBS) $(GTK_LIBS)
 libasb_plugin_font_la_LDFLAGS = -module -avoid-version
 libasb_plugin_font_la_CFLAGS = $(GLIB_CFLAGS) $(GTK_CFLAGS) $(WARNINGFLAGS_C)
 


### PR DESCRIPTION
Until f630bcf, linking GDKPIXBUF implicitly also linked against gtk+-3.0
libappstream-builder itself is linked against the whole stack, but when linking
using -Wl,--as-needed, the library references to cairo and gdk are dropped for
not being used. Hence, let's explicitly link the font-plugin against GTK.