### PR TITLE
Wip/hughsie/meson

### DIFF
--- a/client/meson.build
+++ b/client/meson.build
@@ -8,7 +8,7 @@ if get_option('enable-builder')
     'appstream-builder',
     sources : appstream_builder_srcs,
     include_directories : [
-      include_directories('@0@/..'.format(meson.current_build_dir())),
+      include_directories('..),
       asglib_incdir,
       asbuilder_incdir,
     ],

--- a/libappstream-builder/meson.build
+++ b/libappstream-builder/meson.build
@@ -70,7 +70,7 @@ asbuilder = shared_library(
     top_build_incdir,
     asglib_incdir,
   ],
-  link_args : ['-Wl,--no-undefined', vflag],
+  link_args : vflag,
   link_depends : mapfile,
   link_with : asglib,
   install : true)

--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -11,7 +11,6 @@ deps = [glib, gdkpixbuf, giounix, libarchive, soup, yaml, uuid, libgcab]
 
 asresources = gnome.compile_resources(
   'as-resources', 'appstream-glib.gresource.xml',
-  source_dir : '.',
   c_name : 'as')
 
 configure_file(input : 'as-version.h.in',
@@ -124,8 +123,8 @@ asglib = shared_library(
   version : lt_version,
   dependencies : deps,
   c_args : cargs,
-  include_directories : include_directories('@0@/..'.format(meson.current_build_dir())),
-  link_args : ['-Wl,--no-undefined', vflag],
+  include_directories : include_directories('..'),
+  link_args : vflag,
   link_depends : mapfile,
   install : true)
 asglib_incdir = include_directories('.')

--- a/meson.build
+++ b/meson.build
@@ -3,12 +3,13 @@
 #
 # Licensed under the GNU Lesser General Public License Version 2.1
 
-project('appstream-glib', 'c')
+project('appstream-glib', 'c', version : '0.6.2')
 
-as_major_version = '0'
-as_minor_version = '6'
-as_micro_version = '2'
-as_version = '@0@.@1@.@2@'.format(as_major_version, as_minor_version, as_micro_version)
+as_version = meson.project_version()
+varr = as_version.split('.')
+as_major_version = varr[0]
+as_minor_version = varr[1]
+as_micro_version = varr[2]
 
 conf = configuration_data()
 conf.set('AS_MAJOR_VERSION', as_major_version)


### PR DESCRIPTION
Some cleanups to Meson configuration.

You might also consider moving more preprocessor defines from command line arguments to `config.h` or equivalent as much as possible. This is beneficial in many ways such as:

- less places for state to exist
- when everything is in config.h it is easy to inspect
- smaller command line argument lists are easier to inspect and are faster to process (not usually noticeable in small projects but good practice anyway)
- passing command line arguments with shell metacharacters (i.e. double quotes) through various backends and their invocations is *hard* and there may be interesting bugs, especially on less often used backends

