### PR TITLE
When loading a .yml file, look in /var/lib/app-info/ for icons, not /usr/share

### DIFF
--- a/libappstream-glib/as-store.c
+++ b/libappstream-glib/as-store.c
@@ -1048,7 +1048,7 @@ as_store_load_yaml_file (AsStore *store,
 	/* if we have an origin either from the YAML or _set_origin() */
 	if (priv->origin != NULL) {
 		if (icon_root == NULL)
-			icon_root = "/usr/share/app-info/icons/";
+			icon_root = "/var/lib/app-info/icons/";
 		icon_path = g_build_filename (icon_root,
 					      priv->origin,
 					      NULL);


### PR DESCRIPTION
We noticed in Ubuntu that the uninstalled (from appstream) icons weren't being found by as-glib and so the items weren't being added to the store, leaving us with an almost empty gnome-software!

After digging a little bit I found out that as-glib is looking in /usr/share/app-info/icons/ but they are actually in /var/lib/app-info/icons/ (https://github.com/ximion/appstream/blob/master/src/as-cache-builder.c#L289). Simply updating this path fixes the issue for me. I tried on Debian and they have the same problem. One curious thing is that I'm sure this *used* to work for Debian, so maybe something external has changed to break this? I'm not quite up to speed on all the various moving parts yet.

There's some discussion over on Launchpad (https://bugs.launchpad.net/ubuntu/+source/appstream-glib/+bug/1542242). If simply updating this path isn't right, I'm happy to implement another solution. :)

cc @ximion 