### PR TITLE
util: Add "validate-version" command

### DIFF
--- a/client/as-util.c
+++ b/client/as-util.c
@@ -2887,6 +2887,108 @@ as_util_validate_strict (AsUtilPrivate *priv, gchar **values, GError **error)
 }
 
 static gboolean
+as_util_version_validate_file (const gchar *filename,
+			       const gchar *version,
+			       AsAppValidateFlags flags,
+			       GError **error)
+{
+	g_autoptr(AsApp) app = NULL;
+	AsRelease *release = NULL;
+	AsFormatKind kind;
+
+	/* is AppStream */
+	g_print ("%s: ", filename);
+
+	kind = as_format_guess_kind (filename);
+
+	if (kind == AS_FORMAT_KIND_APPSTREAM || kind == AS_FORMAT_KIND_DESKTOP) {
+		g_set_error (error,
+			     AS_ERROR,
+			     AS_ERROR_INVALID_ARGUMENTS,
+			     _("Cannot validate version of file format '%s'"),
+			     as_format_kind_to_string (kind));
+		return FALSE;
+	}
+
+	/* load file */
+	app = as_app_new ();
+	if (!as_app_parse_file (app, filename, AS_APP_PARSE_FLAG_NONE, error))
+		return FALSE;
+	release = as_app_get_release (app, version);
+
+	if (release == NULL) {
+		g_print ("%s\n", _("FAILED"));
+		g_set_error_literal (error,
+				     AS_ERROR,
+				     AS_ERROR_INVALID_ARGUMENTS,
+				     _("Version validation failed"));
+		return FALSE;
+	}
+
+	g_print ("%s\n", _("OK"));
+	return TRUE;
+}
+
+static gboolean
+as_util_version_validate_files (gchar **args,
+				AsAppValidateFlags flags,
+				GError **error)
+{
+	guint n_failed = 0;
+	guint n_args;
+	const char *version;
+
+	n_args = g_strv_length (args);
+
+	/* check args */
+	if (n_args < 2) {
+		g_set_error_literal (error,
+				     AS_ERROR,
+				     AS_ERROR_INVALID_ARGUMENTS,
+				     "Not enough arguments, "
+				     "expected example.appdata.xml 0.42.1");
+		return FALSE;
+	}
+
+	version = args[n_args - 1];
+
+	/* check each file */
+	for (guint i = 0; i < n_args - 1; i++) {
+	        g_autoptr(GError) error_local = NULL;
+
+		if (as_util_version_validate_file (args[i], version, flags, &error_local))
+			continue;
+
+		/* anything other than AsProblems bail */
+		n_failed++;
+		if (!g_error_matches (error_local, AS_ERROR,
+				      AS_ERROR_INVALID_ARGUMENTS)) {
+			g_propagate_error (error, error_local);
+			return FALSE;
+		}
+		g_clear_error (&error_local);
+	}
+	if (n_failed > 0) {
+		/* TRANSLATORS: error message */
+		g_set_error_literal (error,
+				     AS_ERROR,
+				     AS_ERROR_INVALID_ARGUMENTS,
+				     _("Version validation of files failed"));
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+as_util_validate_version (AsUtilPrivate *priv, gchar **values, GError **error)
+{
+	AsAppValidateFlags flags = AS_APP_VALIDATE_FLAG_NONE;
+	if (priv->nonet)
+		flags |= AS_APP_VALIDATE_FLAG_NO_NETWORK;
+	return as_util_version_validate_files (values, flags, error);
+}
+
+static gboolean
 as_util_check_root_app_icon (AsApp *app, GError **error)
 {
 	AsIcon *icon_default;
@@ -4478,6 +4580,12 @@ main (int argc, char *argv[])
 		     /* TRANSLATORS: command description */
 		     _("Validate an AppData or AppStream file (strict)"),
 		     as_util_validate_strict);
+	as_util_add (priv->cmd_array,
+		     "validate-version",
+		     NULL,
+		     /* TRANSLATORS: command description */
+		     _("Validate that AppData file includes the specified release"),
+		     as_util_validate_version);
 	as_util_add (priv->cmd_array,
 		     "appdata-to-news",
 		     NULL,


### PR DESCRIPTION
The command validates that an AppData or MetaInfo file includes a release
for the specified version. For forgetful maintainers (hi!), this can be
a useful test during distcheck.