### PR TITLE
store: Fix threading related crashes when creating the search cache

### DIFF
--- a/libappstream-glib/as-store.c
+++ b/libappstream-glib/as-store.c
@@ -3407,7 +3407,7 @@ as_store_search_per_user (AsStore *store,
 static void
 as_store_load_search_cache_cb (gpointer data, gpointer user_data)
 {
-	AsApp *app = AS_APP (data);
+	g_autoptr(AsApp) app = AS_APP (data);
 	as_app_search_matches (app, NULL);
 }
 
@@ -3446,7 +3446,7 @@ as_store_load_search_cache (AsStore *store)
 	g_mutex_lock (&priv->mutex);
 	for (i = 0; i < priv->array->len; i++) {
 		AsApp *app = g_ptr_array_index (priv->array, i);
-		g_thread_pool_push (pool, app, NULL);
+		g_thread_pool_push (pool, g_object_ref (app), NULL);
 	}
 	g_mutex_unlock (&priv->mutex);
 	g_thread_pool_free (pool, FALSE, TRUE);


### PR DESCRIPTION
Keep a ref on the AsApp in the worker thread to make sure it doesn't get
destroyed in another thread while being processed.

https://bugzilla.redhat.com/show_bug.cgi?id=1662130
https://bugzilla.redhat.com/show_bug.cgi?id=1661701
https://bugzilla.redhat.com/show_bug.cgi?id=1661382
https://bugzilla.redhat.com/show_bug.cgi?id=1658140
https://bugzilla.redhat.com/show_bug.cgi?id=1644026
https://bugzilla.redhat.com/show_bug.cgi?id=1639558
https://bugzilla.redhat.com/show_bug.cgi?id=1570096