### PR TITLE
Don't reallocate malloc'd memory with g_malloc

### DIFF
--- a/libappstream-builder/asb-self-test.c
+++ b/libappstream-builder/asb-self-test.c
@@ -25,8 +25,6 @@
 #include <stdlib.h>
 #include <locale.h>
 
-#include "as-cleanup.h"
-
 #include "asb-context-private.h"
 #include "asb-plugin.h"
 #include "asb-plugin-loader.h"
@@ -43,7 +41,6 @@
 static gchar *
 asb_test_get_filename (const gchar *filename)
 {
-	_cleanup_free_libc_ gchar *tmp = NULL;
 	g_autofree gchar *path = NULL;
 
 	/* try the source then the destdir */
@@ -52,11 +49,7 @@ asb_test_get_filename (const gchar *filename)
 		g_free (path);
 		path = g_build_filename (TESTDIRBUILD, filename, NULL);
 	}
-	/* glibc allocates a buffer */
-	tmp = realpath (path, NULL);
-	if (tmp == NULL)
-		return NULL;
-	return g_strdup (tmp);
+	return realpath (path, NULL);
 }
 
 /**

--- a/libappstream-glib/as-cleanup.h
+++ b/libappstream-glib/as-cleanup.h
@@ -32,12 +32,6 @@
 
 G_BEGIN_DECLS
 
-#define GS_DEFINE_CLEANUP_FUNCTION(Type, name, func) \
-  static inline void name (void *v) \
-  { \
-    func (*(Type*)v); \
-  }
-
 #define GS_DEFINE_CLEANUP_FUNCTION0(Type, name, func) \
   static inline void name (void *v) \
   { \
@@ -48,9 +42,6 @@ G_BEGIN_DECLS
 GS_DEFINE_CLEANUP_FUNCTION0(GNode*, gs_local_node_unref, as_node_unref)
 GS_DEFINE_CLEANUP_FUNCTION0(GNode*, gs_local_yaml_unref, as_yaml_unref)
 
-GS_DEFINE_CLEANUP_FUNCTION(void*, gs_local_free_libc, free)
-
-#define _cleanup_free_libc_ __attribute__ ((cleanup(gs_local_free_libc)))
 #define _cleanup_node_unref_ __attribute__ ((cleanup(gs_local_node_unref)))
 #define _cleanup_yaml_unref_ __attribute__ ((cleanup(gs_local_yaml_unref)))
 

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -76,15 +76,10 @@ as_test_compare_lines (const gchar *txt1, const gchar *txt2, GError **error)
 static gchar *
 as_test_get_filename (const gchar *filename)
 {
-	_cleanup_free_libc_ gchar *tmp = NULL;
 	g_autofree gchar *path = NULL;
 
 	path = g_build_filename (TESTDATADIR, filename, NULL);
-	/* glibc allocates a buffer */
-	tmp = realpath (path, NULL);
-	if (tmp == NULL)
-		return NULL;
-	return g_strdup (tmp);
+	return realpath (path, NULL);
 }
 
 static GMainLoop *_test_loop = NULL;


### PR DESCRIPTION
glib's g_malloc and friends now always use malloc internally, as of glib
2.46: https://bugzilla.gnome.org/show_bug.cgi?id=751592

This means we no longer have to reallocate glibc malloc'd buffers and
can expect that g_free works fine on them.