### PR TITLE
Handle monitor events for individual files added with as_store_from_file()

### DIFF
--- a/libappstream-glib/as-store.c
+++ b/libappstream-glib/as-store.c
@@ -1430,7 +1430,9 @@ as_store_watch_source_added (AsStore *store, const gchar *filename)
 	/* we helpfully saved this */
 	dirname = g_path_get_dirname (filename);
 	g_debug ("parsing new file %s from %s", filename, dirname);
-	path_data = g_hash_table_lookup (priv->appinfo_dirs, dirname);
+	path_data = g_hash_table_lookup (priv->appinfo_dirs, filename);
+	if (path_data == NULL)
+		path_data = g_hash_table_lookup (priv->appinfo_dirs, dirname);
 	if (path_data == NULL) {
 		g_warning ("no path data for %s", dirname);
 		return;
@@ -1524,13 +1526,6 @@ as_store_add_path_data (AsStore *store,
 		return;
 	}
 
-	/* check is a directory */
-	if (!g_file_test (path, G_FILE_TEST_IS_DIR)) {
-		g_warning ("not adding path %s [%s:%s] as not a directory",
-			   path, as_app_scope_to_string (scope), arch);
-		return;
-	}
-
 	/* check not already exists */
 	path_data = g_hash_table_lookup (priv->appinfo_dirs, path);
 	if (path_data != NULL) {
@@ -1606,6 +1601,7 @@ as_store_from_file_internal (AsStore *store,
 
 	/* watch for file changes */
 	if (watch_flags > 0) {
+		as_store_add_path_data (store, filename, scope, arch);
 		if (!as_monitor_add_file (priv->monitor,
 					  filename,
 					  cancellable,


### PR DESCRIPTION
If you use `as_store_from_file()` to load individual `.xml.gz` files into a store, and replace those files with `g_file_set_contents()` or an equivalent atomic-overwrite from another process, then the file change notification emits

    As-WARNING **: no path data for /.../xmls

and doesn't actually emit the `::changed` signal. This appears to be because the code in `AsStore` that watches the monitor assumes it will be monitoring the `.xml.gz` file's parent directory, not the file itself.

While digging into this I noticed there is also some redundant monitoring going on: `as_store_load_app_info_file()` results in adding a monitor for the `.xml.gz` file itself, even though in that code path we are already going to monitor its parent directory. The file monitoring is only needed for `as_store_from_file()`.