### PR TITLE
tests: Fix 'gcab' executable requirement

### DIFF
--- a/data/tests/meson.build
+++ b/data/tests/meson.build
@@ -17,7 +17,9 @@ if get_option('enable-builder')
     ],
     command : [gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@'],
   )
+endif
 
+if conf.has('HAVE_GCAB_EXE')
   firmware202 = custom_target('firmware-2.0.2',
     output : 'colorhug-als-2.0.2.cab',
     input : [
@@ -26,5 +28,6 @@ if get_option('enable-builder')
       'firmware/2_0_2/firmware.metainfo.xml'
     ],
     command : [gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@'],
+    build_by_default: true,
   )
 endif

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -3602,7 +3602,7 @@ as_test_store_merges_local_func (void)
 static void
 as_test_store_cab_func (void)
 {
-#ifdef HAVE_GCAB
+#if defined(HAVE_GCAB_EXE)
 	gboolean ret;
 	const gchar *src;
 	g_autoptr(GError) error = NULL;

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('appstream-glib', 'c',
   version : '0.7.0',
   license : 'LGPL-2.1+',
   default_options : ['warning_level=1'],
-  meson_version : '>=0.37.0'
+  meson_version : '>=0.38.0'
 )
 
 as_version = meson.project_version()
@@ -62,6 +62,11 @@ libgcab = dependency('libgcab-1.0', required : false)
 
 if libgcab.found()
   conf.set('HAVE_GCAB', 1)
+  # This is to build a test file - not required here, we'll skip the test if it's not there
+  gcab = find_program('gcab', required : false)
+  if gcab.found()
+    conf.set('HAVE_GCAB_EXE', 1)
+  endif
 endif
 
 # builder (default enabled)


### PR DESCRIPTION
I noticed that we were trying to run this test even though we hadn't built the file. It depends on 'gcab' (exe) but we check for libgcab the library.

I guess you could do this dynamically too, to avoid the need for the extra define. Let me know if you want that instead.