### PR TITLE
as-app: add "icon-theme" as recognised component type

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -217,6 +217,8 @@ as_app_kind_from_string (const gchar *kind)
 		return AS_APP_KIND_CONSOLE;
 	if (g_strcmp0 (kind, "driver") == 0)
 		return AS_APP_KIND_DRIVER;
+	if (g_strcmp0 (kind, "icon-theme") == 0)
+		return AS_APP_KIND_ICON_THEME;
 
 	/* legacy */
 	if (g_strcmp0 (kind, "desktop") == 0)

--- a/libappstream-glib/as-app.h
+++ b/libappstream-glib/as-app.h
@@ -298,6 +298,7 @@ typedef AsFormatKind AsAppSourceKind;
  * @AS_APP_KIND_LOCALIZATION:		Localization data
  * @AS_APP_KIND_CONSOLE:		Console program
  * @AS_APP_KIND_DRIVER:			Driver for hardware support
+ * @AS_APP_KIND_ICON_THEME:		An icon theme
  *
  * The component type.
  **/
@@ -319,6 +320,7 @@ typedef enum {
 	AS_APP_KIND_LOCALIZATION,	/* Since: 0.5.11 */
 	AS_APP_KIND_CONSOLE,		/* Since: 0.6.1 */
 	AS_APP_KIND_DRIVER,		/* Since: 0.6.3 */
+	AS_APP_KIND_ICON_THEME,		/* Since: 0.7.17 */
 	/*< private >*/
 	AS_APP_KIND_LAST
 } AsAppKind;


### PR DESCRIPTION
I think making `as_app_kind_from_string` not return `AS_APP_KIND_UNKNOWN` should be enough, but I'm not really sure since I'm not familiar with how the validation flow works in detail.

See: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-IconTheme.html

Fixes #331