### PR TITLE
Install gettext ITS rules

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -20,6 +20,9 @@ man_MANS +=						\
 endif
 endif
 
+itsdatadir = $(datadir)/gettext/its
+dist_itsdata_DATA = appdata.its appdata.loc
+
 XSLTPROC_FLAGS =					\
 	--nonet						\
 	--stringparam man.output.quietly 1		\

--- a/data/appdata.its
+++ b/data/appdata.its
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<its:rules xmlns:its="http://www.w3.org/2005/11/its"
+           version="2.0">
+  <its:translateRule selector="/component" translate="no"/>
+  <its:translateRule selector="/component/name |
+                               /component/summary |
+                               /component/description |
+                               /component/screenshots/screenshot/caption"
+                     translate="yes"/>
+</its:rules>

--- a/data/appdata.loc
+++ b/data/appdata.loc
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<locatingRules>
+  <locatingRule name="AppData" pattern="*.appdata.xml">
+    <documentRule localName="component" target="appdata.its"/>
+  </locatingRule>
+  <locatingRule name="AppData" pattern="*.metainfo.xml">
+    <documentRule localName="component" target="appdata.its"/>
+  </locatingRule>
+</locatingRules>


### PR DESCRIPTION
Recent gettext release has a feature to allow consumer projects to
supply their own string extraction rules for XML files, in ITS format.
Gettext itself ships the rule for AppData, but it would be better
maintained in the upstream project.

See the gettext documentation for details:
http://www.gnu.org/software/gettext/manual/html_node/Preparing-ITS-Rules.html#Preparing-ITS-Rules