### PR TITLE
Avoid unsatisfiable development dependency when built without libgcab

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,10 +138,13 @@ if test x$enable_firmware != xno; then
 	PKG_CHECK_MODULES(GCAB, libgcab-1.0)
 	AC_DEFINE(HAVE_GCAB,[1], [Use gcab])
 	enable_firmware=yes
+	GCAB_DEPENDENCY=libgcab-1.0
 else
 	enable_firmware=no
+	GCAB_DEPENDENCY=
 fi
 AM_CONDITIONAL(HAVE_GCAB, test x$enable_firmware = xyes)
+AC_SUBST([GCAB_DEPENDENCY])
 
 # font support (default enabled)
 AC_ARG_ENABLE(firmware, AS_HELP_STRING([--disable-fonts],[Disable font support]), enable_fonts=$enableval)

--- a/libappstream-glib/appstream-glib.pc.in
+++ b/libappstream-glib/appstream-glib.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: appstream-glib
 Description: Objects and helper methods to help reading and writing AppStream metadata
 Version: @VERSION@
-Requires.private: libarchive, libgcab-1.0, uuid
+Requires.private: libarchive uuid @GCAB_DEPENDENCY@
 Requires: glib-2.0, gobject-2.0, gdk-pixbuf-2.0
 Libs: -L${libdir} -lappstream-glib
 Cflags: -I${includedir}/libappstream-glib


### PR DESCRIPTION
pkg-config checks that all declared Requires.private are available
(they are needed for static linking and potentially for their CFLAGS).

---

I'm currently building appstream-glib in an environment where its ability to update x86 firmware is not interesting (we're targeting embedded devices, and secondarily x86 virtual machines) and ran into this issue.