### PR TITLE
build: Make gperf dependency fully required

### DIFF
--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -103,20 +103,19 @@ sources = [
   asresources,
 ]
 
-if gperf.found()
-  astagpriv = custom_target(
-    'gperf as-tag',
-    output : 'as-tag-private.h',
-    input : 'as-tag.gperf',
-    command : [
-      gperf,
-      '@INPUT@',
-      '--output-file',
-      '@OUTPUT@'
-    ]
-  )
-  sources = sources + [astagpriv]
-endif
+# gperf sources
+astagpriv = custom_target(
+  'gperf as-tag',
+  output : 'as-tag-private.h',
+  input : 'as-tag.gperf',
+  command : [
+    gperf,
+    '@INPUT@',
+    '--output-file',
+    '@OUTPUT@'
+  ]
+)
+sources = sources + [astagpriv]
 
 install_headers(headers, subdir : 'libappstream-glib')
 

--- a/meson.build
+++ b/meson.build
@@ -98,10 +98,7 @@ if get_option('enable-stemmer')
 endif
 
 # use gperf for faster string -> enum matching
-gperf = find_program('gperf', required : false)
-if gperf.found()
-  conf.set('HAVE_GPERF', 1)
-endif
+gperf = find_program('gperf', required : true)
 
 gnome = import('gnome')
 i18n = import('i18n')


### PR DESCRIPTION
Commit 081ced436 made the gperf dependency mandatory, but that seems to
have been partially lost in the migration to Meson. If building without
gperf available, Meson configure would succeed, but then build would
fail due to as-tag-private.h not being generated.

Fix that by removing the conditions for gperf in the meson.build files.

Signed-off-by: Philip Withnall <withnall@endlessm.com>