### PR TITLE
build: Remove unnecessary gtk dependency for builder

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,6 @@ gdkpixbuf = dependency('gdk-pixbuf-2.0', version : '>= 2.31.5')
 
 # builder (default enabled)
 if get_option('builder')
-  gtk = dependency('gtk+-3.0')
   gmodule = dependency('gmodule-2.0')
   if get_option('rpm')
     rpm = dependency('rpm')


### PR DESCRIPTION
Builder checks for gtk+, but the result isn't used anywhere, thus
introducing an unnecessary gtk+ dependency.
-Dbuilder=true -Dfonts=true would still depend on gdk, but a
-Dbuilder=true -Dfonts=false build doesn't anymore.

Closes: #274