### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ To install the libappstream-glib library you either need to install the
 `libappstream-glib` package from your distributor, or you can build a local
 copy. To do the latter just do:
 
-    dnf install automake autoconf libtool glib-devel docbook-utils \
-               gtk-doc gobject-introspection-devel rpm-devel \
-               gtk3-devel sqlite-devel libsoup-devel gettext-devel \
-               libarchive-devel libyaml-devel
-    ./autogen.sh
+    dnf install docbook-utils gcab gettext-devel glib-devel \
+                gobject-introspection-devel gperf gtk-doc gtk3-devel \
+                libarchive-devel libtool libgcab-devel libsoup-devel \
+                libstemmer-devel libuuid-devel libyaml-devel \
+                meson rpm-devel sqlite-devel
+    ./configure
     make
     make install
 
@@ -88,7 +89,7 @@ binary and data files, or you can build a local copy. To do the latter just do:
 
     dnf install automake autoconf libtool rpm-devel \
                 gtk3-devel sqlite-devel libsoup-devel
-    ./autogen.sh
+    ./configure
     make
 
 To actually run the extractor you can do:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ copy. To do the latter just do:
 
     dnf install docbook-utils gcab gettext-devel glib-devel \
                 gobject-introspection-devel gperf gtk-doc gtk3-devel \
-                libarchive-devel libtool libgcab-devel libsoup-devel \
+                libarchive-devel libtool libgcab1-devel libsoup-devel \
                 libstemmer-devel libuuid-devel libyaml-devel \
                 meson rpm-devel sqlite-devel
     ./configure

--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ libarchive = dependency('libarchive')
 soup = dependency('libsoup-2.4', version : '>= 2.51.92')
 json_glib = dependency('json-glib-1.0')
 gdkpixbuf = dependency('gdk-pixbuf-2.0', version : '>= 2.31.5')
-libgcab = dependency('libgcab-1.0', required : false)
+libgcab = dependency('libgcab-1.0')
 
 if libgcab.found()
   conf.set('HAVE_GCAB', 1)


### PR DESCRIPTION
This closes issue #201.

I've removed the `required: false` qualifier from `libgcab` because when I tried building `libappstream-glib` on my system, missing `libgcab` caused the build to fail.