### PR TITLE
Add missing G_BEGIN_DECLS in libappstream-glib/as-tag.h.

### DIFF
--- a/libappstream-glib/as-tag.h
+++ b/libappstream-glib/as-tag.h
@@ -28,6 +28,8 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 /**
  * AsTag:
  * @AS_TAG_UNKNOWN:			Type invalid or not known


### PR DESCRIPTION
Add missing G_BEGIN_DECLS. I suppose it was unintentional?