### PR TITLE
add missing "elementary" to list of project groups

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -4749,6 +4749,7 @@ as_app_parse_appdata_guess_project_group (AsApp *app)
 		const gchar *project_group;
 		const gchar *url_glob;
 	} table[] = {
+		{ "elementary",		"http*://elementary.io*" },
 		{ "Enlightenment",	"http://*enlightenment.org*" },
 		{ "GNOME",		"http*://*.gnome.org*" },
 		{ "GNOME",		"http://gnome-*.sourceforge.net/" },

--- a/libappstream-glib/as-environment-ids.txt
+++ b/libappstream-glib/as-environment-ids.txt
@@ -10,3 +10,4 @@ Unity
 XFCE
 EDE
 Cinnamon
+elementary


### PR DESCRIPTION
Most official elementary software sets the \<project_group\> tag content to "elementary", which is not a recognised project group. This renders nearly all their .appdata.xml files invalid when trying to validate them with appstream-util.

This change would include "elementary" in the list of recognised project groups (I guessed this has to be added to the  table at libappstream-glib/as-app.c:4750). The "homepage" URL used is "http://elementary.io/".

I assumed the list is intentionally alphabetically sorted, so I inserted the missing line according to that.