### PR TITLE
Fix build of libappstream-glib clients

### DIFF
--- a/libappstream-glib/as-agreement-section.h
+++ b/libappstream-glib/as-agreement-section.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-agreement.h
+++ b/libappstream-glib/as-agreement.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-app-builder.h
+++ b/libappstream-glib/as-app-builder.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-app.h
+++ b/libappstream-glib/as-app.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-bundle.h
+++ b/libappstream-glib/as-bundle.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-checksum.h
+++ b/libappstream-glib/as-checksum.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-content-rating.h
+++ b/libappstream-glib/as-content-rating.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-enums.h
+++ b/libappstream-glib/as-enums.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-format.h
+++ b/libappstream-glib/as-format.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-icon.h
+++ b/libappstream-glib/as-icon.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-image.h
+++ b/libappstream-glib/as-image.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-inf.h
+++ b/libappstream-glib/as-inf.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-launchable.h
+++ b/libappstream-glib/as-launchable.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-markup.h
+++ b/libappstream-glib/as-markup.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-monitor.h
+++ b/libappstream-glib/as-monitor.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-node.h
+++ b/libappstream-glib/as-node.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-problem.h
+++ b/libappstream-glib/as-problem.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-provide.h
+++ b/libappstream-glib/as-provide.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-ref-string.h
+++ b/libappstream-glib/as-ref-string.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-release.h
+++ b/libappstream-glib/as-release.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-require.h
+++ b/libappstream-glib/as-require.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-review.h
+++ b/libappstream-glib/as-review.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-screenshot.h
+++ b/libappstream-glib/as-screenshot.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-store-cab.h
+++ b/libappstream-glib/as-store-cab.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-store.h
+++ b/libappstream-glib/as-store.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-suggest.h
+++ b/libappstream-glib/as-suggest.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-tag.h
+++ b/libappstream-glib/as-tag.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-translation.h
+++ b/libappstream-glib/as-translation.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-utils.h
+++ b/libappstream-glib/as-utils.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-version.h.in
+++ b/libappstream-glib/as-version.h.in
@@ -17,7 +17,7 @@
  * depending on the version of libappstream-glib headers installed.
  */
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream_glib.h> can be included directly."
 #endif
 

--- a/libappstream-glib/as-yaml.h
+++ b/libappstream-glib/as-yaml.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#if !defined (__APPSTREAM_GLIB_H) && !defined (AS_COMPILATION)
+#if !defined (__APPSTREAM_GLIB_H_INSIDE__) && !defined (AS_COMPILATION)
 #error "Only <appstream-glib.h> can be included directly."
 #endif
 


### PR DESCRIPTION
With '#pragma once', __APPSTREAM_GLIB_H is never defined.

        In file included from /usr/include/libappstream-glib/appstream-glib.h:35:
        /usr/include/libappstream-glib/as-utils.h:11:2: error: #error "Only <appstream-glib.h> can be included directly."
         #error "Only <appstream-glib.h> can be included directly."
          ^~~~~

Fixes: 87b7483e ("Use '#pragma once' to avoid a lot of boilerplate")