### PR TITLE
Add ASB Extractor Plugin for Sugar Activities

### DIFF
--- a/libappstream-builder/plugins/Makefile.am
+++ b/libappstream-builder/plugins/Makefile.am
@@ -19,6 +19,7 @@ plugin_LTLIBRARIES =					\
 	libasb_plugin_appdata.la			\
 	libasb_plugin_shell_extension.la		\
 	libasb_plugin_desktop.la			\
+	libasb_plugin_sugar-activity.la			\
 	libasb_plugin_gettext.la			\
 	libasb_plugin_hardcoded.la
 
@@ -46,6 +47,11 @@ libasb_plugin_desktop_la_SOURCES = asb-plugin-desktop.c
 libasb_plugin_desktop_la_LIBADD = $(GLIB_LIBS) $(GDKPIXBUF_LIBS)
 libasb_plugin_desktop_la_LDFLAGS = -module -avoid-version
 libasb_plugin_desktop_la_CFLAGS = $(GLIB_CFLAGS) $(WARNINGFLAGS_C)
+
+libasb_plugin_sugar_activity_la_SOURCES = asb-plugin-sugar-activity.c
+libasb_plugin_sugar_activity_la_LIBADD = $(GLIB_LIBS) $(GDKPIXBUF_LIBS)
+libasb_plugin_sugar_activity_la_LDFLAGS = -module -avoid-version
+libasb_plugin_sugar_activity_la_CFLAGS = $(GLIB_CFLAGS) $(WARNINGFLAGS_C)
 
 libasb_plugin_appdata_la_SOURCES = asb-plugin-appdata.c
 libasb_plugin_appdata_la_LIBADD = $(GLIB_LIBS) $(GDKPIXBUF_LIBS)

--- a/libappstream-builder/plugins/asb-plugin-sugar-activity.c
+++ b/libappstream-builder/plugins/asb-plugin-sugar-activity.c
@@ -201,7 +201,6 @@ asb_plugin_process_actinfo (AsbPlugin *plugin,
 	tmp = g_key_file_get_string (actinfo, "Activity", "license", NULL);
 	if (tmp != NULL) {
 		as_app_set_project_license (app, tmp);
-		as_app_set_metadata_license (app, tmp);
 	}
 
 	tmp = g_key_file_get_string (actinfo, "Activity", "icon", NULL);

--- a/libappstream-builder/plugins/asb-plugin-sugar-activity.c
+++ b/libappstream-builder/plugins/asb-plugin-sugar-activity.c
@@ -91,14 +91,33 @@ _asb_plugin_load_sugar_icon (const gchar *path,
 			     AsIcon *ic) {
 	gsize len;
 	gchar *data = NULL;
+	gchar *tmp = NULL;
 	GBytes *bytes = NULL;
+	GString *string = NULL;
+	GRegex *regex = NULL;
 
 	if (!g_file_get_contents (path, &data, &len, NULL))
 		return FALSE;
-	printf ("ICON (got contents) = %s\n", path);
+
+	// Sugar icons have 2 XML entities, stroke_color and fill_color
+	regex = g_regex_new ("<!ENTITY stroke_color \"[^\"]+\">",
+			     0, 0, NULL);
+	tmp = g_regex_replace_literal (regex, data, len, 0,
+				       "<!ENTITY stroke_color \"#282828\">",
+				       0, NULL);
+	g_free (regex);
+
+	regex = g_regex_new ("<!ENTITY fill_color \"[^\"]+\">",
+			     0, 0, NULL);
+	tmp = g_regex_replace_literal (regex, tmp, -1, 0,
+				       "<!ENTITY fill_color \"#FFFFFF\">",
+				       0, NULL);
+	g_free (regex);
+
+	string = g_string_new (tmp);
+	bytes = g_string_free_to_bytes (string);
 
 	as_icon_set_kind (ic, AS_ICON_KIND_EMBEDDED);
-	bytes = g_bytes_new_take (data, len);
 	as_icon_set_data (ic, bytes);
 	as_icon_set_width (ic, 75);
 	as_icon_set_height (ic, 75);

--- a/libappstream-builder/plugins/asb-plugin-sugar-activity.c
+++ b/libappstream-builder/plugins/asb-plugin-sugar-activity.c
@@ -1,0 +1,282 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Sam Parkinson <sam@sam.today>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <config.h>
+#include <string.h>
+#include <fnmatch.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+
+#include <asb-plugin.h>
+
+#define __APPSTREAM_GLIB_PRIVATE_H
+#include <as-utils-private.h>
+#include <as-app-private.h>
+
+/**
+ * asb_plugin_get_name:
+ */
+const gchar *
+asb_plugin_get_name (void)
+{
+	return "sugar-activity";
+}
+
+#define _SUGAR_ACTIVITY_GLOB "/usr/share/sugar/activities/*/activity/activity.info"
+#define _SUGAR_ACTIVITY_ICON_GLOB "/usr/share/sugar/activities/*/activity/*"
+#define _SUGAR_ACTIVITY_LINFO_GLOB "/usr/share/sugar/activities/*/locale/*/activity.linfo"
+
+/**
+ * asb_plugin_add_globs:
+ */
+void
+asb_plugin_add_globs (AsbPlugin *plugin, GPtrArray *globs)
+{
+	// the _SUGAR_ACTIVITY_GLOB is a subset of the icon glob
+	asb_plugin_add_glob (globs, _SUGAR_ACTIVITY_ICON_GLOB);
+	asb_plugin_add_glob (globs, _SUGAR_ACTIVITY_LINFO_GLOB);
+}
+
+/**
+ * _asb_plugin_is_actinfo
+ */
+static gboolean
+_asb_plugin_is_actinfo (const gchar *filename)
+{
+	if (asb_plugin_match_glob (_SUGAR_ACTIVITY_GLOB, filename))
+		return TRUE;
+	return FALSE;
+}
+
+/**
+ * _asb_plugin_is_linfo
+ */
+static gboolean
+_asb_plugin_is_linfo (const gchar *filename)
+{
+	if (asb_plugin_match_glob (_SUGAR_ACTIVITY_LINFO_GLOB, filename))
+		return TRUE;
+	return FALSE;
+}
+
+/**
+ * asb_plugin_check_filename:
+ */
+gboolean
+asb_plugin_check_filename (AsbPlugin *plugin, const gchar *filename)
+{
+	return _asb_plugin_is_linfo (filename) ||
+	       _asb_plugin_is_actinfo (filename);
+}
+
+static gboolean
+_asb_plugin_load_sugar_icon (const gchar *path,
+			     AsIcon *ic) {
+	gsize len;
+	gchar *data = NULL;
+	GBytes *bytes = NULL;
+
+	if (!g_file_get_contents (path, &data, &len, NULL))
+		return FALSE;
+	printf ("ICON (got contents) = %s\n", path);
+
+	as_icon_set_kind (ic, AS_ICON_KIND_EMBEDDED);
+	bytes = g_bytes_new_take (data, len);
+	as_icon_set_data (ic, bytes);
+	as_icon_set_width (ic, 75);
+	as_icon_set_height (ic, 75);
+	return TRUE;
+}
+
+/**
+ * asb_plugin_process_actinfo:
+ */
+static gboolean
+asb_plugin_process_actinfo (AsbPlugin *plugin,
+			    AsbPackage *pkg,
+			    const gchar *filename,
+			    AsApp *app,
+			    GError **error)
+{
+	gsize len;
+	const gchar *tmp;
+	g_autofree gchar *data = NULL;
+	g_autofree gchar *id = NULL;
+	g_autoptr(GKeyFile) actinfo = NULL;
+
+	if (!g_file_get_contents (filename, &data, &len, error))
+		return FALSE;
+
+	actinfo = g_key_file_new ();
+	if (!g_key_file_load_from_data (actinfo, data, len,
+					G_KEY_FILE_NONE, error))
+		return FALSE;
+
+	if (!g_key_file_has_group (actinfo, "Activity"))
+		return FALSE;
+	if (!g_key_file_has_key (actinfo, "Activity", "bundle_id", error))
+		return FALSE;
+
+	as_app_set_kind (app, AS_APP_KIND_DESKTOP);
+
+	tmp = g_key_file_get_string (actinfo, "Activity", "bundle_id", NULL);
+	id = g_strdup_printf ("%s.activity.desktop", tmp);
+	as_app_set_id (app, id);
+
+	tmp = g_key_file_get_string (actinfo, "Activity", "name", NULL);
+	if (tmp != NULL)
+		as_app_set_name (app, NULL, tmp);
+
+	tmp = g_key_file_get_string (actinfo, "Activity", "summary", NULL);
+	if (tmp != NULL) {
+		as_app_set_comment (app, NULL, tmp);
+		g_autofree gchar *desc = NULL;
+		desc = as_markup_import (tmp,
+					 AS_MARKUP_CONVERT_FORMAT_SIMPLE,
+					 error);
+		if (desc != NULL)
+			as_app_set_description (app, NULL, desc);
+	}
+
+	tmp = g_key_file_get_string (actinfo, "Activity", "license", NULL);
+	if (tmp != NULL) {
+		as_app_set_project_license (app, tmp);
+		as_app_set_metadata_license (app, tmp);
+	}
+
+	tmp = g_key_file_get_string (actinfo, "Activity", "icon", NULL);
+	if (tmp != NULL) {
+		g_autoptr(AsIcon) ic = NULL;
+		const gchar *directory;
+		const gchar *path;
+
+		directory = g_path_get_dirname (filename);
+
+		// Icon might be "icon.svg" or might already have .svg suffix
+		path = g_build_filename (directory, tmp, NULL);
+		if (!g_file_test (path, G_FILE_TEST_IS_REGULAR)) {
+			const gchar *with_dotsvg;
+			with_dotsvg = g_strdup_printf ("%s.svg", tmp);
+			path = g_build_filename (directory, with_dotsvg, NULL);
+		}
+
+		if (g_file_test (path, G_FILE_TEST_IS_REGULAR)) {
+			ic = as_icon_new ();
+			if (_asb_plugin_load_sugar_icon (path, ic))
+				as_app_add_icon (app, ic);
+		}
+	}
+	return TRUE;
+}
+
+/**
+ * asb_plugin_process_actinfo:
+ */
+static gboolean
+asb_plugin_process_linfo (AsbPlugin *plugin,
+			    AsbPackage *pkg,
+			    const gchar *filename,
+			    AsApp *app,
+			    GError **error)
+{
+	gsize len;
+	const gchar *tmp;
+	const gchar *locale;
+	g_autofree gchar *data = NULL;
+	g_autoptr(GKeyFile) linfo = NULL;
+
+	// filename ~= "/usr/share/sugar/activities/*/locale/*/activity.linfo"
+	// locale is the 2nd wildcard section
+	tmp = g_path_get_dirname (filename);
+	locale = g_path_get_basename (tmp);
+
+	if (!g_file_get_contents (filename, &data, &len, error))
+		return FALSE;
+
+	linfo = g_key_file_new ();
+	if (!g_key_file_load_from_data (linfo, data, len,
+					G_KEY_FILE_NONE, error))
+		return FALSE;
+	if (!g_key_file_has_group (linfo, "Activity"))
+		return FALSE;
+
+	tmp = g_key_file_get_string (linfo, "Activity", "name", NULL);
+	if (tmp != NULL)
+		as_app_set_name (app, locale, tmp);
+
+	tmp = g_key_file_get_string (linfo, "Activity", "summary", NULL);
+	if (tmp != NULL) {
+		as_app_set_comment (app, locale, tmp);
+		g_autofree gchar *desc = NULL;
+		desc = as_markup_import (tmp,
+					 AS_MARKUP_CONVERT_FORMAT_SIMPLE,
+					 error);
+		if (desc != NULL)
+			as_app_set_description (app, locale, desc);
+	}
+
+	return TRUE;
+}
+
+/**
+ * asb_plugin_process:
+ */
+GList *
+asb_plugin_process (AsbPlugin *plugin,
+		    AsbPackage *pkg,
+		    const gchar *tmpdir,
+		    GError **error)
+{
+	gboolean ret;
+	GList *apps = NULL;
+	guint i;
+	gchar **filelist;
+	g_autoptr(AsbApp) app = NULL;
+
+	app = asb_app_new (pkg, NULL);
+
+	filelist = asb_package_get_filelist (pkg);
+	for (i = 0; filelist[i] != NULL; i++) {
+		g_autofree gchar *filename_tmp = NULL;
+		filename_tmp = g_build_filename (tmpdir, filelist[i], NULL);
+
+		if (_asb_plugin_is_actinfo (filelist[i])) {
+			ret = asb_plugin_process_actinfo (
+			    plugin, pkg, filename_tmp, AS_APP (app), error);
+			if (!ret) {
+				g_set_error (error,
+					     ASB_PLUGIN_ERROR,
+					     ASB_PLUGIN_ERROR_FAILED,
+					     "bad activity.info in %s",
+					     asb_package_get_basename (pkg));
+				return NULL;
+			}
+			asb_plugin_add_app (&apps, AS_APP (app));
+		} else if (_asb_plugin_is_linfo (filelist[i])) {
+			ret = asb_plugin_process_linfo (
+			    plugin, pkg, filename_tmp, AS_APP (app), error);
+
+			if (!ret)
+			    g_debug ("Bad activity.linfo: %s\n", filelist[i]);
+		}
+	}
+
+	return apps;
+}


### PR DESCRIPTION
Sugar Activities are a unique type of application desinged for Sugar.
Originally, they did not run outside of the Sugar DE.  However, they
now do and we will being shipping .desktop files for them [1].

We don't ship app data files.  It is much eaiser to just write a plugin
for ASB than write an app data file for every activity.  Having a
ASB plugin is also beneficial for us as it allows us to tag clearly
all Sugar Activities as being Sugar Activities.  This would allow us
to use App Stream as a basis for a Sugar Activity store and updater.

Additioanlly, it allows GNOME Software to have richer metadata when
accessing the Sugar Activities.  Sugar Activities already have
summaries, translations and icons, which are beneficial for
GNOME Software.

[1]  https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/321