### PR TITLE
Veto apps that have empty OnlyShowIn=

### DIFF
--- a/libappstream-glib/as-app-desktop.c
+++ b/libappstream-glib/as-app-desktop.c
@@ -324,7 +324,10 @@ as_app_parse_file_key (AsApp *app,
 						   G_KEY_FILE_DESKTOP_GROUP,
 						   key,
 						   NULL, NULL);
-		if (g_strv_length (list) == 1)
+		/* "OnlyShowIn=" is the same as "NoDisplay=True" */
+		if (g_strv_length (list) == 0)
+			as_app_add_veto (app, "Empty OnlyShowIn");
+		else if (g_strv_length (list) == 1)
 			as_app_set_project_group (app, list[0]);
 
 	/* Name */


### PR DESCRIPTION
Apps that have OnlyShowIn= are equivalent to NoDisplay=True (gnome-shell
doesn't show them). Veto such apps to avoid them inadvertently showing
up in gnome-software and to match gnome-shell behaviour.

https://bugzilla.redhat.com/show_bug.cgi?id=1567689
https://gitlab.gnome.org/GNOME/gnome-software/issues/367