### PR TITLE
WIP: libasglib: Support all compression formats for AppStream XML repodata

### DIFF
--- a/libappstream-glib/as-format.c
+++ b/libappstream-glib/as-format.c
@@ -155,6 +155,12 @@ as_format_guess_kind (const gchar *filename)
 {
 	if (g_str_has_suffix (filename, ".xml.gz"))
 		return AS_FORMAT_KIND_APPSTREAM;
+	if (g_str_has_suffix (filename, ".xml.bz2"))
+		return AS_FORMAT_KIND_APPSTREAM;
+	if (g_str_has_suffix (filename, ".xml.xz"))
+		return AS_FORMAT_KIND_APPSTREAM;
+	if (g_str_has_suffix (filename, ".xml.zst"))
+		return AS_FORMAT_KIND_APPSTREAM;
 	if (g_str_has_suffix (filename, ".yml"))
 		return AS_FORMAT_KIND_APPSTREAM;
 	if (g_str_has_suffix (filename, ".yml.gz"))

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -1275,6 +1275,24 @@ as_utils_install_filename (AsUtilsLocation location,
 			ret = as_utils_install_icon (location, filename, basename, destdir, error);
 			break;
 		}
+		tmp = g_strstr_len (basename, -1, "-icons.tar.bz2");
+		if (tmp != NULL) {
+			*tmp = '\0';
+			ret = as_utils_install_icon (location, filename, basename, destdir, error);
+			break;
+		}
+		tmp = g_strstr_len (basename, -1, "-icons.tar.xz");
+		if (tmp != NULL) {
+			*tmp = '\0';
+			ret = as_utils_install_icon (location, filename, basename, destdir, error);
+			break;
+		}
+		tmp = g_strstr_len (basename, -1, "-icons.tar.zst");
+		if (tmp != NULL) {
+			*tmp = '\0';
+			ret = as_utils_install_icon (location, filename, basename, destdir, error);
+			break;
+		}
 
 		/* unrecognised */
 		g_set_error_literal (error,


### PR DESCRIPTION
Various Linux distributions are compressing AppStream XML repodata
with compression algorithms other than gzip. libappstream-glib needs
to recognize these so that they can be properly decompressed and used
accordingly.