### PR TITLE
Fix build on musl systems.

### DIFF
--- a/client/as-util.c
+++ b/client/as-util.c
@@ -27,6 +27,7 @@
 #include <gio/gio.h>
 
 #include <appstream-glib.h>
+#include <stdint.h>
 #include <archive_entry.h>
 #include <archive.h>
 #include <libsoup/soup.h>

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -34,6 +34,7 @@
 
 #include <fnmatch.h>
 #include <string.h>
+#include <stdint.h>
 #include <archive_entry.h>
 #include <archive.h>
 #include <libsoup/soup.h>


### PR DESCRIPTION
Systems that use [musl](https://www.musl-libc.org/) as libc fail to compile with the following error

```
In file included from ../libappstream-glib/as-utils.c:37:0:
/usr/x86_64-linux-musl/usr/include/archive_entry.h:64:9: error: unknown type name ‘int64_t’
 typedef int64_t la_int64_t;
```

same happens with `client/as-utils.c`, including `stdint.h` before the `archive_entry.h` include fixes the build error.

Tested on Void Linux x86_64, i686, aarch64, armv7hf, x86_64-musl, armv6hf-musl, aarch64-musl. [Travis  Builds](https://travis-ci.org/maxice8/void-packages/builds/328361592)