### PR TITLE
as-image: Correctly scale and position images into requested size

### DIFF
--- a/libappstream-glib/as-image.c
+++ b/libappstream-glib/as-image.c
@@ -808,9 +808,8 @@ as_image_save_pixbuf (AsImage *image,
 				 (gint) width,
 				 (gint) height);
 	gdk_pixbuf_fill (pixbuf, 0x00000000);
-	/* check the ratio to see which property needs to be fitted and which needs
-	 * to be reduced */
-	if (pixbuf_width * 9 > pixbuf_height * 16) {
+	/* scale image to largest size in requested size */
+	if (height * pixbuf_width > pixbuf_height * width) {
 		tmp_width = width;
 		tmp_height = width * pixbuf_height / pixbuf_width;
 	} else {

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -1257,6 +1257,14 @@ as_test_image_func (void)
 	g_assert_cmpstr (as_image_get_basename (image), ==, "screenshot.png");
 	g_assert_cmpstr (as_image_get_md5 (image), ==, "9de72240c27a6f8f2eaab692795cdafc");
 
+	/* resample to wrong aspect ratio */
+	pixbuf = as_image_save_pixbuf (image,
+				       423, 752,
+				       AS_IMAGE_SAVE_FLAG_PAD_16_9);
+	g_assert_cmpint (gdk_pixbuf_get_width (pixbuf), ==, 423);
+	g_assert_cmpint (gdk_pixbuf_get_height (pixbuf), ==, 752);
+	g_clear_object (&pixbuf);
+
 	/* resample */
 	pixbuf = as_image_save_pixbuf (image,
 				       752, 423,


### PR DESCRIPTION
The previous code didn't handle output dimensions that were needed letterboxing.