### PR TITLE
Add Sugar as a valid desktop environment

### DIFF
--- a/libappstream-glib/as-environment-ids.txt
+++ b/libappstream-glib/as-environment-ids.txt
@@ -6,6 +6,7 @@ MATE
 Razor
 ROX
 TDE
+Sugar
 Unity
 XFCE
 EDE


### PR DESCRIPTION
Sugar `.appdata.xml` files include Sugar as their `<project_group>`: https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/331/commits/9206c376ace24df6a5814bd9f65f5ca4deec3546#diff-9ecd02401a4ccbfff774b94db38b9c4bR432

So, we probably need to add here as well!