### PR TITLE
Add the WEB_APP URL kind

### DIFF
--- a/libappstream-glib/as-enums.c
+++ b/libappstream-glib/as-enums.c
@@ -94,6 +94,8 @@ as_url_kind_to_string (AsUrlKind url_kind)
 		return "missing";
 	if (url_kind == AS_URL_KIND_TRANSLATE)
 		return "translate";
+	if (url_kind == AS_URL_KIND_WEB_APP)
+		return "web-application";
 	return "unknown";
 }
 
@@ -124,6 +126,8 @@ as_url_kind_from_string (const gchar *url_kind)
 		return AS_URL_KIND_MISSING;
 	if (g_strcmp0 (url_kind, "translate") == 0)
 		return AS_URL_KIND_TRANSLATE;
+	if (g_strcmp0 (url_kind, "web-application") == 0)
+		return AS_URL_KIND_WEB_APP;
 	return AS_URL_KIND_UNKNOWN;
 }
 

--- a/libappstream-glib/as-enums.h
+++ b/libappstream-glib/as-enums.h
@@ -72,6 +72,7 @@ typedef enum {
  * @AS_URL_KIND_HELP:			Application help manual
  * @AS_URL_KIND_MISSING:		The package is available, but missing
  * @AS_URL_KIND_TRANSLATE:		Application translation page
+ * @AS_URL_KIND_WEB_APP:		Web application location
  *
  * The URL type.
  **/
@@ -84,6 +85,7 @@ typedef enum {
 	AS_URL_KIND_HELP,		/* Since: 0.1.5 */
 	AS_URL_KIND_MISSING,		/* Since: 0.2.2 */
 	AS_URL_KIND_TRANSLATE,		/* Since: 0.6.1 */
+	AS_URL_KIND_WEB_APP,		/* Since: 0.7.3 */
 	/*< private >*/
 	AS_URL_KIND_LAST
 } AsUrlKind;


### PR DESCRIPTION
The Telegram web application opens its [homepage](https://telegram.org/). Instead, it should open [this](https://web.telegram.org/) location. As it stands, a user has to perform unnecessary clicks each time the application is launched. Another example is Skype ([homepage](https://www.skype.com), [web app](https://web.skype.com)), which would be a wonderful addition once WebKitGTK+ can support it.

I suggest adding a new, optional type `AS_URL_KIND_WEB_APP`. If this is acceptable, I will submit a patch to GNOME Software so that it prefers it over `AS_URL_KIND_HOMEPAGE` during the web application installation.