### PR TITLE
Add support for "+" operator at the end of SPDX license identifiers

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -928,6 +928,7 @@ as_app_validate_license (const gchar *license_text, GError **error)
 	for (i = 0; licenses[i] != NULL; i++) {
 		if (g_strcmp0 (licenses[i], "&") == 0 ||
 		    g_strcmp0 (licenses[i], "|") == 0 ||
+		    g_strcmp0 (licenses[i], "+") == 0 ||
 		    g_strcmp0 (licenses[i], "(") == 0 ||
 		    g_strcmp0 (licenses[i], ")") == 0)
 			continue;
@@ -951,19 +952,11 @@ as_app_validate_is_content_license_id (const gchar *license_id)
 		return TRUE;
 	if (g_strcmp0 (license_id, "@CC-BY-3.0") == 0)
 		return TRUE;
-	if (g_strcmp0 (license_id, "@CC-BY-3.0+") == 0)
-		return TRUE;
 	if (g_strcmp0 (license_id, "@CC-BY-4.0") == 0)
-		return TRUE;
-	if (g_strcmp0 (license_id, "@CC-BY-4.0+") == 0)
 		return TRUE;
 	if (g_strcmp0 (license_id, "@CC-BY-SA-3.0") == 0)
 		return TRUE;
-	if (g_strcmp0 (license_id, "@CC-BY-SA-3.0+") == 0)
-		return TRUE;
 	if (g_strcmp0 (license_id, "@CC-BY-SA-4.0") == 0)
-		return TRUE;
-	if (g_strcmp0 (license_id, "@CC-BY-SA-4.0+") == 0)
 		return TRUE;
 	if (g_strcmp0 (license_id, "@GFDL-1.1") == 0)
 		return TRUE;
@@ -976,6 +969,8 @@ as_app_validate_is_content_license_id (const gchar *license_id)
 	if (g_strcmp0 (license_id, "&") == 0)
 		return TRUE;
 	if (g_strcmp0 (license_id, "|") == 0)
+		return TRUE;
+	if (g_strcmp0 (license_id, "+") == 0)
 		return TRUE;
 	return FALSE;
 }

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -4151,6 +4151,16 @@ as_test_utils_spdx_token_func (void)
 	g_strfreev (tok);
 	g_free (tmp);
 
+	/* "+" operator */
+	tok = as_utils_spdx_license_tokenize ("CC-BY-SA-3.0+ AND Zlib");
+	tmp = g_strjoinv ("  ", tok);
+	g_assert_cmpstr (tmp, ==, "@CC-BY-SA-3.0  +  &  @Zlib");
+	g_free (tmp);
+	tmp = as_utils_spdx_license_detokenize (tok);
+	g_assert_cmpstr (tmp, ==, "CC-BY-SA-3.0+ AND Zlib");
+	g_strfreev (tok);
+	g_free (tmp);
+
 	/* detokenisation literals */
 	tok = as_utils_spdx_license_tokenize ("Public Domain");
 	tmp = as_utils_spdx_license_detokenize (tok);
@@ -4188,6 +4198,8 @@ as_test_utils_spdx_token_func (void)
 	g_assert (as_utils_is_spdx_license ("LicenseRef-proprietary"));
 	g_assert (as_utils_is_spdx_license ("CC0 and GFDL-1.3"));
 	g_assert (as_utils_is_spdx_license ("CC0 AND GFDL-1.3"));
+	g_assert (as_utils_is_spdx_license ("CC-BY-SA-3.0+"));
+	g_assert (as_utils_is_spdx_license ("CC-BY-SA-3.0+ AND Zlib"));
 	g_assert (as_utils_is_spdx_license ("NOASSERTION"));
 	g_assert (!as_utils_is_spdx_license ("CC0 dave"));
 	g_assert (!as_utils_is_spdx_license (""));

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -342,6 +342,18 @@ as_utils_spdx_license_tokenize_drop (AsUtilsSpdxHelper *helper)
 		return;
 	}
 
+	/* is license enum with "+" */
+	if (g_str_has_suffix (tmp, "+")) {
+		g_autofree gchar *license_id = g_strndup (tmp, strlen (tmp) - 1);
+		if (as_utils_is_spdx_license_id (license_id)) {
+			g_ptr_array_add (helper->array, g_strdup_printf ("@%s", license_id));
+			g_ptr_array_add (helper->array, g_strdup ("+"));
+			helper->last_token_literal = FALSE;
+			g_string_truncate (helper->collect, 0);
+			return;
+		}
+	}
+
 	/* is old license enum */
 	for (i = 0; licenses[i].old != NULL; i++) {
 		if (g_strcmp0 (tmp, licenses[i].old) != 0)
@@ -466,6 +478,10 @@ as_utils_spdx_license_detokenize (gchar **license_tokens)
 			g_string_append (tmp, " OR ");
 			continue;
 		}
+		if (g_strcmp0 (license_tokens[i], "+") == 0) {
+			g_string_append (tmp, "+");
+			continue;
+		}
 		if (license_tokens[i][0] != '@') {
 			g_string_append (tmp, license_tokens[i]);
 			continue;
@@ -517,6 +533,8 @@ as_utils_is_spdx_license (const gchar *license)
 		if (g_strcmp0 (tokens[i], "&") == 0)
 			continue;
 		if (g_strcmp0 (tokens[i], "|") == 0)
+			continue;
+		if (g_strcmp0 (tokens[i], "+") == 0)
 			continue;
 		return FALSE;
 	}


### PR DESCRIPTION
SPDX v2.0 and later support an unary "+" operator suffix at the end of
license identifiers, e.g. "CC-BY-SA-3.0+". This commit adds support for
tokenizing and detokenizing this and adds new tests.