### PR TITLE
Add AS_APP_QUIRK_DEVELOPER_VERIFIED

### DIFF
--- a/libappstream-glib/as-app.h
+++ b/libappstream-glib/as-app.h
@@ -352,6 +352,7 @@ typedef enum {
  * @AS_APP_QUIRK_NEEDS_USER_ACTION:	The component requires some kind of user action
  * @AS_APP_QUIRK_IS_PROXY:		Is a proxy app that operates on other applications
  * @AS_APP_QUIRK_REMOVABLE_HARDWARE:	The device is unusable whilst the action is performed
+ * @AS_APP_QUIRK_DEVELOPER_VERIFIED:	The app developer has been verified
  *
  * The component attributes.
  **/
@@ -368,6 +369,7 @@ typedef enum {
 	AS_APP_QUIRK_NEEDS_USER_ACTION	= 1 << 8,	/* Since: 0.6.2 */
 	AS_APP_QUIRK_IS_PROXY 		= 1 << 9,	/* Since: 0.6.6 */
 	AS_APP_QUIRK_REMOVABLE_HARDWARE	= 1 << 10,	/* Since: 0.6.6 */
+	AS_APP_QUIRK_DEVELOPER_VERIFIED	= 1 << 11,	/* Since: 0.7.11 */
 	/*< private >*/
 	AS_APP_QUIRK_LAST
 } AsAppQuirk;


### PR DESCRIPTION
This quirk allows apps to marked as having an additional level of checking
performed on the developer. This is to give confidence to the user that this
is the official version of an app. This is a common design pattern used in
modern packaging systems (e.g. Apple App Store, Google Play).