### PR TITLE
Augment the max length of <li> tag to 300 in strict validation.

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -163,7 +163,7 @@ as_app_validate_description_li (const gchar *text, AsAppValidateHelper *helper)
 {
 	gboolean require_sentence_case = TRUE;
 	guint str_len;
-	guint length_li_max = 100;
+	guint length_li_max = 300;
 	guint length_li_min = 20;
 
 	/* relax the requirements a bit */


### PR DESCRIPTION
Our release `<description>` is not long, but clearly not one-worded. We still give a short description of the new features we list. Otherwise if we just drop titles, we may as well not write anything because that would be barely understandable.

Unfortunately it seems you limit list items to 100 characters. This is just too short IMO. It's like worse than a tweet or something! :P 

```
• style-invalid         : <li> is too long [Horizon Straightening: the Measurement tool is augmented with a button to rotate the active drawable with the measurement line used as horizon. It works on linked drawables as well.] maximum is 100 chars
```
Could we drop the limit or raise it to something reasonable (like at least 300 characters?).
Also nothing in the [spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description) says anything either about size limitation.