### PR TITLE
trivial: lower requirement for appstream-glib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ GNOME_COMPILE_WARNINGS([maximum],[
 
 # internationalization
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT_VERSION([0.19.7])
 AC_SUBST([GETTEXT_PACKAGE], [appstream-glib])
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Package name for gettext])
 


### PR DESCRIPTION
This allows easier compilation on Ubuntu 16.04