### PR TITLE
Update list of allowed metadata licences

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -1046,6 +1046,12 @@ as_app_validate_license (const gchar *license_text, GError **error)
 static gboolean
 as_app_validate_is_content_license_id (const gchar *license_id)
 {
+	if (g_strcmp0 (license_id, "@FSFAP") == 0)
+		return TRUE;
+	if (g_strcmp0 (license_id, "@MIT") == 0)
+		return TRUE;
+	if (g_strcmp0 (license_id, "@0BSD") == 0)
+		return TRUE;
 	if (g_strcmp0 (license_id, "@CC0-1.0") == 0)
 		return TRUE;
 	if (g_strcmp0 (license_id, "@CC-BY-3.0") == 0)
@@ -1062,7 +1068,11 @@ as_app_validate_is_content_license_id (const gchar *license_id)
 		return TRUE;
 	if (g_strcmp0 (license_id, "@GFDL-1.3") == 0)
 		return TRUE;
-	if (g_strcmp0 (license_id, "@FSFAP") == 0)
+	if (g_strcmp0 (license_id, "@BSL-1.0") == 0)
+		return TRUE;
+	if (g_strcmp0 (license_id, "@FTL") == 0)
+		return TRUE;
+	if (g_strcmp0 (license_id, "@FSFUL") == 0)
 		return TRUE;
 	return FALSE;
 }


### PR DESCRIPTION
This basically updates the list with values from the reference implementation.
https://github.com/hughsie/appstream-glib/blob/d9270c52bffde6ebd4fc3e3b4e0d34f802b920db/libappstream-glib/as-app-validate.c#L1046-L1068
https://github.com/ximion/appstream/blob/08f44a7fda48dc639346414687e79ee2e82963dd/src/as-spdx.c#L469-L507

Fixes hughsie/appstream-glib#323