### PR TITLE
Add a destructor for AsRefString

### DIFF
--- a/libappstream-glib/as-ref-string.c
+++ b/libappstream-glib/as-ref-string.c
@@ -64,6 +64,12 @@ as_ref_string_get_hash_safe (void)
 	return as_ref_string_hash;
 }
 
+static void __attribute__ ((destructor))
+as_ref_string_destructor (void)
+{
+	g_clear_pointer (&as_ref_string_hash, g_hash_table_unref);
+}
+
 /**
  * as_ref_string_new_static:
  * @str: a string


### PR DESCRIPTION
AsRefString uses a singleton hash table for deduplicating strings. This
is all "possibly lost" memory according to valgrind as the hash table
never gets destroyed.

This commit adds a custom destructor so that we can clean up the
singleton hash table as well and avoid unnecessary noise in valgrind
output.