### PR TITLE
Correct disabling of timestamps for gzip

### DIFF
--- a/libappstream-builder/asb-utils.c
+++ b/libappstream-builder/asb-utils.c
@@ -443,7 +443,7 @@ asb_utils_write_archive (const gchar *filename,
 	a = archive_write_new ();
 	if (g_str_has_suffix (filename, ".gz")) {
 		archive_write_add_filter_gzip (a);
-		archive_write_set_filter_option (a, "gz", "timestamp", NULL);
+		archive_write_set_filter_option (a, "gzip", "timestamp", NULL);
 	}
 	if (g_str_has_suffix (filename, ".bz2"))
 		archive_write_add_filter_bzip2 (a);


### PR DESCRIPTION
Correct module name is "gzip".