### PR TITLE
Fix g_ptr_array_sort use

### DIFF
--- a/libappstream-builder/asb-utils.c
+++ b/libappstream-builder/asb-utils.c
@@ -508,6 +508,12 @@ asb_utils_add_files_recursive (GPtrArray *files,
 	return TRUE;
 }
 
+static gint
+my_pstrcmp (const gchar **a, const gchar **b)
+{
+	return g_strcmp0 (*a, *b);
+}
+
 /**
  * asb_utils_write_archive_dir:
  * @filename: archive filename
@@ -535,7 +541,7 @@ asb_utils_write_archive_dir (const gchar *filename,
 		return TRUE;
 
 	/* sort by filename for deterministic results */
-	g_ptr_array_sort (files, g_strcmp0);
+	g_ptr_array_sort (files, (GCompareFunc) my_pstrcmp);
 
 	/* write tar file */
 	return asb_utils_write_archive (filename, directory, files, error);


### PR DESCRIPTION
Looks like the current code used g_ptr_array_sort() incorrectly; fix untested. Noticed because gcc complained:

asb-utils.c: In function ‘asb_utils_write_archive_dir’:
asb-utils.c:538:27: warning: passing argument 2 of ‘g_ptr_array_sort’ from incompatible pointer type [-Wincompatible-pointer-types]
  g_ptr_array_sort (files, g_strcmp0);
                           ^~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:31:0,
                 from /usr/include/glib-2.0/glib/gprintf.h:21,
                 from /usr/include/glib-2.0/glib/gstdio.h:23,
                 from asb-utils.c:30:
/usr/include/glib-2.0/glib/garray.h:175:12: note: expected ‘GCompareFunc {aka int (*)(const void *, const void *)}’ but argument is of type ‘int (*)(const char *, const char *)’
 void       g_ptr_array_sort               (GPtrArray        *array,
            ^~~~~~~~~~~~~~~~