### PR TITLE
as-content-rating: Add as_content_rating_get_rating_ids()

### DIFF
--- a/libappstream-glib/as-content-rating.c
+++ b/libappstream-glib/as-content-rating.c
@@ -87,6 +87,50 @@ as_content_rating_class_init (AsContentRatingClass *klass)
 	object_class->finalize = as_content_rating_finalize;
 }
 
+static gint
+ids_sort_cb (gconstpointer id_ptr_a, gconstpointer id_ptr_b)
+{
+	const gchar *id_a = *((const gchar **) id_ptr_a);
+	const gchar *id_b = *((const gchar **) id_ptr_b);
+
+	return g_strcmp0 (id_a, id_b);
+}
+
+/**
+ * as_content_rating_get_rating_ids:
+ * @content_rating: a #AsContentRating
+ *
+ * Gets the set of ratings IDs which are present in this @content_rating. An
+ * example of a ratings ID is `violence-bloodshed`.
+ *
+ * The IDs are returned in lexicographical order.
+ *
+ * Returns: (array zero-terminated=1) (transfer container): %NULL-terminated
+ *    array of ratings IDs; each ratings ID is owned by the #AsContentRating and
+ *    must not be freed, but the container must be freed with g_free()
+ *
+ * Since: 0.7.15
+ **/
+const gchar **
+as_content_rating_get_rating_ids (AsContentRating *content_rating)
+{
+	AsContentRatingPrivate *priv = GET_PRIVATE (content_rating);
+	GPtrArray *ids = g_ptr_array_new_with_free_func (NULL);
+	guint i;
+
+	g_return_val_if_fail (AS_IS_CONTENT_RATING (content_rating), NULL);
+
+	for (i = 0; i < priv->keys->len; i++) {
+		AsContentRatingKey *key = g_ptr_array_index (priv->keys, i);
+		g_ptr_array_add (ids, key->id);
+	}
+
+	g_ptr_array_sort (ids, ids_sort_cb);
+	g_ptr_array_add (ids, NULL);  /* NULL terminator */
+
+	return (const gchar **) g_ptr_array_free (g_steal_pointer (&ids), FALSE);
+}
+
 /**
  * as_content_rating_get_value:
  * @content_rating: a #AsContentRating

--- a/libappstream-glib/as-content-rating.h
+++ b/libappstream-glib/as-content-rating.h
@@ -82,6 +82,8 @@ void		 as_content_rating_add_attribute(AsContentRating	*content_rating,
 						 const gchar		*id,
 						 AsContentRatingValue	 value);
 
+const gchar	**as_content_rating_get_rating_ids (AsContentRating	*content_rating);
+
 /* setters */
 void		 as_content_rating_set_kind	(AsContentRating	*content_rating,
 						 const gchar		*kind);

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -1700,6 +1700,9 @@ as_test_content_rating_func (void)
 	gboolean ret;
 	g_autoptr(AsNodeContext) ctx = NULL;
 	g_autoptr(AsContentRating) content_rating = NULL;
+	g_autofree const gchar **rating_ids = NULL;
+	const gchar *expected_rating_ids[] = { "drugs-alcohol", "violence-cartoon", NULL };
+	gsize i;
 
 	content_rating = as_content_rating_new ();
 
@@ -1722,6 +1725,15 @@ as_test_content_rating_func (void)
 			 AS_CONTENT_RATING_VALUE_MILD);
 	g_assert_cmpint (as_content_rating_get_value (content_rating, "violence-bloodshed"), ==,
 			 AS_CONTENT_RATING_VALUE_UNKNOWN);
+
+	rating_ids = as_content_rating_get_rating_ids (content_rating);
+	g_assert_nonnull (rating_ids);
+
+	for (i = 0; rating_ids[i] != NULL && expected_rating_ids[i] != NULL; i++)
+		g_assert_cmpstr (rating_ids[i], ==, expected_rating_ids[i]);
+	g_assert_null (rating_ids[i]);
+	g_assert_null (expected_rating_ids[i]);
+
 	as_node_unref (root);
 
 	/* check CSM */


### PR DESCRIPTION
This allows the set of rating IDs in the AsContentRating to be returned,
allowing the caller to iterate over them to check their values, rather
than having to hard-code their own list of OARS rating IDs.

Includes a basic test.

Signed-off-by: Philip Withnall <withnall@endlessm.com>