### PR TITLE
Do not install the libappstream-builder shared library

### DIFF
--- a/contrib/libappstream-glib.spec.in
+++ b/contrib/libappstream-glib.spec.in
@@ -60,6 +60,7 @@ representation.
 %package devel
 Summary: GLib Libraries and headers for appstream-glib
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Obsoletes: %{name}-builder-devel < 0.7.14-2
 
 %description devel
 GLib headers and libraries for appstream-glib.
@@ -136,16 +137,7 @@ GLib headers and libraries for appstream-builder.
 %{_libdir}/asb-plugins-%{as_plugin_version}/libasb_plugin_hardcoded.so
 %{_libdir}/asb-plugins-%{as_plugin_version}/libasb_plugin_icon.so
 %{_libdir}/asb-plugins-%{as_plugin_version}/libasb_plugin_shell_extension.so
-%{_libdir}/libappstream-builder.so.8*
 %{_mandir}/man1/appstream-builder.1.gz
-
-%files builder-devel
-%license COPYING
-%{_libdir}/libappstream-builder.so
-%{_libdir}/pkgconfig/appstream-builder.pc
-%dir %{_includedir}/libappstream-builder
-%{_includedir}/libappstream-builder/*.h
-%{_datadir}/gir-1.0/AppStreamBuilder-1.0.gir
 
 %changelog
 * #LONGDATE# Richard Hughes <richard@hughsie.com> #VERSION#-0.#BUILD##ALPHATAG#

--- a/libappstream-builder/meson.build
+++ b/libappstream-builder/meson.build
@@ -25,13 +25,6 @@ if get_option('alpm')
   deps = deps + [alpm]
 endif
 
-headers = [
-  'appstream-builder.h',
-  'asb-app.h',
-]
-
-install_headers(headers, subdir : 'libappstream-builder')
-
 sources = [
   'asb-app.c',
   'asb-context.c',
@@ -54,40 +47,19 @@ endif
 
 top_build_incdir = include_directories('..')
 
-mapfile = 'appstream-builder.map'
-vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
-asbuilder = shared_library(
+asbuilder = static_library(
   'appstream-builder', sources,
-  soversion : lt_current,
-  version : lt_version,
   dependencies : deps,
   c_args : asbuilder_cargs,
   include_directories : [
     top_build_incdir,
     asglib_incdir,
   ],
-  link_args : vflag,
-  link_depends : mapfile,
   link_with : asglib,
-  install : true,
 )
 asbuilder_incdir = include_directories('.')
 
 subdir('plugins')
-
-pkgg.generate(
-  version : as_version,
-  libraries : asbuilder,
-  requires : [
-    'glib-2.0',
-    'gobject-2.0',
-    'gdk-pixbuf-2.0',
-  ],
-  name : 'appstream-builder',
-  description : 'Objects and helper methods to help reading and writing AppStream metadata',
-  filebase : 'appstream-builder',
-  subdirs : 'libappstream-builder'
-)
 
 asb_self_test = executable(
   'asb-self-test',
@@ -108,36 +80,3 @@ asb_self_test = executable(
   ],
 )
 test('asb-self-test', asb_self_test)
-
-asbuilder_introspection_srcs = [
-  'asb-app.c',
-  'asb-app.h',
-  'asb-context.c',
-  'asb-context.h',
-  'asb-context-private.h',
-  'asb-package.c',
-  'asb-package.h',
-  'asb-task.c',
-  'asb-task.h',
-]
-
-if get_option('introspection')
-  asglib_gir_dep = declare_dependency(sources: asglib_gir)
-
-  gnome.generate_gir(asbuilder,
-    sources : asbuilder_introspection_srcs,
-    nsversion : '1.0',
-    namespace : 'AppStreamBuilder',
-    symbol_prefix : 'asb_',
-    identifier_prefix : 'Asb',
-    export_packages : 'appstream-builder',
-    dependencies: asglib_gir_dep,
-    includes : [
-      'AppStreamGlib-1.0',
-      'GdkPixbuf-2.0',
-      'Gio-2.0',
-      'GObject-2.0',
-    ],
-    install : true
-  )
-endif

--- a/libappstream-builder/plugins/meson.build
+++ b/libappstream-builder/plugins/meson.build
@@ -11,7 +11,6 @@ shared_module(
   dependencies : [
     gdkpixbuf,
   ],
-  link_with : [asbuilder, asglib],
   c_args : asb_plugins_cargs,
   install : true,
   install_dir : plugindir,
@@ -28,7 +27,6 @@ shared_module(
   dependencies : [
     gdkpixbuf,
   ],
-  link_with : [asbuilder, asglib],
   c_args : asb_plugins_cargs,
   install : true,
   install_dir : plugindir,
@@ -45,7 +43,6 @@ shared_module(
   dependencies : [
     gdkpixbuf,
   ],
-  link_with : [asbuilder, asglib],
   c_args : asb_plugins_cargs,
   install : true,
   install_dir : plugindir,
@@ -62,7 +59,6 @@ shared_module(
   dependencies : [
     gdkpixbuf,
   ],
-  link_with : [asbuilder, asglib],
   c_args : asb_plugins_cargs,
   install : true,
   install_dir : plugindir,
@@ -79,7 +75,6 @@ shared_module(
   dependencies : [
     gdkpixbuf,
   ],
-  link_with : [asbuilder, asglib],
   c_args : asb_plugins_cargs,
   install : true,
   install_dir : plugindir,
@@ -97,7 +92,6 @@ shared_module(
     gdkpixbuf,
     json_glib,
   ],
-  link_with : [asbuilder, asglib],
   c_args : asb_plugins_cargs,
   install : true,
   install_dir : plugindir,
@@ -118,7 +112,6 @@ if get_option('fonts')
       freetype,
       fontconfig,
     ],
-    link_with : [asbuilder, asglib],
     c_args : asb_plugins_cargs,
     install : true,
     install_dir : plugindir,


### PR DESCRIPTION
Nothing uses it, and it's not API or ABI stable.