### PR TITLE
Fix crash with invalid children of <ul/>

### DIFF
--- a/libappstream-glib/as-node.c
+++ b/libappstream-glib/as-node.c
@@ -1891,7 +1891,7 @@ as_node_get_localized_unwrap_type_li (const AsNode *node,
 						     AS_NODE_ERROR,
 						     AS_NODE_ERROR_INVALID_MARKUP,
 						     "Tag %s in %s invalid",
-						     data_c->name,
+						     as_tag_data_get_name (data_c),
 						     as_tag_data_get_name (data));
 					return FALSE;
 				}

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2810,6 +2810,7 @@ as_test_node_xml_func (void)
 	AsNode *n2;
 	AsNode *root;
 	GString *xml;
+	GHashTable *hashtable;
 
 	/* invalid XML */
 	root = as_node_from_xml ("<moo>", 0, &error);
@@ -2920,6 +2921,16 @@ as_test_node_xml_func (void)
 	g_assert_cmpstr (xml->str, ==, "<!-- 1st -->\n<!-- 2nd -->\n<foo/>\n");
 	g_string_free (xml, TRUE);
 	as_node_unref (root);
+
+	/* invalid child of ul */
+	root = as_node_from_xml ("<ul><ul></ul></ul>", 0, &error);
+	g_assert_no_error (error);
+	g_assert (root != NULL);
+	hashtable = as_node_get_localized_unwrap (root, &error);
+	g_assert_error (error, AS_NODE_ERROR, AS_NODE_ERROR_INVALID_MARKUP);
+	g_assert_cmpstr (error->message, ==, "Tag ul in ul invalid");
+	g_clear_error (&error);
+	g_assert (hashtable == NULL);
 }
 
 static void


### PR DESCRIPTION
It segfaulted when building the error message as data_c->name was invalid.
data_c was a valid tag, so only the data_c->tag union member was active.
Fix the crash by calling the proper function instead and add a test case.