### PR TITLE
Only require <release> for validate, but not validate-relax

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -941,10 +941,13 @@ as_app_validate_releases (AsApp *app, AsAppValidateHelper *helper, GError **erro
 	    as_format_get_kind (format) != AS_FORMAT_KIND_METAINFO)
 		return TRUE;
 
-	/* only for desktop and console apps */
-	if (as_app_get_kind (app) == AS_APP_KIND_DESKTOP ||
-	    as_app_get_kind (app) == AS_APP_KIND_CONSOLE) {
-		require_release = TRUE;
+	/* make the requirements more strict */
+	if ((helper->flags & AS_APP_VALIDATE_FLAG_RELAX) == 0) {
+		/* only for desktop and console apps */
+		if (as_app_get_kind (app) == AS_APP_KIND_DESKTOP ||
+		    as_app_get_kind (app) == AS_APP_KIND_CONSOLE) {
+			require_release = TRUE;
+		}
 	}
 
 	/* require releases */


### PR DESCRIPTION
The plan was to require <release> for validate, so that we would be able
to require a version number for flathub, but it accidentally got enabled
for validate-relax as well.