### PR TITLE
Do not require <translation> for validation unless strict

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -1199,7 +1199,7 @@ as_app_validate (AsApp *app, guint32 flags, GError **error)
 	gboolean require_url = TRUE;
 	gboolean require_content_license = TRUE;
 	gboolean require_name = TRUE;
-	gboolean require_translation = TRUE;
+	gboolean require_translation = FALSE;
 	gboolean require_content_rating = FALSE;
 	gboolean require_name_shorter_than_summary = FALSE;
 	gboolean validate_license = TRUE;
@@ -1241,7 +1241,6 @@ as_app_validate (AsApp *app, guint32 flags, GError **error)
 		number_para_max = 20;
 		number_para_min = 1;
 		require_sentence_case = FALSE;
-		require_translation = FALSE;
 		require_content_rating = FALSE;
 		switch (as_format_get_kind (format)) {
 		case AS_FORMAT_KIND_METAINFO:
@@ -1264,6 +1263,7 @@ as_app_validate (AsApp *app, guint32 flags, GError **error)
 		require_sentence_case = TRUE;
 		require_name_shorter_than_summary = TRUE;
 		require_contactdetails = TRUE;
+		require_translation = TRUE;
 		number_para_min = 2;
 		number_para_max = 4;
 	}

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2295,8 +2295,6 @@ as_test_app_validate_file_bad_func (void)
 				    "<release> has no version");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_ATTRIBUTE_MISSING,
 				    "<release> has no timestamp");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
-				    "<translation> not specified");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_INVALID,
 				    "<release> versions are not in order");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_INVALID,
@@ -2305,7 +2303,7 @@ as_test_app_validate_file_bad_func (void)
 				    "<release> timestamp is in the future");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_MARKUP_INVALID,
 				    "<id> has invalid character");
-	g_assert_cmpint (probs->len, ==, 22);
+	g_assert_cmpint (probs->len, ==, 21);
 
 	/* again, harder */
 	probs2 = as_app_validate (app, AS_APP_VALIDATE_FLAG_STRICT, &error);
@@ -2497,14 +2495,12 @@ as_test_app_validate_style_func (void)
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
 				    "<url> is not present");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
-				    "<translation> not specified");
-	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
 				    "<content_rating> required");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
 				    "<release> required");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_TAG_MISSING,
 				    "<description> required");
-	g_assert_cmpint (probs->len, ==, 13);
+	g_assert_cmpint (probs->len, ==, 12);
 }
 
 static void


### PR DESCRIPTION
Flathub is already patching appstream-glib to remove this check.

Fixes https://github.com/hughsie/appstream-glib/issues/302