### PR TITLE
as-app: properly initialize unique_id_mutex

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -524,6 +524,7 @@ as_app_init (AsApp *app)
 	priv->urls = g_hash_table_new_full (g_str_hash, g_str_equal,
 					    (GDestroyNotify) as_ref_string_unref,
 					    (GDestroyNotify) as_ref_string_unref);
+	g_mutex_init (&priv->unique_id_mutex);
 	priv->token_cache = g_hash_table_new_full (g_str_hash, g_str_equal,
 						   (GDestroyNotify) as_ref_string_unref,
 						   g_free);


### PR DESCRIPTION
We are using it, clearing it, but e never initialize it.
For some reasons it seems to work, not sure how or why,
but when glib is uilt with clang, then the problem
surfaces and we get a nice segmentation fault.
Properly initializing it fixes this