### PR TITLE
Avoid using PATH_MAX

### DIFF
--- a/libappstream-builder/asb-self-test.c
+++ b/libappstream-builder/asb-self-test.c
@@ -43,8 +43,7 @@
 static gchar *
 asb_test_get_filename (const gchar *filename)
 {
-	char full_tmp[PATH_MAX];
-	gchar *tmp;
+	_cleanup_free_libc_ gchar *tmp = NULL;
 	_cleanup_free_ gchar *path = NULL;
 
 	/* try the source then the destdir */
@@ -53,10 +52,11 @@ asb_test_get_filename (const gchar *filename)
 		g_free (path);
 		path = g_build_filename (TESTDIRBUILD, filename, NULL);
 	}
-	tmp = realpath (path, full_tmp);
+	/* glibc allocates a buffer */
+	tmp = realpath (path, NULL);
 	if (tmp == NULL)
 		return NULL;
-	return g_strdup (full_tmp);
+	return g_strdup (tmp);
 }
 
 /**

--- a/libappstream-glib/as-cleanup.h
+++ b/libappstream-glib/as-cleanup.h
@@ -29,6 +29,8 @@
 #include "as-node.h"
 #include "as-yaml.h"
 
+#include <stdlib.h>
+
 G_BEGIN_DECLS
 
 #define GS_DEFINE_CLEANUP_FUNCTION(Type, name, func) \
@@ -76,10 +78,13 @@ GS_DEFINE_CLEANUP_FUNCTION(char**, gs_local_strfreev, g_strfreev)
 GS_DEFINE_CLEANUP_FUNCTION(GList*, gs_local_free_list, g_list_free)
 GS_DEFINE_CLEANUP_FUNCTION(void*, gs_local_free, g_free)
 
+GS_DEFINE_CLEANUP_FUNCTION(void*, gs_local_free_libc, free)
+
 #define _cleanup_date_time_unref_ __attribute__ ((cleanup(gs_local_date_time_unref)))
 #define _cleanup_dir_close_ __attribute__ ((cleanup(gs_local_dir_close)))
 #define _cleanup_timer_destroy_ __attribute__ ((cleanup(gs_local_destroy_timer)))
 #define _cleanup_free_ __attribute__ ((cleanup(gs_local_free)))
+#define _cleanup_free_libc_ __attribute__ ((cleanup(gs_local_free_libc)))
 #define _cleanup_checksum_free_ __attribute__ ((cleanup(gs_local_checksum_free)))
 #define _cleanup_error_free_ __attribute__ ((cleanup(gs_local_free_error)))
 #define _cleanup_list_free_ __attribute__ ((cleanup(gs_local_free_list)))

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -76,15 +76,15 @@ as_test_compare_lines (const gchar *txt1, const gchar *txt2, GError **error)
 static gchar *
 as_test_get_filename (const gchar *filename)
 {
-	char full_tmp[PATH_MAX];
-	gchar *tmp;
+	_cleanup_free_libc_ gchar *tmp = NULL;
 	_cleanup_free_ gchar *path = NULL;
 
 	path = g_build_filename (TESTDATADIR, filename, NULL);
-	tmp = realpath (path, full_tmp);
+	/* glibc allocates a buffer */
+	tmp = realpath (path, NULL);
 	if (tmp == NULL)
 		return NULL;
-	return g_strdup (full_tmp);
+	return g_strdup (tmp);
 }
 
 static GMainLoop *_test_loop = NULL;


### PR DESCRIPTION
Switch away from `PATH_MAX` (optional in `POSIX`), so appstream-glib builds and runs fine again on Hurd.