### PR TITLE
preserve 0x prefix in the version string less than 0xff

### DIFF
--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -4006,11 +4006,17 @@ as_test_utils_version_func (void)
 		AsVersionParseFlag flags;
 	} version_from_uint32[] = {
 		{ 0x0,		"0.0.0.0",	AS_VERSION_PARSE_FLAG_NONE },
+		{ 0x9,		"0.0.0.9",	AS_VERSION_PARSE_FLAG_NONE },
+		{ 0xf,		"0.0.0.15",	AS_VERSION_PARSE_FLAG_NONE },
+		{ 0x1a,		"0.0.0.26",	AS_VERSION_PARSE_FLAG_NONE },
 		{ 0xff,		"0.0.0.255",	AS_VERSION_PARSE_FLAG_NONE },
 		{ 0xff01,	"0.0.255.1",	AS_VERSION_PARSE_FLAG_NONE },
 		{ 0xff0001,	"0.255.0.1",	AS_VERSION_PARSE_FLAG_NONE },
 		{ 0xff000100,	"255.0.1.0",	AS_VERSION_PARSE_FLAG_NONE },
 		{ 0x0,		"0.0.0",	AS_VERSION_PARSE_FLAG_USE_TRIPLET },
+		{ 0x9,		"0.0.9",	AS_VERSION_PARSE_FLAG_USE_TRIPLET },
+		{ 0xf,		"0.0.15",	AS_VERSION_PARSE_FLAG_USE_TRIPLET },
+		{ 0x1a,		"0.0.26",	AS_VERSION_PARSE_FLAG_USE_TRIPLET },
 		{ 0xff,		"0.0.255",	AS_VERSION_PARSE_FLAG_USE_TRIPLET },
 		{ 0xff01,	"0.0.65281",	AS_VERSION_PARSE_FLAG_USE_TRIPLET },
 		{ 0xff0001,	"0.255.1",	AS_VERSION_PARSE_FLAG_USE_TRIPLET },
@@ -4022,6 +4028,15 @@ as_test_utils_version_func (void)
 		const gchar *new;
 	} version_parse[] = {
 		{ "0",		"0" },
+		{ "9",		"9" },
+		{ "0x9",	"0x9" },
+		{ "15",		"15" },
+		{ "0xf",	"0xf" },
+		{ "0x0f",	"0x0f" },
+		{ "26",		"26" },
+		{ "0x1a",	"0x1a" },
+		{ "255",	"0.0.255" },
+		{ "0xff",	"0.0.255" },
 		{ "257",	"0.0.257" },
 		{ "1.2.3",	"1.2.3" },
 		{ "0xff0001",	"0.255.1" },

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -1589,7 +1589,6 @@ as_utils_version_parse (const gchar *version)
 
 	/* convert 0x prefixed strings to dotted decimal */
 	if (g_str_has_prefix (version, "0x")) {
-		version += 2;
 		base = 16;
 	} else {
 		/* for non-numeric content, just return the string */
@@ -1601,7 +1600,7 @@ as_utils_version_parse (const gchar *version)
 	}
 
 	/* convert */
-	tmp = g_ascii_strtoull (version, &endptr, base);
+	tmp = g_ascii_strtoull (base == 16 ? version+2 : version, &endptr, base);
 	if (endptr != NULL && endptr[0] != '\0')
 		return g_strdup (version);
 	if (tmp == 0 || tmp < 0xff)


### PR DESCRIPTION
For hex version less than `0xff`, the `0x` prefix was being removed accidentally and later it may converted to wrong value. A use case is that in https://bugs.launchpad.net/bugs/1651552 when fwupdmgr parse firmware.inf in the .cab file with version `0x1a`, it will first convert to `1a` and later `1a` is being treat as non-numeric content. The pull request should fix this issue by preserving the `0x` prefix in the version string less than 0xff.