### PR TITLE
Revert "Allow parsing desktop files using as_app_parse_data()"

### DIFF
--- a/libappstream-glib/as-app-private.h
+++ b/libappstream-glib/as-app-private.h
@@ -102,10 +102,6 @@ gboolean	 as_app_parse_desktop_file	(AsApp		*app,
 						 const gchar	*filename,
 						 AsAppParseFlags flags,
 						 GError		**error);
-gboolean	 as_app_parse_desktop_data	(AsApp		*app,
-						 GBytes		*data,
-						 AsAppParseFlags flags,
-						 GError		**error);
 gboolean	 as_app_parse_inf_file		(AsApp		*app,
 						 const gchar	*filename,
 						 AsAppParseFlags flags,

--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -6249,8 +6249,6 @@ as_app_parse_data (AsApp *app, GBytes *data, guint32 flags, GError **error)
 
 	/* validate */
 	data_raw = g_bytes_get_data (data, &len);
-	if (g_str_has_prefix (data_raw, "[Desktop Entry]"))
-		return as_app_parse_desktop_data (app, data, flags, error);
 	if (g_strstr_len (data_raw, (gssize) len, "<?xml version=") == NULL)
 		priv->problems |= AS_APP_PROBLEM_NO_XML_HEADER;
 


### PR DESCRIPTION
The original issue was fixed in gnome-software in a different way that
didn't require appstream-glib changes in
https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/335.

This commit reverts the appstream-glib change as it regressed older
gnome-software versions.

This reverts commit 3b6701a62ef1e8f449010bd1c2bba01d1929b560.
This reverts commit d407862968c6528f44c93102e53da5664ffc8f4d.