### PR TITLE
Rewrite the version comparison algorithm

### DIFF
--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -5065,6 +5065,71 @@ as_test_utils_vercmp_func (void)
 	g_assert_cmpint (as_utils_vercmp ("1", NULL), ==, G_MAXINT);
 	g_assert_cmpint (as_utils_vercmp (NULL, "1"), ==, G_MAXINT);
 	g_assert_cmpint (as_utils_vercmp (NULL, NULL), ==, G_MAXINT);
+
+	/* numbers */
+	g_assert_cmpint (as_utils_vercmp ("0", "000"), ==, 0);
+	g_assert_cmpint (as_utils_vercmp ("001", "1"), ==, 0);
+	g_assert_cmpint (as_utils_vercmp ("001", "2"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("002", "1"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("010", "00100"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("0012345", "098765"), <, 0);
+
+	/* Blender */
+	g_assert_cmpint (as_utils_vercmp ("2.79b", "2.79b"), ==, 0);
+	g_assert_cmpint (as_utils_vercmp ("2.79a", "2.79b"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("2.79b", "2.79a"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("2.79", "2.79b"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("2.79b", "2.79"), >, 0);
+
+	/* Widelands */
+	g_assert_cmpint (as_utils_vercmp ("Build 9half", "Build 9half"), ==, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 9half", "Build 19"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 19", "Build 9half"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 9", "Build 19"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 19", "Build 3"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 1", "Build 2"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 19", "Build 18"), >, 0);
+
+	/* Widelands-like */
+	g_assert_cmpint (as_utils_vercmp ("Build 9half", "Build 10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 9.5", "Build 10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 9+", "Build 10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 9a", "Build 10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 9", "Build 10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("Build 009", "Build 10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("9half", "10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("9.5", "10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("9+", "10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("9a", "10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("9", "10"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("009", "10"), <, 0);
+
+	/* RPM VersionComparison */
+	// https://fedoraproject.org/wiki/Archive:Tools/RPM/VersionComparison
+	g_assert_cmpint (as_utils_vercmp ("1.0010", "1.9"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("1.05", "1.5"), ==, 0);
+	g_assert_cmpint (as_utils_vercmp ("1.0", "1"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("2.50", "2.5"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("fc4", "fc.4"), ==, 0);
+	g_assert_cmpint (as_utils_vercmp ("FC5", "fc4"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("2a", "2.0"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("1.0", "1.fc4"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("3.0.0_fc", "3.0.0.fc"), ==, 0);
+
+	/* ximion AppStream */
+	// https://github.com/ximion/appstream/blob/d10f947e4590b0f04fc6bd74acf04b7987057e36/tests/test-basics.c#L382-L410
+	g_assert_cmpint (as_utils_vercmp ("6", "8"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("0.6.12b-d", "0.6.12a"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("7.4", "7.4"), ==, 0);
+	g_assert_cmpint (as_utils_vercmp ("ab.d", "ab.f"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("0.6.16", "0.6.14"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("5.9.1+dfsg-5pureos1", "5.9.1+dfsg-5"), >, 0);
+	g_assert_cmpint (as_utils_vercmp ("2.79", "2.79a"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("3.0.rc2", "3.0.0"), <, 0);
+	g_assert_cmpint (as_utils_vercmp ("3.0.0~rc2", "3.0.0"), <, 0);
+	g_assert_cmpint (as_utils_vercmp (NULL, NULL), ==, G_MAXINT);
+	g_assert_cmpint (as_utils_vercmp (NULL, "4.0"), ==, G_MAXINT);
+	g_assert_cmpint (as_utils_vercmp ("4.0", NULL), ==, G_MAXINT);
 }
 
 static void

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -1414,8 +1414,8 @@ as_utils_vercmp_full (const gchar *version_a,
 
 	/* split into sections, and try to parse */
 	if (flags & AS_VERSION_COMPARE_FLAG_USE_HEURISTICS) {
-		g_autofree gchar *str_a = as_utils_version_parse (version_a);
-		g_autofree gchar *str_b = as_utils_version_parse (version_b);
+		g_autofree gchar *str_a = as_utils_version_parse_hex (version_a);
+		g_autofree gchar *str_b = as_utils_version_parse_hex (version_b);
 		return as_utils_vercmp_rpm (str_a, str_b);
 	} else {
 		return as_utils_vercmp_rpm (version_a, version_b);
@@ -1758,8 +1758,10 @@ as_utils_version_from_uint16 (guint16 val, AsVersionParseFlag flags)
  *
  * - Dotted decimal, e.g. "1.2.3"
  * - Base 16, a hex number *with* a 0x prefix, e.g. "0x10203"
+ * - Base 10, a string containing just [0-9], e.g. "66051"
+ * - Date in YYYYMMDD format, e.g. 20150915
  *
- * Anything with a '.' or that doesn't match 0x[a-f,0-9] is considered
+ * Anything with a '.' or that doesn't match [0-9] or 0x[a-f,0-9] is considered
  * a string and returned without modification.
  *
  * Returns: A version number, e.g. "1.0.3"
@@ -1768,6 +1770,63 @@ as_utils_version_from_uint16 (guint16 val, AsVersionParseFlag flags)
  */
 gchar *
 as_utils_version_parse (const gchar *version)
+{
+	const gchar *version_noprefix = version;
+	gchar *endptr = NULL;
+	guint64 tmp;
+	guint base;
+	guint i;
+
+	/* already dotted decimal */
+	if (g_strstr_len (version, -1, ".") != NULL)
+		return g_strdup (version);
+
+	/* is a date */
+	if (g_str_has_prefix (version, "20") &&
+	    strlen (version) == 8)
+		return g_strdup (version);
+
+	/* convert 0x prefixed strings to dotted decimal */
+	if (g_str_has_prefix (version, "0x")) {
+		version_noprefix += 2;
+		base = 16;
+	} else {
+		/* for non-numeric content, just return the string */
+		for (i = 0; version[i] != '\0'; i++) {
+			if (!g_ascii_isdigit (version[i]))
+				return g_strdup (version);
+		}
+		base = 10;
+	}
+
+	/* convert */
+	tmp = g_ascii_strtoull (version_noprefix, &endptr, base);
+	if (endptr != NULL && endptr[0] != '\0')
+		return g_strdup (version);
+	if (tmp == 0)
+		return g_strdup (version);
+	return as_utils_version_from_uint32 ((guint32) tmp, AS_VERSION_PARSE_FLAG_USE_TRIPLET);
+}
+
+/**
+ * as_utils_version_parse_hex:
+ * @version: A version number
+ *
+ * Returns a dotted decimal version string from a version string. The supported
+ * formats are:
+ *
+ * - Dotted decimal, e.g. "1.2.3"
+ * - Base 16, a hex number *with* a 0x prefix, e.g. "0x10203"
+ *
+ * Anything with a '.' or that doesn't match 0x[a-f,0-9] is considered
+ * a string and returned without modification.
+ *
+ * Returns: A version number, e.g. "1.0.3"
+ *
+ * Since: 0.7.15
+ */
+gchar *
+as_utils_version_parse_hex (const gchar *version)
 {
 	const gchar *version_noprefix = version;
 	gchar *endptr = NULL;

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -1422,7 +1422,9 @@ as_utils_vercmp_full (const gchar *version_a,
 	}
 }
 
-// Based on: https://github.com/rpm-software-management/rpm/blob/ca8ff08e4f61f05c743797ea4afbb9bf0bce3064/lib/rpmvercmp.c#L12-L122
+// Based on:
+// https://github.com/rpm-software-management/rpm/blob/ca8ff08e4f61f05c743797ea4afbb9bf0bce3064/lib/rpmvercmp.c#L12-L122
+// https://github.com/ximion/appstream/blob/d10f947e4590b0f04fc6bd74acf04b7987057e36/src/as-utils.c#L1003-L1125
 /**
  * as_utils_vercmp_rpm:
  * @version_a: the release version, e.g. 1.2.3

--- a/libappstream-glib/as-utils.h
+++ b/libappstream-glib/as-utils.h
@@ -177,8 +177,9 @@ gchar		*as_utils_version_from_uint32	(guint32	 val,
 						 AsVersionParseFlag flags);
 gchar		*as_utils_version_from_uint16	(guint16	 val,
 						 AsVersionParseFlag flags);
+gchar		*as_utils_version_parse_full	(const gchar	*version,
+						 const gboolean	hex_only);
 gchar		*as_utils_version_parse		(const gchar	*version);
-gchar		*as_utils_version_parse_hex	(const gchar	*version);
 guint		 as_utils_string_replace	(GString	*string,
 						 const gchar	*search,
 						 const gchar	*replace);

--- a/libappstream-glib/as-utils.h
+++ b/libappstream-glib/as-utils.h
@@ -163,6 +163,12 @@ gchar		**as_utils_search_tokenize	(const gchar	*search);
 gint		 as_utils_vercmp_full		(const gchar	*version_a,
 						 const gchar	*version_b,
 						 AsVersionCompareFlag flags);
+gchar		*as_utils_version_reparse	(const gchar	*version);
+gint		 as_utils_vercmp_rpm		(const gchar	*version_a,
+						 const gchar	*version_b);
+gint		 as_utils_vercmp_complex	(const gchar	*version_a,
+						 const gchar	*version_b,
+						 AsVersionCompareFlag flags);
 gint		 as_utils_vercmp		(const gchar	*version_a,
 						 const gchar	*version_b);
 gboolean	 as_utils_guid_is_valid		(const gchar	*guid);

--- a/libappstream-glib/as-utils.h
+++ b/libappstream-glib/as-utils.h
@@ -178,6 +178,7 @@ gchar		*as_utils_version_from_uint32	(guint32	 val,
 gchar		*as_utils_version_from_uint16	(guint16	 val,
 						 AsVersionParseFlag flags);
 gchar		*as_utils_version_parse		(const gchar	*version);
+gchar		*as_utils_version_parse_hex	(const gchar	*version);
 guint		 as_utils_string_replace	(GString	*string,
 						 const gchar	*search,
 						 const gchar	*replace);

--- a/libappstream-glib/as-utils.h
+++ b/libappstream-glib/as-utils.h
@@ -163,12 +163,8 @@ gchar		**as_utils_search_tokenize	(const gchar	*search);
 gint		 as_utils_vercmp_full		(const gchar	*version_a,
 						 const gchar	*version_b,
 						 AsVersionCompareFlag flags);
-gchar		*as_utils_version_reparse	(const gchar	*version);
 gint		 as_utils_vercmp_rpm		(const gchar	*version_a,
 						 const gchar	*version_b);
-gint		 as_utils_vercmp_complex	(const gchar	*version_a,
-						 const gchar	*version_b,
-						 AsVersionCompareFlag flags);
 gint		 as_utils_vercmp		(const gchar	*version_a,
 						 const gchar	*version_b);
 gboolean	 as_utils_guid_is_valid		(const gchar	*guid);


### PR DESCRIPTION
Proposed patch: [libappstream-glib-rpmvercmp.patch](https://paste.ubuntu.com/p/TfVMpjJBNr/)
```
diff -Naur a/appstream-glib/libappstream-glib/as-utils.c b/appstream-glib/libappstream-glib/as-utils.c
--- a/appstream-glib/libappstream-glib/as-utils.c	2018-11-13 06:28:45.000000000 +0100
+++ b/appstream-glib/libappstream-glib/as-utils.c	2018-11-13 08:55:25.000000000 +0100
@@ -1463,6 +1463,209 @@
 }
 
 /**
+ * as_utils_version_reparse:
+ * @version: A version number
+ *
+ * Returns a dotted decimal version string from a version string. The supported
+ * formats are:
+ *
+ * - Dotted decimal, e.g. "1.2.3"
+ * - Base 16, a hex number *with* a 0x prefix, e.g. "0x10203"
+ *
+ * Anything with a '.' or that doesn't match 0x[a-f,0-9] is considered
+ * a string and returned without modification.
+ *
+ * Returns: A version number, e.g. "1.0.3"
+ *
+ * Since: 0.7.15
+ */
+gchar *
+as_utils_version_reparse (const gchar *version)
+{
+	const gchar *version_noprefix = version;
+	gchar *endptr = NULL;
+	guint64 tmp;
+	guint base;
+
+	/* already dotted decimal */
+	if (g_strstr_len (version, -1, ".") != NULL)
+		return g_strdup (version);
+
+	/* convert 0x prefixed strings to dotted decimal */
+	if (g_str_has_prefix (version, "0x")) {
+		version_noprefix += 2;
+		base = 16;
+	} else {
+		/* just return the string */
+		return g_strdup (version);
+	}
+
+	/* convert */
+	tmp = g_ascii_strtoull (version_noprefix, &endptr, base);
+	if (endptr != NULL && endptr[0] != '\0')
+		return g_strdup (version);
+	if (tmp == 0)
+		return g_strdup (version);
+	return as_utils_version_from_uint32 ((guint32) tmp, AS_VERSION_PARSE_FLAG_USE_TRIPLET);
+}
+
+// Based on: https://github.com/rpm-software-management/rpm/blob/ca8ff08e4f61f05c743797ea4afbb9bf0bce3064/lib/rpmvercmp.c#L12-L122
+/**
+ * as_utils_vercmp_rpm:
+ * @version_a: the release version, e.g. 1.2.3
+ * @version_b: the release version, e.g. 1.2.3.1
+ *
+ * Compares version numbers for sorting.
+ *
+ * Returns: -1 if a < b, +1 if a > b, 0 if they are equal
+ *
+ * Since: 0.7.15
+ */
+gint
+as_utils_vercmp_rpm (const gchar *version_a, const gchar *version_b)
+{
+	/* easy comparison to see if versions are identical */
+	if (g_strcmp0(version_a, version_b) == 0) return 0;
+
+	gchar oldch1, oldch2;
+	gchar abuf[strlen(version_a)+1], bbuf[strlen(version_b)+1];
+	gchar *str1 = abuf, *str2 = bbuf;
+	gchar * one, * two;
+	gint rc;
+	gint isnum;
+
+	g_strlcpy(str1, version_a, sizeof(abuf));
+	g_strlcpy(str2, version_b, sizeof(bbuf));
+
+	one = str1;
+	two = str2;
+
+	/* loop through each version segment of str1 and str2 and compare them */
+	while (*one || *two) {
+	while (*one && !g_ascii_isalnum(*one) && *one != '~') one++;
+	while (*two && !g_ascii_isalnum(*two) && *two != '~') two++;
+
+	/* handle the tilde separator, it sorts before everything else */
+	if (*one == '~' || *two == '~') {
+		if (*one != '~') return 1;
+		if (*two != '~') return -1;
+		one++;
+		two++;
+		continue;
+	}
+
+	/* If we ran to the end of either, we are finished with the loop */
+	if (!(*one && *two)) break;
+
+	str1 = one;
+	str2 = two;
+
+	/* grab first completely alpha or completely numeric segment */
+	/* leave one and two pointing to the start of the alpha or numeric */
+	/* segment and walk str1 and str2 to end of segment */
+	if (g_ascii_isdigit(*str1)) {
+		while (*str1 && g_ascii_isdigit(*str1)) str1++;
+		while (*str2 && g_ascii_isdigit(*str2)) str2++;
+		isnum = 1;
+	} else {
+		while (*str1 && g_ascii_isalpha(*str1)) str1++;
+		while (*str2 && g_ascii_isalpha(*str2)) str2++;
+		isnum = 0;
+	}
+
+	/* save character at the end of the alpha or numeric segment */
+	/* so that they can be restored after the comparison */
+	oldch1 = *str1;
+	*str1 = '\0';
+	oldch2 = *str2;
+	*str2 = '\0';
+
+	/* this cannot happen, as we previously tested to make sure that */
+	/* the first string has a non-null segment */
+	if (one == str1) return -1;	/* arbitrary */
+
+	/* take care of the case where the two version segments are */
+	/* different types: one numeric, the other alpha (i.e. empty) */
+	/* numeric segments are always newer than alpha segments */
+	/* XXX See patch #60884 (and details) from bugzilla #50977. */
+	if (two == str2) return (isnum ? 1 : -1);
+
+	if (isnum) {
+		gsize onelen, twolen;
+		/* this used to be done by converting the digit segments */
+		/* to ints using atoi() - it's changed because long  */
+		/* digit segments can overflow an int - this should fix that. */
+
+		/* throw away any leading zeros - it's a number, right? */
+		while (*one == '0') one++;
+		while (*two == '0') two++;
+
+		/* whichever number has more digits wins */
+		onelen = strlen(one);
+		twolen = strlen(two);
+		if (onelen > twolen) return 1;
+		if (twolen > onelen) return -1;
+	}
+
+	/* strcmp will return which one is greater - even if the two */
+	/* segments are alpha or if they are numeric.  don't return  */
+	/* if they are equal because there might be more segments to */
+	/* compare */
+	rc = g_strcmp0(one, two);
+	if (rc) return (rc < 1 ? -1 : 1);
+
+	/* restore character that was replaced by null above */
+	*str1 = oldch1;
+	one = str1;
+	*str2 = oldch2;
+	two = str2;
+	}
+
+	/* this catches the case where all numeric and alpha segments have */
+	/* compared identically but the segment sepparating characters were */
+	/* different */
+	if ((!*one) && (!*two)) return 0;
+
+	/* whichever version still has characters left over wins */
+	if (!*one) return -1; else return 1;
+}
+
+/**
+ * as_utils_vercmp_complex:
+ * @version_a: the release version, e.g. 1.2.3
+ * @version_b: the release version, e.g. 1.2.3.1
+ * @flags: some #AsVersionCompareFlag
+ *
+ * Compares version numbers for sorting.
+ *
+ * Returns: -1 if a < b, +1 if a > b, 0 if they are equal, and %G_MAXINT on error
+ *
+ * Since: 0.7.15
+ */
+gint
+as_utils_vercmp_complex (const gchar *version_a,
+			 const gchar *version_b,
+			 AsVersionCompareFlag flags)
+{
+	/* sanity check */
+	if (version_a == NULL || version_b == NULL)
+		return G_MAXINT;
+
+	/* optimisation */
+	if (g_strcmp0 (version_a, version_b) == 0)
+		return 0;
+
+	/* split into sections, and try to parse */
+	if (flags & AS_VERSION_COMPARE_FLAG_USE_HEURISTICS) {
+		g_autofree gchar *str_a = as_utils_version_reparse (version_a);
+		g_autofree gchar *str_b = as_utils_version_reparse (version_b);
+		return as_utils_vercmp_rpm (str_a, str_b);
+	} else {
+		return as_utils_vercmp_rpm (version_a, version_b);
+	}
+}
+
+/**
  * as_utils_vercmp:
  * @version_a: the release version, e.g. 1.2.3
  * @version_b: the release version, e.g. 1.2.3.1
@@ -1476,8 +1679,8 @@
 gint
 as_utils_vercmp (const gchar *version_a, const gchar *version_b)
 {
-	return as_utils_vercmp_full (version_a, version_b,
-				     AS_VERSION_COMPARE_FLAG_USE_HEURISTICS);
+	return as_utils_vercmp_complex (version_a, version_b,
+					AS_VERSION_COMPARE_FLAG_USE_HEURISTICS);
 }
 
 /**
diff -Naur a/appstream-glib/libappstream-glib/as-utils.h b/appstream-glib/libappstream-glib/as-utils.h
--- a/appstream-glib/libappstream-glib/as-utils.h	2018-11-13 06:28:45.000000000 +0100
+++ b/appstream-glib/libappstream-glib/as-utils.h	2018-11-13 08:39:21.000000000 +0100
@@ -163,6 +163,12 @@
 gint		 as_utils_vercmp_full		(const gchar	*version_a,
 						 const gchar	*version_b,
 						 AsVersionCompareFlag flags);
+gchar		*as_utils_version_reparse	(const gchar	*version);
+gint		 as_utils_vercmp_rpm		(const gchar	*version_a,
+						 const gchar	*version_b);
+gint		 as_utils_vercmp_complex	(const gchar	*version_a,
+						 const gchar	*version_b,
+						 AsVersionCompareFlag flags);
 gint		 as_utils_vercmp		(const gchar	*version_a,
 						 const gchar	*version_b);
 gboolean	 as_utils_guid_is_valid		(const gchar	*guid);
```

This patch deprecates the following functions:
- as_utils_vercmp_full
- as_utils_version_parse

If you want, I can just insert the code from as_utils_vercmp_complex and as_utils_version_reparse into them.

I also prepared a simple test: [org.freedesktop.appstream-test.yaml](https://paste.ubuntu.com/p/D3jzMB6Z8c/)
```
app-id: org.freedesktop.appstream-test
runtime: org.freedesktop.Platform
runtime-version: '18.08'
sdk: org.freedesktop.Sdk
command: appstream-test
modules:
  - name: libappstream-glib
    buildsystem: meson
    config-opts:
      - -Dfonts=false
      - -Ddep11=false
      - -Drpm=false
      - -Dstemmer=false
    sources:
      - type: git
        url: https://github.com/scx/appstream-glib.git
        branch: master
        commit: 2ff970eb3cc748da336695f941356b74da16c55f
    post-install:
      - meson test
    cleanup:
      - /share/installed-tests
  - name: appstream-test
    buildsystem: simple
    sources:
      - type: script
        commands:
          - appstream-util --version
          - appstream-util vercmp 'Build 9half' 'Build 10'
          - appstream-util vercmp 'Build 9.5' 'Build 10'
          - appstream-util vercmp 'Build 9+' 'Build 10'
          - appstream-util vercmp 'Build 9a' 'Build 10'
          - appstream-util vercmp 'Build 9' 'Build 10'
          - appstream-util vercmp '9half' '10'
          - appstream-util vercmp '9.5' '10'
          - appstream-util vercmp '9+' '10'
          - appstream-util vercmp '9a' '10'
          - appstream-util vercmp '9' '10'
          - appstream-util vercmp '1.2.3' '1.2.3'
          - appstream-util vercmp '001.002.003' '001.002.003'
          - appstream-util vercmp '1.2.3' '0x1020003'
          - appstream-util vercmp '0x10203' '0x10203'
          - appstream-util vercmp '1.2.3' '1.2.4'
          - appstream-util vercmp '001.002.000' '001.002.009'
          - appstream-util vercmp '1.2.3' '1.2.2'
          - appstream-util vercmp '001.002.009' '001.002.000'
          - appstream-util vercmp '1.2.3' '1.2.3.1'
          - appstream-util vercmp '1.2.3.1' '1.2.4'
          - appstream-util vercmp '1.2.3a' '1.2.3a'
          - appstream-util vercmp '1.2.3a' '1.2.3b'
          - appstream-util vercmp '1.2.3b' '1.2.3a'
          - appstream-util vercmp '1.2.3' '1.2.3a'
          - appstream-util vercmp '1.2.3a' '1.2.3'
          - appstream-util vercmp 'alpha' 'alpha'
          - appstream-util vercmp 'alpha' 'beta'
          - appstream-util vercmp 'beta' 'alpha'
          - appstream-util vercmp '1.2a.3' '1.2a.3'
          - appstream-util vercmp '1.2a.3' '1.2b.3'
          - appstream-util vercmp '1.2b.3' '1.2a.3'
          - appstream-util vercmp '1.2.3~rc1' '1.2.3~rc1'
          - appstream-util vercmp '1.2.3~rc1' '1.2.3'
          - appstream-util vercmp '1.2.3' '1.2.3~rc1'
          - appstream-util vercmp '1.2.3~rc2' '1.2.3~rc1'
        dest-filename: appstream-test
    build-commands:
      - install -p -D -m 0755 'appstream-test' -t '/app/bin/'
```

Build command:
```
mkdir -p build && flatpak-builder 'build' 'org.freedesktop.appstream-test.yaml' --force-clean --install-deps-from='flathub'
```

Run command:
```
flatpak-builder --run 'build' 'org.freedesktop.appstream-test.yaml' 'appstream-test' 2>/dev/null
```

Results:
```
Version:	0.7.14
Build 9half < Build 10
Build 9.5 < Build 10
Build 9+ < Build 10
Build 9a < Build 10
Build 9 < Build 10
9half < 10
9.5 < 10
9+ < 10
9a < 10
9 < 10
1.2.3 = 1.2.3
001.002.003 = 001.002.003
1.2.3 = 0x1020003
0x10203 = 0x10203
1.2.3 < 1.2.4
001.002.000 < 001.002.009
1.2.3 > 1.2.2
001.002.009 > 001.002.000
1.2.3 < 1.2.3.1
1.2.3.1 < 1.2.4
1.2.3a = 1.2.3a
1.2.3a < 1.2.3b
1.2.3b > 1.2.3a
1.2.3 < 1.2.3a
1.2.3a > 1.2.3
alpha = alpha
alpha < beta
beta > alpha
1.2a.3 = 1.2a.3
1.2a.3 < 1.2b.3
1.2b.3 > 1.2a.3
1.2.3~rc1 = 1.2.3~rc1
1.2.3~rc1 < 1.2.3
1.2.3 > 1.2.3~rc1
1.2.3~rc2 > 1.2.3~rc1
```

See also: https://github.com/hughsie/appstream-glib/issues/270#issuecomment-438183984