### PR TITLE
Let appstream-builder emit new <launchables> 

### DIFF
--- a/libappstream-glib/as-launchable.c
+++ b/libappstream-glib/as-launchable.c
@@ -90,6 +90,10 @@ as_launchable_kind_from_string (const gchar *kind)
 {
 	if (g_strcmp0 (kind, "desktop-id") == 0)
 		return AS_LAUNCHABLE_KIND_DESKTOP_ID;
+	if (g_strcmp0 (kind, "service") == 0)
+		return AS_LAUNCHABLE_KIND_SERVICE;
+	if (g_strcmp0 (kind, "cockpit-manifest") == 0)
+		return AS_LAUNCHABLE_KIND_COCKPIT_MANIFEST;
 	return AS_LAUNCHABLE_KIND_UNKNOWN;
 }
 
@@ -108,6 +112,10 @@ as_launchable_kind_to_string (AsLaunchableKind kind)
 {
 	if (kind == AS_LAUNCHABLE_KIND_DESKTOP_ID)
 		return "desktop-id";
+	if (kind == AS_LAUNCHABLE_KIND_SERVICE)
+		return "service";
+	if (kind == AS_LAUNCHABLE_KIND_COCKPIT_MANIFEST)
+		return "cockpit-manifest";
 	return NULL;
 }
 

--- a/libappstream-glib/as-launchable.h
+++ b/libappstream-glib/as-launchable.h
@@ -57,6 +57,8 @@ struct _AsLaunchableClass
 typedef enum {
 	AS_LAUNCHABLE_KIND_UNKNOWN,
 	AS_LAUNCHABLE_KIND_DESKTOP_ID,		/* Since: 0.6.13 */
+	AS_LAUNCHABLE_KIND_SERVICE,		/* Since: 0.11.2 */
+	AS_LAUNCHABLE_KIND_COCKPIT_MANIFEST,    /* Since: 0.11.4 */
 	/*< private >*/
 	AS_LAUNCHABLE_KIND_LAST
 } AsLaunchableKind;


### PR DESCRIPTION
This pull request addresses the following issues:

- Appstream-builder throws away the type of launchables that it doesn't understand.  This PR makes it understand the new types from the 0.11 series of he AppStream spec. 

- Launchables don't appear in the appstream-builder output at all since it restricts itself to version 0.8 of the AppStream spec.  This PR makes it output according to version 0.11.4.

- The AppStream version is represented as a double, which has trouble working with anything that has a minor version above 0.9.  This PR switches to strings to represent versions.
