### PR TITLE
yaml: Make icon parser spec compliant

### DIFF
--- a/data/tests/usr/share/app-info/yaml/aequorea.yml
+++ b/data/tests/usr/share/app-info/yaml/aequorea.yml
@@ -9,7 +9,10 @@ Name:
   C: Iceweasel
 Package: iceweasel
 Icon:
-  cached: iceweasel.png
+  cached:
+      - name: iceweasel.png
+        width: 64
+        height: 64
 Keywords:
   C:
     - browser

--- a/libappstream-glib/as-icon.c
+++ b/libappstream-glib/as-icon.c
@@ -700,16 +700,58 @@ as_icon_node_parse (AsIcon *icon, GNode *node,
  * Since: 0.3.1
  **/
 gboolean
-as_icon_node_parse_dep11 (AsIcon *im, GNode *node,
+as_icon_node_parse_dep11 (AsIcon *icon, GNode *node,
 			  AsNodeContext *ctx, GError **error)
 {
-	if (g_strcmp0 (as_yaml_node_get_key (node), "cached") == 0) {
-		as_icon_set_name (im, as_yaml_node_get_value (node));
-		as_icon_set_kind (im, AS_ICON_KIND_CACHED);
-	} else if (g_strcmp0 (as_yaml_node_get_key (node), "stock") == 0) {
-		as_icon_set_name (im, as_yaml_node_get_value (node));
-		as_icon_set_kind (im, AS_ICON_KIND_STOCK);
+	GNode *n;
+	AsIconPrivate *priv = GET_PRIVATE (icon);
+
+	for (n = node->children; n != NULL; n = n->next) {
+		const gchar *key;
+		gint size;
+
+		key = as_yaml_node_get_key (n);
+		if (g_strcmp0 (key, "width") == 0) {
+			size = as_yaml_node_get_value_as_int (n);
+			if (size == G_MAXINT)
+				size = 64;
+			priv->width = size;
+		} else if (g_strcmp0 (key, "height") == 0) {
+			size = as_yaml_node_get_value_as_int (n);
+			if (size == G_MAXINT)
+				size = 64;
+			priv->height = size;
+		} else {
+			if (priv->kind == AS_ICON_KIND_REMOTE) {
+				if (g_strcmp0 (key, "url") == 0) {
+					const gchar *media_baseurl;
+					media_baseurl = as_node_context_get_media_base_url (ctx);
+					if (media_baseurl == NULL) {
+						/* no baseurl, we can just set the value as URL */
+						as_icon_set_url (icon, as_yaml_node_get_value (n));
+					} else {
+						/* handle the media baseurl */
+						g_autofree gchar *url = NULL;
+						url = g_build_filename (media_baseurl,
+									as_yaml_node_get_value (n),
+									NULL);
+						as_icon_set_url (icon, url);
+					}
+				}
+			} else {
+				if (g_strcmp0 (key, "name") == 0) {
+					const gchar *icon_name;
+					icon_name = as_yaml_node_get_value (n);
+
+					if (g_str_has_prefix (icon_name, "/"))
+						as_icon_set_filename (icon, icon_name);
+					else
+						as_icon_set_name (icon, icon_name);
+				}
+			}
+		}
 	}
+
 	return TRUE;
 }
 

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -4156,7 +4156,11 @@ as_test_yaml_func (void)
 		"  [KVL]C=Iceweasel\n"
 		" [KVL]Package=iceweasel\n"
 		" [MAP]Icon\n"
-		"  [KVL]cached=iceweasel.png\n"
+		"  [SEQ]cached\n"
+		"   [MAP]{\n"
+		"    [KVL]name=iceweasel.png\n"
+		"    [KVL]width=64\n"
+		"    [KVL]height=64\n"
 		" [MAP]Keywords\n"
 		"  [SEQ]C\n"
 		"   [KEY]browser\n"
@@ -4182,7 +4186,6 @@ as_test_yaml_func (void)
 	g_assert (ret);
 	g_string_free (str, TRUE);
 	as_yaml_unref (node);
-
 }
 
 static void


### PR DESCRIPTION
This should resolve #98 which became a pretty high-priority item now... It also, while we're at it, implements the full spec for DEP-11-YAML icons, you never know when we'll need it...

The code is basically copied from libappstream.

Btw, issue 100 for asglib! \o/