### PR TITLE
as-app-validate: Allow MIT for metadata_license

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -1044,6 +1044,8 @@ as_app_validate_is_content_license_id (const gchar *license_id)
 		return TRUE;
 	if (g_strcmp0 (license_id, "@FSFAP") == 0)
 		return TRUE;
+	if (g_strcmp0 (license_id, "@MIT") == 0)
+		return TRUE;
 	if (g_strcmp0 (license_id, "&") == 0)
 		return TRUE;
 	if (g_strcmp0 (license_id, "|") == 0)


### PR DESCRIPTION
According to the [specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-metadata_license), MIT is acceptable for metadata_license.