### PR TITLE
Ignore invalid desktop files

### DIFF
--- a/libappstream-glib/as-store.c
+++ b/libappstream-glib/as-store.c
@@ -2025,8 +2025,9 @@ as_store_load_installed (AsStore *store,
 				g_clear_error (&error_local);
 				continue;
 			}
-			g_propagate_error (error, error_local);
-			return FALSE;
+			g_warning ("failed to parse %s: %s", filename, error_local->message);
+			g_clear_error (&error_local);
+			continue;
 		}
 
 		/* do not load applications with vetos */


### PR DESCRIPTION
Don't error out just because we hit one bad desktop file; this could
lead to e.g. users never receiving updates.

https://bugzilla.gnome.org/show_bug.cgi?id=754313