### PR TITLE
Pay attention to errors from yaml_parser_parse

### DIFF
--- a/libappstream-glib/as-yaml.c
+++ b/libappstream-glib/as-yaml.c
@@ -211,8 +211,7 @@ as_node_yaml_process_layer (yaml_parser_t *parser, AsNode *parent)
 	gboolean valid = TRUE;
 	yaml_event_t event;
 
-	while (valid) {
-		yaml_parser_parse (parser, &event);
+	while (valid && yaml_parser_parse (parser, &event)) {
 		switch (event.type) {
 		case YAML_SCALAR_EVENT:
 			tmp = (const gchar *) event.data.scalar.value;


### PR DESCRIPTION
The previous commit message blames libyaml for spinning forever on invalid input.  This is not the case.  libyaml is correctly returning an error code, but `as_node_yaml_process_layer` was ignoring it and spinning forever calling back into libyaml as if expecting the error to disappear by itself.

The code should probably be audited for other ignored error codes, but this fixes the immediate problem.