### PR TITLE
Wip/jehan/win32 port

### DIFF
--- a/client/as-util.c
+++ b/client/as-util.c
@@ -23,8 +23,11 @@
 
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
-#include <glib-unix.h>
 #include <gio/gio.h>
+
+#ifndef _WIN32
+#include <glib-unix.h>
+#endif
 
 #include <appstream-glib.h>
 #include <archive_entry.h>
@@ -4282,6 +4285,20 @@ as_util_watch_cancelled_cb (GCancellable *cancellable, gpointer user_data)
 	g_main_loop_quit (priv->loop);
 }
 
+#ifdef _WIN32
+static AsUtilPrivate *as_util_priv = NULL;
+
+static BOOL
+as_util_sigint_cb (DWORD dwCtrlType)
+{
+    if (dwCtrlType == CTRL_C_EVENT) {
+        g_debug ("Handling SIGINT");
+        g_cancellable_cancel (as_util_priv->cancellable);
+        return TRUE;
+    }
+	return FALSE;
+}
+#else
 static gboolean
 as_util_sigint_cb (gpointer user_data)
 {
@@ -4290,6 +4307,7 @@ as_util_sigint_cb (gpointer user_data)
 	g_cancellable_cancel (priv->cancellable);
 	return FALSE;
 }
+#endif
 
 static gboolean
 as_util_regex (AsUtilPrivate *priv, gchar **values, GError **error)
@@ -4355,11 +4373,16 @@ main (int argc, char *argv[])
 	/* do stuff on ctrl+c */
 	priv->loop = g_main_loop_new (NULL, FALSE);
 	priv->cancellable = g_cancellable_new ();
+#ifdef _WIN32
+    as_util_priv = priv;
+    SetConsoleCtrlHandler (as_util_sigint_cb, TRUE);
+#else
 	g_unix_signal_add_full (G_PRIORITY_DEFAULT,
 				SIGINT,
 				as_util_sigint_cb,
 				priv,
 				NULL);
+#endif
 	g_signal_connect (priv->cancellable, "cancelled",
 			  G_CALLBACK (as_util_watch_cancelled_cb), priv);
 

--- a/libappstream-glib/as-app-builder.c
+++ b/libappstream-glib/as-app-builder.c
@@ -33,7 +33,6 @@
 
 #include "config.h"
 
-#include <fnmatch.h>
 #include <string.h>
 
 #include "as-app-builder.h"

--- a/libappstream-glib/as-app-desktop.c
+++ b/libappstream-glib/as-app-desktop.c
@@ -19,20 +19,31 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
+#include <string.h>
+
+#include "as-app-private.h"
+#include "as-utils.h"
+
 #ifdef _WIN32
 #include <shlwapi.h>
  /* The Microsoft MS-DOS pattern matching is close enough to
   * the glob shell pattern matching for our usage.
   */
-#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
+static int
+fnmatch (const char *pattern, const char *string, int flags)
+{
+	typedef BOOL (WINAPI *t_PathMatchSpecA) (LPCSTR pszFile, LPCSTR pszSpec);
+	t_PathMatchSpecA p_PathMatchSpecA;
+
+	p_PathMatchSpecA = (t_PathMatchSpecA) GetProcAddress (GetModuleHandle ("Shlwapi.dll"), "PathMatchSpecA");
+
+	g_return_val_if_fail (p_PathMatchSpecA, 1);
+
+	return p_PathMatchSpecA(string, pattern);
+}
 #else
 #include <fnmatch.h>
 #endif
-
-#include <string.h>
-
-#include "as-app-private.h"
-#include "as-utils.h"
 
 static gchar *
 as_app_desktop_key_get_locale (const gchar *key)

--- a/libappstream-glib/as-app-desktop.c
+++ b/libappstream-glib/as-app-desktop.c
@@ -19,7 +19,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
+#ifdef _WIN32
+#include <shlwapi.h>
+ /* The Microsoft MS-DOS pattern matching is close enough to
+  * the glob shell pattern matching for our usage.
+  */
+#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
+#else
 #include <fnmatch.h>
+#endif
+
 #include <string.h>
 
 #include "as-app-private.h"

--- a/libappstream-glib/as-app-desktop.c
+++ b/libappstream-glib/as-app-desktop.c
@@ -39,7 +39,7 @@ fnmatch (const char *pattern, const char *string, int flags)
 
 	g_return_val_if_fail (p_PathMatchSpecA, 1);
 
-	return p_PathMatchSpecA(string, pattern);
+	return p_PathMatchSpecA(string, pattern) ? 0 : 1;
 }
 #else
 #include <fnmatch.h>

--- a/libappstream-glib/as-app-inf.c
+++ b/libappstream-glib/as-app-inf.c
@@ -19,7 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-#include <fnmatch.h>
 #include <string.h>
 
 #include "as-app-private.h"

--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -21,7 +21,6 @@
 
 #include "config.h"
 
-#include <fnmatch.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <libsoup/soup.h>
 #include <libsoup/soup-status.h>

--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -35,7 +35,16 @@
 #include "config.h"
 
 #include <string.h>
+
+#ifdef _WIN32
+#include <shlwapi.h>
+ /* The Microsoft MS-DOS pattern matching is close enough to
+  * the glob shell pattern matching for our usage.
+  */
+#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
+#else
 #include <fnmatch.h>
+#endif
 
 #include "as-app-private.h"
 #include "as-bundle-private.h"

--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -72,7 +72,7 @@ fnmatch (const char *pattern, const char *string, int flags)
 
 	g_return_val_if_fail (p_PathMatchSpecA, 1);
 
-	return p_PathMatchSpecA(string, pattern);
+	return p_PathMatchSpecA(string, pattern) ? 0 : 1;
 }
 #else
 #include <fnmatch.h>

--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -36,16 +36,6 @@
 
 #include <string.h>
 
-#ifdef _WIN32
-#include <shlwapi.h>
- /* The Microsoft MS-DOS pattern matching is close enough to
-  * the glob shell pattern matching for our usage.
-  */
-#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
-#else
-#include <fnmatch.h>
-#endif
-
 #include "as-app-private.h"
 #include "as-bundle-private.h"
 #include "as-content-rating-private.h"
@@ -66,6 +56,27 @@
 #include "as-suggest-private.h"
 #include "as-utils-private.h"
 #include "as-yaml.h"
+
+#ifdef _WIN32
+#include <shlwapi.h>
+ /* The Microsoft MS-DOS pattern matching is close enough to
+  * the glob shell pattern matching for our usage.
+  */
+static int
+fnmatch (const char *pattern, const char *string, int flags)
+{
+	typedef BOOL (WINAPI *t_PathMatchSpecA) (LPCSTR pszFile, LPCSTR pszSpec);
+	t_PathMatchSpecA p_PathMatchSpecA;
+
+	p_PathMatchSpecA = (t_PathMatchSpecA) GetProcAddress (GetModuleHandle ("Shlwapi.dll"), "PathMatchSpecA");
+
+	g_return_val_if_fail (p_PathMatchSpecA, 1);
+
+	return p_PathMatchSpecA(string, pattern);
+}
+#else
+#include <fnmatch.h>
+#endif
 
 typedef struct
 {

--- a/libappstream-glib/as-format.c
+++ b/libappstream-glib/as-format.c
@@ -202,11 +202,15 @@ as_format_guess_kind (const gchar *filename)
 void
 as_format_set_filename (AsFormat *format, const gchar *filename)
 {
+	gchar *canon_filename;
+
 	AsFormatPrivate *priv = GET_PRIVATE (format);
 	g_return_if_fail (AS_IS_FORMAT (format));
 	if (priv->kind == AS_FORMAT_KIND_UNKNOWN)
 		priv->kind = as_format_guess_kind (filename);
-	as_ref_string_assign_safe (&priv->filename, filename);
+	canon_filename = g_canonicalize_filename (filename, NULL);
+	as_ref_string_assign_safe (&priv->filename, canon_filename);
+	g_free (canon_filename);
 }
 
 /**

--- a/libappstream-glib/as-require.c
+++ b/libappstream-glib/as-require.c
@@ -32,20 +32,31 @@
 
 #include "config.h"
 
+#include "as-require-private.h"
+#include "as-node-private.h"
+#include "as-ref-string.h"
+#include "as-utils-private.h"
+
 #ifdef _WIN32
 #include <shlwapi.h>
  /* The Microsoft MS-DOS pattern matching is close enough to
   * the glob shell pattern matching for our usage.
   */
-#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
+static int
+fnmatch (const char *pattern, const char *string, int flags)
+{
+	typedef BOOL (WINAPI *t_PathMatchSpecA) (LPCSTR pszFile, LPCSTR pszSpec);
+	t_PathMatchSpecA p_PathMatchSpecA;
+
+	p_PathMatchSpecA = (t_PathMatchSpecA) GetProcAddress (GetModuleHandle ("Shlwapi.dll"), "PathMatchSpecA");
+
+	g_return_val_if_fail (p_PathMatchSpecA, 1);
+
+	return p_PathMatchSpecA(string, pattern);
+}
 #else
 #include <fnmatch.h>
 #endif
-
-#include "as-require-private.h"
-#include "as-node-private.h"
-#include "as-ref-string.h"
-#include "as-utils-private.h"
 
 typedef struct
 {

--- a/libappstream-glib/as-require.c
+++ b/libappstream-glib/as-require.c
@@ -52,7 +52,7 @@ fnmatch (const char *pattern, const char *string, int flags)
 
 	g_return_val_if_fail (p_PathMatchSpecA, 1);
 
-	return p_PathMatchSpecA(string, pattern);
+	return p_PathMatchSpecA(string, pattern) ? 0 : 1;
 }
 #else
 #include <fnmatch.h>

--- a/libappstream-glib/as-require.c
+++ b/libappstream-glib/as-require.c
@@ -32,7 +32,15 @@
 
 #include "config.h"
 
+#ifdef _WIN32
+#include <shlwapi.h>
+ /* The Microsoft MS-DOS pattern matching is close enough to
+  * the glob shell pattern matching for our usage.
+  */
+#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
+#else
 #include <fnmatch.h>
+#endif
 
 #include "as-require-private.h"
 #include "as-node-private.h"

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -25,7 +25,16 @@
 #include <glib/gstdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <shlwapi.h>
+ /* The Microsoft MS-DOS pattern matching is close enough to
+  * the glob shell pattern matching for our usage.
+  */
+#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
+#else
 #include <fnmatch.h>
+#endif
 
 #include "as-agreement-private.h"
 #include "as-app-private.h"

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -68,7 +68,7 @@ fnmatch (const char *pattern, const char *string, int flags)
 
 	g_return_val_if_fail (p_PathMatchSpecA, 1);
 
-	return p_PathMatchSpecA(string, pattern);
+	return p_PathMatchSpecA(string, pattern) ? 0 : 1;
 }
 #define FNM_NOESCAPE 0
 #else

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -115,7 +115,21 @@ as_test_get_filename (const gchar *filename)
 		g_free (path);
 		path = g_build_filename (TESTDIRBUILD, filename, NULL);
 	}
+#ifdef _WIN32
+	{
+		DWORD retval;
+		TCHAR full_path[PATH_MAX];
+
+		retval = GetFullPathNameA (path, PATH_MAX, full_path, NULL);
+
+		if (retval > 0)
+			return g_strdup (full_path);
+		else
+			return NULL;
+	}
+#else
 	return realpath (path, NULL);
+#endif
 }
 
 static GMainLoop *_test_loop = NULL;

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2371,6 +2371,9 @@ as_test_store_local_appdata_func (void)
 			       "ignoring description '*' from */broken.appdata.xml: Unknown tag '_p'");
 
 	/* open test store */
+#ifdef _WIN32
+	g_setenv ("XDG_DATA_DIRS", "/usr/share/", TRUE);
+#endif
 	store = as_store_new ();
 	filename = as_test_get_filename (".");
 	as_store_set_destdir (store, filename);

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -26,16 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _WIN32
-#include <shlwapi.h>
- /* The Microsoft MS-DOS pattern matching is close enough to
-  * the glob shell pattern matching for our usage.
-  */
-#define fnmatch(pattern, string, flags) PathMatchSpecA(string, pattern)
-#else
-#include <fnmatch.h>
-#endif
-
 #include "as-agreement-private.h"
 #include "as-app-private.h"
 #include "as-app-builder.h"
@@ -62,6 +52,28 @@
 #include "as-tag.h"
 #include "as-utils-private.h"
 #include "as-yaml.h"
+
+#ifdef _WIN32
+#include <shlwapi.h>
+ /* The Microsoft MS-DOS pattern matching is close enough to
+  * the glob shell pattern matching for our usage.
+  */
+static int
+fnmatch (const char *pattern, const char *string, int flags)
+{
+	typedef BOOL (WINAPI *t_PathMatchSpecA) (LPCSTR pszFile, LPCSTR pszSpec);
+	t_PathMatchSpecA p_PathMatchSpecA;
+
+	p_PathMatchSpecA = (t_PathMatchSpecA) GetProcAddress (GetModuleHandle ("Shlwapi.dll"), "PathMatchSpecA");
+
+	g_return_val_if_fail (p_PathMatchSpecA, 1);
+
+	return p_PathMatchSpecA(string, pattern);
+}
+#define FNM_NOESCAPE 0
+#else
+#include <fnmatch.h>
+#endif
 
 #define AS_TEST_WILDCARD_SHA1	"\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?"
 

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2366,9 +2366,15 @@ as_test_store_local_appdata_func (void)
 	g_autoptr(AsStore) store = NULL;
 
 	/* this are the warnings expected */
+#ifdef _WIN32
+	g_test_expect_message (G_LOG_DOMAIN,
+			       G_LOG_LEVEL_WARNING,
+			       "ignoring description '*' from *\\broken.appdata.xml: Unknown tag '_p'");
+#else
 	g_test_expect_message (G_LOG_DOMAIN,
 			       G_LOG_LEVEL_WARNING,
 			       "ignoring description '*' from */broken.appdata.xml: Unknown tag '_p'");
+#endif
 
 	/* open test store */
 #ifdef _WIN32

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2363,6 +2363,7 @@ as_test_store_local_appdata_func (void)
 	gboolean ret;
 	g_autofree gchar *filename = NULL;
 	g_autofree gchar *filename_full = NULL;
+	g_autofree gchar *canonical_filename;
 	g_autoptr(AsStore) store = NULL;
 
 	/* this are the warnings expected */
@@ -2399,7 +2400,8 @@ as_test_store_local_appdata_func (void)
 	filename_full = g_build_filename (filename,
 					  "usr/share/appdata/broken.appdata.xml",
 					  NULL);
-	g_assert_cmpstr (as_format_get_filename (format), ==, filename_full);
+	canonical_filename = g_canonicalize_filename (filename_full, NULL);
+	g_assert_cmpstr (as_format_get_filename (format), ==, canonical_filename);
 }
 
 static void

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -1548,12 +1548,12 @@ as_utils_guid_from_data (const gchar *namespace_id,
 	t_UuidToString p_UuidToString;
 	t_RpcStringFree p_RpcStringFree;
 
-	p_UuidCreate = (t_UuidCreate) GetProcAddress (GetModuleHandle ("Rpcrt4.dll"), "UuidCreate");
-	p_UuidFromString = (t_UuidFromString) GetProcAddress (GetModuleHandle ("Rpcrt4.dll"), "UuidFromString");
-	p_UuidToString = (t_UuidToString) GetProcAddress (GetModuleHandle ("Rpcrt4.dll"), "UuidToString");
-	p_RpcStringFree = (t_RpcStringFree) GetProcAddress (GetModuleHandle ("Rpcrt4.dll"), "RpcStringFree");
+	p_UuidCreate = (t_UuidCreate) GetProcAddress (GetModuleHandle ("rpcrt4.dll"), "UuidCreate");
+	p_UuidFromString = (t_UuidFromString) GetProcAddress (GetModuleHandle ("rpcrt4.dll"), "UuidFromStringA");
+	p_UuidToString = (t_UuidToString) GetProcAddress (GetModuleHandle ("rpcrt4.dll"), "UuidToStringA");
+	p_RpcStringFree = (t_RpcStringFree) GetProcAddress (GetModuleHandle ("rpcrt4.dll"), "RpcStringFreeA");
 
-	g_return_val_if_fail (p_UuidCreate && p_UuidFromString && p_UuidToString, FALSE);
+	g_return_val_if_fail (p_UuidCreate && p_UuidFromString && p_UuidToString && p_RpcStringFree, FALSE);
 #else
 	gchar guid_new[37]; /* 36 plus NUL */
 	gint rc;
@@ -1689,7 +1689,7 @@ as_utils_guid_is_valid (const gchar *guid)
         RPC_STATUS rc;
         UUID uu;
 
-		p_UuidFromString = (t_UuidFromString) GetProcAddress (GetModuleHandle ("Rpcrt4.dll"), "UuidFromString");
+		p_UuidFromString = (t_UuidFromString) GetProcAddress (GetModuleHandle ("rpcrt4.dll"), "UuidFromStringA");
 
 		g_return_val_if_fail (p_UuidFromString, FALSE);
 

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -32,7 +32,6 @@
 
 #include "config.h"
 
-#include <fnmatch.h>
 #include <string.h>
 #include <archive_entry.h>
 #include <archive.h>

--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -6,12 +6,17 @@ cargs = [
 
 deps = [
   gdkpixbuf,
-  giounix,
   glib,
   libarchive,
   soup,
   uuid,
 ]
+
+if platform_win32
+  deps += [giowindows]
+else
+  deps += [giounix]
+endif
 
 if get_option('dep11')
   deps += yaml

--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -9,13 +9,12 @@ deps = [
   glib,
   libarchive,
   soup,
-  uuid,
 ]
 
 if platform_win32
   deps += [giowindows]
 else
-  deps += [giounix]
+  deps += [giounix, uuid]
 endif
 
 if get_option('dep11')
@@ -143,6 +142,14 @@ asglib = shared_library(
 )
 asglib_incdir = include_directories('.')
 
+pkg_req_private = [
+  'libarchive'
+]
+
+if not platform_win32
+  pkg_req_private += ['uuid']
+endif
+
 pkgg.generate(
   version : as_version,
   libraries : asglib,
@@ -151,10 +158,7 @@ pkgg.generate(
     'gobject-2.0',
     'gdk-pixbuf-2.0',
   ],
-  requires_private : [
-    'libarchive',
-    'uuid',
-  ],
+  requires_private : pkg_req_private,
   name : 'appstream-glib',
   description : 'Objects and helper methods to help reading and writing AppStream metadata',
   filebase : 'appstream-glib',

--- a/meson.build
+++ b/meson.build
@@ -60,13 +60,13 @@ plugindir = join_paths(get_option('prefix'),
                        'asb-plugins-' + as_plugin_version)
 
 glib_ver = '>= 2.45.8'
-uuid = dependency('uuid')
 glib = dependency('glib-2.0', version : glib_ver)
 gmodule = dependency('gmodule-2.0', version : glib_ver)
 if platform_win32
   giowindows = dependency('gio-windows-2.0', version : glib_ver)
 else
   giounix = dependency('gio-unix-2.0', version : glib_ver)
+  uuid = dependency('uuid')
 endif
 libarchive = dependency('libarchive')
 soup = dependency('libsoup-2.4', version : '>= 2.51.92')

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,17 @@ as_major_version = varr[0]
 as_minor_version = varr[1]
 as_micro_version = varr[2]
 
+# Check the right platform.
+
+platform_win32 = false
+
+host_os = host_machine.system()
+
+platform_win32 = (host_os.startswith('mingw') or
+                  host_os.startswith('cygwin') or
+                  host_os.startswith('windows'))
+
+
 conf = configuration_data()
 conf.set('AS_MAJOR_VERSION_CONF', as_major_version)
 conf.set('AS_MINOR_VERSION_CONF', as_minor_version)
@@ -52,7 +63,11 @@ glib_ver = '>= 2.45.8'
 uuid = dependency('uuid')
 glib = dependency('glib-2.0', version : glib_ver)
 gmodule = dependency('gmodule-2.0', version : glib_ver)
-giounix = dependency('gio-unix-2.0', version : glib_ver)
+if platform_win32
+  giowindows = dependency('gio-windows-2.0', version : glib_ver)
+else
+  giounix = dependency('gio-unix-2.0', version : glib_ver)
+endif
 libarchive = dependency('libarchive')
 soup = dependency('libsoup-2.4', version : '>= 2.51.92')
 json_glib = dependency('json-glib-1.0', version : '>= 1.1.2')


### PR DESCRIPTION
As discussed on #252, this ports appstream-glib to Windows.

With all the changes done, I could successfully build the library, it works on GIMP, and the unit tests work fine too.

Though note that I configured with many options false:

```
Project options:
  Option        Current Value Possible Values Description                        
  ------        ------------- --------------- -----------                        
  alpm          false         [true, false]   enable ALPM support                
  builder       false         [true, false]   enable AppStream builder           
  dep11         false         [true, false]   enable DEP-11                      
  fonts         true          [true, false]   enable font support                
  gtk-doc       false         [true, false]   generate API reference             
  introspection false         [true, false]   generate GObject Introspection data
  man           true          [true, false]   generate man pages                 
  rpm           false         [true, false]   enable RPM support                 
  stemmer       false         [true, false]   enable stemmer support 
```

For the time being, I don't think I need most of these (for GIMP extensions, for which we want to add management through metadata; as a reminder of why I need these). If I realize I do, I would gladly try to port whatever part of code these options need. But for now, I went the easy route (which was annoying enough as it is! :P).