### PR TITLE
as-app-builder: Don't cast gsize to guint32 when getting file length

### DIFF
--- a/libappstream-glib/as-app-builder.c
+++ b/libappstream-glib/as-app-builder.c
@@ -294,7 +294,7 @@ as_app_builder_parse_file_qt (AsAppBuilderContext *ctx,
 			      const gchar *filename,
 			      GError **error)
 {
-	guint32 len;
+	gsize len;
 	guint32 m = 0;
 	g_autofree guint8 *data = NULL;
 	const guint8 qm_magic[] = {
@@ -303,7 +303,7 @@ as_app_builder_parse_file_qt (AsAppBuilderContext *ctx,
 	};
 
 	/* load file */
-	if (!g_file_get_contents (filename, (gchar **) &data, (gsize *) &len, error))
+	if (!g_file_get_contents (filename, (gchar **) &data, &len, error))
 		return FALSE;
 
 	/* check header */


### PR DESCRIPTION
Ok, here's another one!

[On Ubuntu/Debian s390x](https://launchpadlibrarian.net/324218726/buildlog_ubuntu-artful-s390x.appstream-glib_0.7.0~git20170615-1_BUILDING.txt.gz), the test `as_test_app_builder_qt_func` fails.

```
As:ERROR:../libappstream-glib/as-self-test.c:418:as_test_app_builder_qt_func: assertion failed (error == NULL): file /home/ubuntu/appstream-glib-0.7.0~git20170615/data/tests/usr/share/kdeapp/translations/kdeapp_fr.qm is invalid (as-app-error-quark, 0)
```

I spent ages thinking this was an endianness problem, but then I actually looked at the code and it was the `len < sizeof(qm_magic)` that was failing, because `len` is `0`. To be honest I'm not exactly sure why the cast doesn't work, but hey ho - it seems to be not required here.