### PR TITLE
build: Properly check for the rpm option

### DIFF
--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -17,7 +17,7 @@ if get_option('dep11')
   deps += yaml
 endif
 
-if get_option('rpm')
+if get_option('builder') and get_option('rpm')
   deps += rpm
 endif
 


### PR DESCRIPTION
Currently, building appstream-glib with `-Dbuilder=false -Drpm=true` fails:

https://gnome1.codethink.co.uk/logs/build-2019-02-24-091101/build-gnome-apps-nightly-master-org.gnome.Software-aarch64.txt

This is because in the top-level meson.build file, the `rpm` variable is only defined when both the `builder` and `rpm` options are true.

That means in libappstream-glib/meson.build we cannot just check for the `rpm` option and assume the variable was defined.

---

I'm not sure whether this is the right fix, I can see two other possibilities:

1. make the `rpm` option actually depend on the `builder` one, considering `-Dbuilder=false -Drpm=true` as an invalid configuration.

2. always define the `rpm` variable even when the `rpm` option is true, even if the `builder` one is false.

Thinking some more about it, the second point above is probably preferable since commit 2d8182a2d3213e67be087d60002bb36826f38e4c makes use of the rpm library in a way that is unrelated to the builder.