### PR TITLE
as-app-validate: Check if icon_name is NULL

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -709,7 +709,8 @@ as_app_validate_icons (AsApp *app, AsAppValidateHelper *helper)
 		break;
 	case AS_ICON_KIND_LOCAL:
 		icon_name = as_icon_get_filename (icon);
-		if (!g_str_has_prefix (icon_name, "/")) {
+		if (icon_name == NULL ||
+		    !g_str_has_prefix (icon_name, "/")) {
 			ai_app_validate_add (helper,
 					     AS_PROBLEM_KIND_TAG_INVALID,
 					     "local icon is not a filename [%s]",
@@ -718,7 +719,8 @@ as_app_validate_icons (AsApp *app, AsAppValidateHelper *helper)
 		break;
 	case AS_ICON_KIND_CACHED:
 		icon_name = as_icon_get_name (icon);
-		if (g_str_has_prefix (icon_name, "/")) {
+		if (icon_name == NULL ||
+		    g_str_has_prefix (icon_name, "/")) {
 			ai_app_validate_add (helper,
 					     AS_PROBLEM_KIND_TAG_INVALID,
 					     "cached icon is a filename [%s]",


### PR DESCRIPTION
When 'as_icon_get_{file}name' return NULL, 'as_app_validate_icons' function
will show Critical Warning by calling 'g_str_has_prefix'. But it wouldn't be
a critical and sometimes, it could be NULL.