### PR TITLE
Make upgrade command check for SPDX license string instead of single ID

### DIFF
--- a/client/as-util.c
+++ b/client/as-util.c
@@ -281,9 +281,9 @@ as_util_convert_appdata (GFile *file_input,
 		as_node_set_comment (n2, "FIXME: Use https://spdx.org/licenses/");
 	} else {
 		/* ensure in SPDX format */
-		if (!as_utils_is_spdx_license_id (as_node_get_data (n2))) {
+		if (!as_utils_is_spdx_license (as_node_get_data (n2))) {
 			action_required = TRUE;
-			as_node_set_comment (n2, "FIXME: convert to an SPDX ID");
+			as_node_set_comment (n2, "FIXME: convert to an SPDX license string");
 		}
 	}
 


### PR DESCRIPTION
The current upgrade check just tests to see if the project license is a single SPDX license ID, whereas any license string is valid in this field. For example, Meld has:
`  <project_license>GPL-2.0+ and CC-BY-SA-3.0</project_license>`
which is marked as needing updating.

This patch uses `as_utils_is_spdx_license()`, which seems right to me, but it's not what the actual validation command uses. For some reason, validation manually calls the tokenisation and then validates the licenses individually... I'm not sure if that's more correct in some way I don't recognise, so I went with the easier option.