### PR TITLE
dep11: Adapt to spec change

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -3777,9 +3777,8 @@ as_app_node_parse_dep11 (AsApp *app, GNode *node,
 			}
 			continue;
 		}
-		if (g_strcmp0 (tmp, "Packages") == 0) {
-			for (c = n->children; c != NULL; c = c->next)
-				as_app_add_pkgname (app, as_yaml_node_get_key (c));
+		if (g_strcmp0 (tmp, "Package") == 0) {
+			as_app_add_pkgname (app, as_yaml_node_get_value (n));
 			continue;
 		}
 		if (g_strcmp0 (tmp, "Name") == 0) {


### PR DESCRIPTION
Hi!
I don't have enough time to implement every bit of the DEP-11 0.8 specification (as described at http://www.freedesktop.org/software/appstream/docs/sect-AppStream-DEP11.html ), but this should at least make appstream-glib load some useful data from the files again.
Cheers,
    Matthias
