### PR TITLE
meson: Install appdata-xml.m4

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,7 @@
 subdir('installed-tests')
 subdir('tests')
 
+install_data('appdata-xml.m4', install_dir : 'share/aclocal')
 install_data('appstream-xml.m4', install_dir : 'share/aclocal')
 install_data('appstream-util', install_dir : 'share/bash-completion/completions')
 


### PR DESCRIPTION
Accidentally dropped when ported to meson

Fixes: https://github.com/hughsie/appstream-glib/issues/183