### PR TITLE
trivial: Use correct autoptr cleanup on yaml error when loading from a file

### DIFF
--- a/libappstream-glib/as-yaml.c
+++ b/libappstream-glib/as-yaml.c
@@ -441,7 +441,7 @@ as_yaml_read_handler_cb (void *data,
 AsNode *
 as_yaml_from_file (GFile *file, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(AsNode) node = NULL;
+	g_autoptr(AsYaml) node = NULL;
 #if AS_BUILD_DEP11
 	const gchar *content_type = NULL;
 	yaml_parser_t parser;


### PR DESCRIPTION
It seems this was needed in a second place.  This fixes calling from appstream-util validate.

> $ appstream-util validate ./yaml.yml
> ./yaml.yml: scanner error: mapping values are not allowed in this context at ln:2 col:5 
