### PR TITLE
Trivial: Set minimal required version for pngquant in the sample .spec file

### DIFF
--- a/contrib/libappstream-glib.spec.in
+++ b/contrib/libappstream-glib.spec.in
@@ -69,7 +69,7 @@ GLib headers and libraries for appstream-glib.
 %package builder
 Summary: Library and command line tools for building AppStream metadata
 Requires: %{name}%{?_isa} = %{version}-%{release}
-Requires: pngquant
+Requires: pngquant >= 2.8
 
 %description builder
 This library and command line tool is used for building AppStream metadata


### PR DESCRIPTION
commit 562772 introduced the usage of pngquant (by calling out to the binary)
and makes use of the --strip parameter, which was introduced in version 2.8 of pngquant.