### PR TITLE
for issues#228 update asb_package_guess_from_filename for inaccuracy rpm filename

### DIFF
--- a/libappstream-builder/asb-package.c
+++ b/libappstream-builder/asb-package.c
@@ -842,7 +842,7 @@ asb_package_guess_from_filename (AsbPackage *pkg)
 	gchar *at;
 
 	/* remove .rpm extension */
-	tmp = g_strdup (priv->filename);
+	tmp = g_strdup (g_strrstr (priv->filename, "/"));
 	at = g_strrstr (tmp, ".rpm");
 	if (at == NULL)
 		return;


### PR DESCRIPTION
in appstream-glib/libappstream-builder/asb-package.c asb_package_guess_from_filename
---
if priv->filename likes `/xxx/xxx-xxx/xxx-xxx/free/x86_64/xxx.x86_64.rpm` , then priv will get
```
arch:x86_64
release:ccc/free/x86_64/test
version:bbb/ccc
name:bbb
```
Obviously, that's wrong.