### PR TITLE
Add SUSE-Public-Domain to License map

### DIFF
--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -593,6 +593,7 @@ as_utils_license_to_spdx (const gchar *license)
 		{ "ZPLv2.0",			"ZPL-2.0" },
 		{ "Unlicense",			"CC0-1.0" },
 		{ "Public Domain",		"LicenseRef-public-domain" },
+		{ "SUSE-Public-Domain",		"LicenseRef-public-domain" },
 		{ "Copyright only",		"LicenseRef-public-domain" },
 		{ "Proprietary",		"LicenseRef-proprietary" },
 		{ "Commercial",			"LicenseRef-proprietary" },


### PR DESCRIPTION
As 'Public Domain' is not a SPDX-listed license, distributions handle
the string differently. SUSE decided to retain the generic SPDX-Format
used for other licenses, prefixed with SUSE-.