### PR TITLE
Add Geary to the app id fallbacks

### DIFF
--- a/libappstream-glib/as-store.c
+++ b/libappstream-glib/as-store.c
@@ -708,6 +708,7 @@ as_store_get_app_by_id_with_fallbacks (AsStore *store, const gchar *id)
 		{ "file-roller.desktop",	"org.gnome.FileRoller.desktop" },
 		{ "font-manager.desktop",	"org.gnome.FontManager.desktop" },
 		{ "gcalctool.desktop",		"gnome-calculator.desktop" },
+		{ "geary.desktop",		"org.gnome.Geary.desktop" },
 		{ "gedit.desktop",		"org.gnome.gedit.desktop" },
 		{ "glchess.desktop",		"gnome-chess.desktop" },
 		{ "glines.desktop",		"five-or-more.desktop" },


### PR DESCRIPTION
Geary recently renamed its app id to follow flatpak conventions. Adding a fallback to appstream.

For more info, see [bug 766196](https://bugzilla.gnome.org/show_bug.cgi?id=766196) on GNOME bugzilla.