### PR TITLE
AsApp: add API to control noshow project groups

### DIFF
--- a/libappstream-glib/as-app-desktop.c
+++ b/libappstream-glib/as-app-desktop.c
@@ -270,6 +270,16 @@ as_app_parse_file_key (AsApp *app,
 		if (tmp != NULL && tmp[0] != '\0')
 			as_app_add_pkgname (app, tmp);
 
+	/* NotShowIn */
+	} else if (g_strcmp0 (key, G_KEY_FILE_DESKTOP_KEY_NOT_SHOW_IN) == 0) {
+		list = g_key_file_get_string_list (kf,
+						   G_KEY_FILE_DESKTOP_GROUP,
+						   key,
+						   NULL, NULL);
+
+		for (i = 0; list[i] != NULL; i++)
+			as_app_add_noshow_project_group (app, list[i]);
+
 	/* OnlyShowIn */
 	} else if (g_strcmp0 (key, G_KEY_FILE_DESKTOP_KEY_ONLY_SHOW_IN) == 0) {
 		/* if an app has only one entry, it's that desktop */

--- a/libappstream-glib/as-app.h
+++ b/libappstream-glib/as-app.h
@@ -314,6 +314,7 @@ GHashTable	*as_app_get_metadata		(AsApp		*app);
 GHashTable	*as_app_get_descriptions	(AsApp		*app);
 GHashTable	*as_app_get_urls		(AsApp		*app);
 GPtrArray	*as_app_get_vetos		(AsApp		*app);
+GPtrArray       *as_app_get_noshow_project_groups (AsApp        *app);
 const gchar	*as_app_get_icon_path		(AsApp		*app);
 const gchar	*as_app_get_id_filename		(AsApp		*app);
 const gchar	*as_app_get_id			(AsApp		*app);
@@ -353,6 +354,8 @@ gboolean	 as_app_has_compulsory_for_desktop (AsApp	*app,
 						 const gchar	*desktop);
 gboolean	 as_app_has_quirk		(AsApp		*app,
 						 AsAppQuirk	 quirk);
+gboolean         as_app_has_noshow_project_group (AsApp         *app,
+						  const char    *project_group);
 
 /* setters */
 void		 as_app_set_id			(AsApp		*app,
@@ -445,6 +448,8 @@ void		 as_app_add_extends		(AsApp		*app,
 						 const gchar	*extends);
 void		 as_app_add_quirk		(AsApp		*app,
 						 AsAppQuirk	 quirk);
+void             as_app_add_noshow_project_group (AsApp         *app,
+						  const gchar   *project_group);
 
 /* object methods */
 GPtrArray	*as_app_validate		(AsApp		*app,


### PR DESCRIPTION
These map to the NotShowIn fields of desktop files, and can be used from
clients such as gnome-software to make decisions based on such
information.