### PR TITLE
Modernize the validation requirements

### DIFF
--- a/data/tests/broken.appdata.xml
+++ b/data/tests/broken.appdata.xml
@@ -9,11 +9,11 @@
   <summary>Observe power management.</summary>
   <description>
     <ul>
-     <li>One</li>
+     <li>On</li>
      <li>two.</li>
     </ul>
     <p xml:lang="C">
-      This application is awesome
+      Awesome!
     </p>
     <p>
       This application is awesome

--- a/data/tests/intltool.appdata.xml.in
+++ b/data/tests/intltool.appdata.xml.in
@@ -30,4 +30,17 @@
   <translation type="gettext">gnome-power-manager</translation>
   <url type="homepage">http://www.gnome.org/projects/gnome-power-manager/</url>
   <updatecontact>richard_at_hughsie.com</updatecontact>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release date="2019-03-11" version="3.32.0">
+      <description>
+        <p>
+          This is the first stable release for GNOME 3.32.
+        </p>
+        <ul>
+          <li>Appstream parsing is completely rewritten and now uses the new libxmlb library, instead of appstream-glib</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
 </application>

--- a/data/tests/success.appdata.xml
+++ b/data/tests/success.appdata.xml
@@ -42,4 +42,17 @@
   <url type="homepage">http://www.gnome.org/projects/gnome-power-manager/</url>
   <updatecontact>richard_at_hughsie.com</updatecontact>
   <project_group>GNOME</project_group>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release date="2019-03-11" version="3.32.0">
+      <description>
+        <p>
+          This is the first stable release for GNOME 3.32.
+        </p>
+        <ul>
+          <li>Appstream parsing is completely rewritten and now uses the new libxmlb library, instead of appstream-glib</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
 </application>

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2251,21 +2251,15 @@ as_test_app_validate_file_bad_func (void)
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "<name> cannot end in '.'");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
-				    "<summary> cannot end in '.'");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "Not enough <screenshot> tags");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "<li> is too short");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
-				    "<li> cannot end in '.'");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "<ul> cannot start a description");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "<ul> cannot start a description");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "<p> should not start with 'This application'");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
-				    "<p> does not end in '.|:|!'");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "<p> is too short");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
@@ -2279,10 +2273,6 @@ as_test_app_validate_file_bad_func (void)
 				    "<release> has no version");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_ATTRIBUTE_MISSING,
 				    "<release> has no timestamp");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
-				    "<p> requires sentence case");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
-				    "<li> requires sentence case");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
 				    "<translation> not specified");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_INVALID,
@@ -2291,11 +2281,9 @@ as_test_app_validate_file_bad_func (void)
 				    "<release> version was duplicated");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_ATTRIBUTE_INVALID,
 				    "<release> timestamp is in the future");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
-				    "<content_rating> required for game");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_MARKUP_INVALID,
 				    "<id> has invalid character");
-	g_assert_cmpint (probs->len, ==, 34);
+	g_assert_cmpint (probs->len, ==, 23);
 
 	/* again, harder */
 	probs2 = as_app_validate (app, AS_APP_VALIDATE_FLAG_STRICT, &error);
@@ -2303,7 +2291,7 @@ as_test_app_validate_file_bad_func (void)
 	g_assert (probs2 != NULL);
 	as_test_app_validate_check (probs2, AS_PROBLEM_KIND_TAG_INVALID,
 				    "XML data contains unknown tag");
-	g_assert_cmpint (probs2->len, ==, 40);
+	g_assert_cmpint (probs2->len, ==, 35);
 }
 
 static void
@@ -2448,7 +2436,7 @@ as_test_app_validate_style_func (void)
 	_as_app_add_format_kind (app, AS_FORMAT_KIND_APPDATA);
 	as_app_set_metadata_license (app, "BSD");
 	as_app_set_project_license (app, "GPL-2.0+");
-	as_app_set_name (app, "C", "Test app name that is very log indeed.");
+	as_app_set_name (app, "C", "Test app name that is very long indeed although Rob forced me to relax the requirements.");
 	as_app_set_comment (app, "C", "Awesome");
 	as_app_set_update_contact (app, "someone_who_cares@upstream_project.org");
 
@@ -2475,13 +2463,17 @@ as_test_app_validate_style_func (void)
 				    "<summary> is too short");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
 				    "Not enough <screenshot> tags");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_STYLE_INCORRECT,
-				    "<summary> is shorter than <name>");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
 				    "<url> is not present");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
 				    "<translation> not specified");
-	g_assert_cmpint (probs->len, ==, 11);
+	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
+				    "<content_rating> required");
+	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
+				    "<release> required");
+	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
+				    "<description> required");
+	g_assert_cmpint (probs->len, ==, 13);
 }
 
 static void


### PR DESCRIPTION
 * Require <content_rating> for any desktop or console application
 * Make <release> mandatory when validating
 * Further relax style requirements
 * Require description for desktop an console apps

This changes a lot of things that are now best practice for all apps, and
required to be included in Flathub.

Use `appstream-util validate-relax` to ignore some new failures and use
`appstream-util validate-strict` to bring them back.

Fixes: https://github.com/hughsie/appstream-glib/issues/263