### PR TITLE
Fix the arithmetic when fitting an image in 16:9

### DIFF
--- a/libappstream-glib/as-image.c
+++ b/libappstream-glib/as-image.c
@@ -766,7 +766,9 @@ as_image_save_pixbuf (AsImage *image,
 				 (gint) width,
 				 (gint) height);
 	gdk_pixbuf_fill (pixbuf, 0x00000000);
-	if ((pixbuf_width / 16) * 9 > pixbuf_height) {
+	/* check the ratio to see which property needs to be fitted and which needs
+	 * to be reduced */
+	if (pixbuf_width * 9 > pixbuf_height * 16) {
 		tmp_width = width;
 		tmp_height = width * pixbuf_height / pixbuf_width;
 	} else {


### PR DESCRIPTION
When saving a 16:9 pixbuf and the image parameter is not 16:9 we create
a transparent pixbuf with this ratio and fit the image in it. However,
this calculation was not correctly done due to an integer division so
the result is that the width/height of the pixbuf's area to be copied
was bigger than what the dimensions of the pixbuf; so no image was
copied and we'd be left with a trasnparent pixbuf.

This patch fixes this problem by using multiplications instead of
a division in the mentioned code (as they avoid imprecision problems).