### PR TITLE
libappstream-glib/meson.build: pass -DAS_COMPILATION to gir compiler

### DIFF
--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -235,6 +235,9 @@ if get_option('introspection')
       'Gio-2.0',
       'GdkPixbuf-2.0'
     ],
+    extra_args : [
+      '-DAS_COMPILATION',
+    ],
     link_with : asglib,
     install : true,
   )


### PR DESCRIPTION
This fixes cross building of gir using Yocto Project/Buildroot
method.

This is also done on:

atk with -DATK_COMPILATION,
gdk-pixbuf with -DGDK_PIXBUF_COMPILATION,
libgusb with -DGUSB_COMPILATION.