### PR TITLE
Offset future checks by UTC+14

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -836,6 +836,7 @@ as_app_validate_release (AsApp *app,
 	guint number_para_max = 10;
 	guint number_para_min = 1;
 	gboolean required_timestamp = TRUE;
+	const guint64 MAX_TZ_OFFSET = 14 * 60 * 60; /* UTC+14 is the biggest offset */
 
 	/* relax the requirements a bit */
 	if ((helper->flags & AS_APP_VALIDATE_FLAG_RELAX) > 0) {
@@ -870,7 +871,7 @@ as_app_validate_release (AsApp *app,
 	}
 
 	/* check the timestamp is not in the future */
-	if (timestamp > (guint64) g_get_real_time () / G_USEC_PER_SEC) {
+	if (timestamp > (guint64) g_get_real_time () / G_USEC_PER_SEC + MAX_TZ_OFFSET) {
 		ai_app_validate_add (helper,
 				     AS_PROBLEM_KIND_ATTRIBUTE_INVALID,
 				     "<release> timestamp is in the future");


### PR DESCRIPTION
The timestamp comes from a converted release date but it is in UTC. So anyone
east of UTC will get a "timestamp is in the future" warning for today's date
until UTC ticks past midnight.

According to Wikipedia the highest offset is UTC+14 so let's offset our time
by that much. This way we treat "today" as valid release date anywhere on the
planet.

Fixes https://github.com/hughsie/appstream-glib/issues/317