### PR TITLE
Bump minimum glib2 dependency.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ plugindir = join_paths(get_option('prefix'),
                        get_option('libdir'),
                        'asb-plugins-' + as_plugin_version)
 
-glib_ver = '>= 2.45.8'
+glib_ver = '>= 2.58.0'
 glib = dependency('glib-2.0', version : glib_ver)
 gmodule = dependency('gmodule-2.0', version : glib_ver)
 if platform_win32


### PR DESCRIPTION
as-app-desktop.c uses g_key_file_load_from_bytes which was added to glib 2.49.3
(see NEWS¹). Additionally as-format.c uses g_canonicalize_filename which
was added in 2.58 (commit²)

Closes #341.

¹ https://gitlab.gnome.org/GNOME/glib/blob/2.49.3/NEWS#L9
² https://gitlab.gnome.org/GNOME/glib/commit/b9b642de06e714584e89aa7b8d878a98599538ed#c0e40c6287fb64a7a3d8c9fa35b5e014025da233_175_175