### PR TITLE
Add an AS_STATE_PURCHASABLE constant so we can support purchasing apps

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -289,6 +289,8 @@ as_app_state_to_string (AsAppState state)
 		return "installed";
 	if (state == AS_APP_STATE_AVAILABLE)
 		return "available";
+	if (state == AS_APP_STATE_PURCHASABLE)
+		return "purchasable";
 	if (state == AS_APP_STATE_AVAILABLE_LOCAL)
 		return "local";
 	if (state == AS_APP_STATE_QUEUED_FOR_INSTALL)

--- a/libappstream-glib/as-app.h
+++ b/libappstream-glib/as-app.h
@@ -250,6 +250,7 @@ typedef enum {
  * @AS_APP_STATE_INSTALLING:			Application is being installed
  * @AS_APP_STATE_REMOVING:			Application is being removed
  * @AS_APP_STATE_UPDATABLE_LIVE:		Application is installed and updatable live
+ * @AS_APP_STATE_PURCHASABLE:			Application is available for purchasing
  *
  * The application state.
  **/
@@ -264,6 +265,7 @@ typedef enum {
 	AS_APP_STATE_INSTALLING,			/* Since: 0.2.2 */
 	AS_APP_STATE_REMOVING,				/* Since: 0.2.2 */
 	AS_APP_STATE_UPDATABLE_LIVE,			/* Since: 0.5.4 */
+	AS_APP_STATE_PURCHASABLE,			/* Since: 0.5.17 */
 	/*< private >*/
 	AS_APP_STATE_LAST
 } AsAppState;


### PR DESCRIPTION
I haven't completed the other side of this patch in GNOME Software but I'm pretty sure this state is the way to go. If you're in agreement it is useful to land this now so G-S etc can depend on a released version that contains the state.