### PR TITLE
Add -lang package as a dependency in order to properly detect transla…

### DIFF
--- a/libappstream-builder/asb-package-rpm.c
+++ b/libappstream-builder/asb-package-rpm.c
@@ -333,6 +333,10 @@ asb_package_rpm_ensure_deps (AsbPackage *pkg, GError **error)
 			*tmp = '\0';
 		asb_package_add_dep (pkg, dep_no_qual);
 	}
+        /* Add the corresponding -lang package as a dependency */
+        tmp = g_strconcat (asb_package_get_name (pkg), "-lang", NULL);
+        asb_package_add_dep (pkg, tmp);
+        g_free (tmp);
 out:
 	rpmtdFreeData (td);
 	rpmtdFree (td);


### PR DESCRIPTION
…tions

In openSUSE, the -lang package is 'only' recommended, so that users CAN save the
space if they don't need them (and using bundles there is also a method to only install
one language instead of all supported ones).

Unfortunately, with this technique, gnome-software keeps on pretending that no application
is localized in openSUSE.