### PR TITLE
as-content-rating: Add content rating system APIs from gnome-software

### DIFF
--- a/libappstream-glib/as-content-rating.c
+++ b/libappstream-glib/as-content-rating.c
@@ -18,6 +18,8 @@
 
 #include "config.h"
 
+#include <glib/gi18n-lib.h>
+
 #include "as-node-private.h"
 #include "as-content-rating-private.h"
 #include "as-ref-string.h"
@@ -209,6 +211,905 @@ as_content_rating_value_from_string (const gchar *value)
 	return AS_CONTENT_RATING_VALUE_UNKNOWN;
 }
 
+static const gchar *rating_system_names[] = {
+	[AS_CONTENT_RATING_SYSTEM_UNKNOWN] = NULL,
+	[AS_CONTENT_RATING_SYSTEM_INCAA] = "INCAA",
+	[AS_CONTENT_RATING_SYSTEM_ACB] = "ACB",
+	[AS_CONTENT_RATING_SYSTEM_DJCTQ] = "DJCTQ",
+	[AS_CONTENT_RATING_SYSTEM_GSRR] = "GSRR",
+	[AS_CONTENT_RATING_SYSTEM_PEGI] = "PEGI",
+	[AS_CONTENT_RATING_SYSTEM_KAVI] = "KAVI",
+	[AS_CONTENT_RATING_SYSTEM_USK] = "USK",
+	[AS_CONTENT_RATING_SYSTEM_ESRA] = "ESRA",
+	[AS_CONTENT_RATING_SYSTEM_CERO] = "CERO",
+	[AS_CONTENT_RATING_SYSTEM_OFLCNZ] = "OFLCNZ",
+	[AS_CONTENT_RATING_SYSTEM_RUSSIA] = "RUSSIA",
+	[AS_CONTENT_RATING_SYSTEM_MDA] = "MDA",
+	[AS_CONTENT_RATING_SYSTEM_GRAC] = "GRAC",
+	[AS_CONTENT_RATING_SYSTEM_ESRB] = "ESRB",
+	[AS_CONTENT_RATING_SYSTEM_IARC] = "IARC",
+};
+G_STATIC_ASSERT (G_N_ELEMENTS (rating_system_names) == AS_CONTENT_RATING_SYSTEM_LAST);
+
+/**
+ * as_content_rating_system_to_string:
+ * @system: an #AsContentRatingSystem
+ *
+ * Get a human-readable string to identify @system. %NULL will be returned for
+ * %AS_CONTENT_RATING_SYSTEM_UNKNOWN.
+ *
+ * Returns: (nullable): a human-readable string for @system, or %NULL if unknown
+ * Since: 0.7.18
+ */
+const gchar *
+as_content_rating_system_to_string (AsContentRatingSystem system)
+{
+	if ((gint) system < AS_CONTENT_RATING_SYSTEM_UNKNOWN ||
+	    (gint) system >= AS_CONTENT_RATING_SYSTEM_LAST)
+		return NULL;
+
+	return rating_system_names[system];
+}
+
+static char *
+get_esrb_string (const gchar *source, const gchar *translate)
+{
+	if (g_strcmp0 (source, translate) == 0)
+		return g_strdup (source);
+	/* TRANSLATORS: This is the formatting of English and localized name
+	 * of the rating e.g. "Adults Only (solo adultos)" */
+	return g_strdup_printf (_("%s (%s)"), source, translate);
+}
+
+/**
+ * as_content_rating_system_format_age:
+ * @system: an #AsContentRatingSystem
+ * @age: a CSM age to format
+ *
+ * Format @age as a human-readable string in the given rating @system. This is
+ * the way to present system-specific strings in a UI.
+ *
+ * Returns: (transfer full) (nullable): a newly allocated formatted version of
+ *    @age, or %NULL if the given @system has no representation for @age
+ * Since: 0.7.18
+ */
+/* data obtained from https://en.wikipedia.org/wiki/Video_game_rating_system */
+gchar *
+as_content_rating_system_format_age (AsContentRatingSystem system, guint age)
+{
+	if (system == AS_CONTENT_RATING_SYSTEM_INCAA) {
+		if (age >= 18)
+			return g_strdup ("+18");
+		if (age >= 13)
+			return g_strdup ("+13");
+		return g_strdup ("ATP");
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_ACB) {
+		if (age >= 18)
+			return g_strdup ("R18+");
+		if (age >= 15)
+			return g_strdup ("MA15+");
+		return g_strdup ("PG");
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_DJCTQ) {
+		if (age >= 18)
+			return g_strdup ("18");
+		if (age >= 16)
+			return g_strdup ("16");
+		if (age >= 14)
+			return g_strdup ("14");
+		if (age >= 12)
+			return g_strdup ("12");
+		if (age >= 10)
+			return g_strdup ("10");
+		return g_strdup ("L");
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_GSRR) {
+		if (age >= 18)
+			return g_strdup ("限制");
+		if (age >= 15)
+			return g_strdup ("輔15");
+		if (age >= 12)
+			return g_strdup ("輔12");
+		if (age >= 6)
+			return g_strdup ("保護");
+		return g_strdup ("普通");
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_PEGI) {
+		if (age >= 18)
+			return g_strdup ("18");
+		if (age >= 16)
+			return g_strdup ("16");
+		if (age >= 12)
+			return g_strdup ("12");
+		if (age >= 7)
+			return g_strdup ("7");
+		if (age >= 3)
+			return g_strdup ("3");
+		return NULL;
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_KAVI) {
+		if (age >= 18)
+			return g_strdup ("18+");
+		if (age >= 16)
+			return g_strdup ("16+");
+		if (age >= 12)
+			return g_strdup ("12+");
+		if (age >= 7)
+			return g_strdup ("7+");
+		if (age >= 3)
+			return g_strdup ("3+");
+		return NULL;
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_USK) {
+		if (age >= 18)
+			return g_strdup ("18");
+		if (age >= 16)
+			return g_strdup ("16");
+		if (age >= 12)
+			return g_strdup ("12");
+		if (age >= 6)
+			return g_strdup ("6");
+		return g_strdup ("0");
+	}
+	/* Reference: http://www.esra.org.ir/ */
+	if (system == AS_CONTENT_RATING_SYSTEM_ESRA) {
+		if (age >= 18)
+			return g_strdup ("+18");
+		if (age >= 15)
+			return g_strdup ("+15");
+		if (age >= 12)
+			return g_strdup ("+12");
+		if (age >= 7)
+			return g_strdup ("+7");
+		if (age >= 3)
+			return g_strdup ("+3");
+		return NULL;
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_CERO) {
+		if (age >= 18)
+			return g_strdup ("Z");
+		if (age >= 17)
+			return g_strdup ("D");
+		if (age >= 15)
+			return g_strdup ("C");
+		if (age >= 12)
+			return g_strdup ("B");
+		return g_strdup ("A");
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_OFLCNZ) {
+		if (age >= 18)
+			return g_strdup ("R18");
+		if (age >= 16)
+			return g_strdup ("R16");
+		if (age >= 15)
+			return g_strdup ("R15");
+		if (age >= 13)
+			return g_strdup ("R13");
+		return g_strdup ("G");
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_RUSSIA) {
+		if (age >= 18)
+			return g_strdup ("18+");
+		if (age >= 16)
+			return g_strdup ("16+");
+		if (age >= 12)
+			return g_strdup ("12+");
+		if (age >= 6)
+			return g_strdup ("6+");
+		return g_strdup ("0+");
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_MDA) {
+		if (age >= 18)
+			return g_strdup ("M18");
+		if (age >= 16)
+			return g_strdup ("ADV");
+		return get_esrb_string ("General", _("General"));
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_GRAC) {
+		if (age >= 18)
+			return g_strdup ("18");
+		if (age >= 15)
+			return g_strdup ("15");
+		if (age >= 12)
+			return g_strdup ("12");
+		return get_esrb_string ("ALL", _("ALL"));
+	}
+	if (system == AS_CONTENT_RATING_SYSTEM_ESRB) {
+		if (age >= 18)
+			return get_esrb_string ("Adults Only", _("Adults Only"));
+		if (age >= 17)
+			return get_esrb_string ("Mature", _("Mature"));
+		if (age >= 13)
+			return get_esrb_string ("Teen", _("Teen"));
+		if (age >= 10)
+			return get_esrb_string ("Everyone 10+", _("Everyone 10+"));
+		if (age >= 6)
+			return get_esrb_string ("Everyone", _("Everyone"));
+
+		return get_esrb_string ("Early Childhood", _("Early Childhood"));
+	}
+	/* IARC = everything else */
+	if (age >= 18)
+		return g_strdup ("18+");
+	if (age >= 16)
+		return g_strdup ("16+");
+	if (age >= 12)
+		return g_strdup ("12+");
+	if (age >= 7)
+		return g_strdup ("7+");
+	if (age >= 3)
+		return g_strdup ("3+");
+	return NULL;
+}
+
+static const gchar *content_rating_strings[AS_CONTENT_RATING_SYSTEM_LAST][7] = {
+	/* AS_CONTENT_RATING_SYSTEM_UNKNOWN is handled in code */
+	[AS_CONTENT_RATING_SYSTEM_INCAA] = { "ATP", "+13", "+18", NULL },
+	[AS_CONTENT_RATING_SYSTEM_ACB] = { "PG", "MA15+", "R18+", NULL },
+	[AS_CONTENT_RATING_SYSTEM_DJCTQ] = { "L", "10", "12", "14", "16", "18", NULL },
+	[AS_CONTENT_RATING_SYSTEM_GSRR] = { "普通", "保護", "輔12", "輔15", "限制", NULL },
+	[AS_CONTENT_RATING_SYSTEM_PEGI] = { "3", "7", "12", "16", "18", NULL },
+	[AS_CONTENT_RATING_SYSTEM_KAVI] = { "3+", "7+", "12+", "16+", "18+", NULL },
+	[AS_CONTENT_RATING_SYSTEM_USK] = { "0", "6", "12", "16", "18", NULL },
+	[AS_CONTENT_RATING_SYSTEM_ESRA] = { "+3", "+7", "+12", "+15", "+18", NULL },
+	[AS_CONTENT_RATING_SYSTEM_CERO] = { "A", "B", "C", "D", "Z", NULL },
+	[AS_CONTENT_RATING_SYSTEM_OFLCNZ] = { "G", "R13", "R15", "R16", "R18", NULL },
+	[AS_CONTENT_RATING_SYSTEM_RUSSIA] = { "0+", "6+", "12+", "16+", "18+", NULL },
+	[AS_CONTENT_RATING_SYSTEM_MDA] = { "General", "ADV", "M18", NULL },
+	[AS_CONTENT_RATING_SYSTEM_GRAC] = { "ALL", "12", "15", "18", NULL },
+	/* Note: ESRB has locale-specific suffixes, so needs special further
+	 * handling in code. These strings are just the locale-independent parts. */
+	[AS_CONTENT_RATING_SYSTEM_ESRB] = { "Early Childhood", "Everyone", "Everyone 10+", "Teen", "Mature", "Adults Only", NULL },
+	[AS_CONTENT_RATING_SYSTEM_IARC] = { "3+", "7+", "12+", "16+", "18+", NULL },
+};
+
+/**
+ * as_content_rating_system_get_formatted_ages:
+ * @system: an #AsContentRatingSystem
+ *
+ * Get an array of all the possible return values of
+ * as_content_rating_system_format_age() for the given @system. The array is
+ * sorted with youngest CSM age first.
+ *
+ * Returns: (transfer full): %NULL-terminated array of human-readable age strings
+ * Since: 0.7.18
+ */
+gchar **
+as_content_rating_system_get_formatted_ages (AsContentRatingSystem system)
+{
+	g_return_val_if_fail ((int) system < AS_CONTENT_RATING_SYSTEM_LAST, NULL);
+
+	/* IARC is the fallback for everything */
+	if (system == AS_CONTENT_RATING_SYSTEM_UNKNOWN)
+		system = AS_CONTENT_RATING_SYSTEM_IARC;
+
+	/* ESRB is special as it requires localised suffixes */
+	if (system == AS_CONTENT_RATING_SYSTEM_ESRB) {
+		g_auto(GStrv) esrb_ages = g_new0 (gchar *, 7);
+
+		esrb_ages[0] = get_esrb_string (content_rating_strings[system][0], _("Early Childhood"));
+		esrb_ages[1] = get_esrb_string (content_rating_strings[system][1], _("Everyone"));
+		esrb_ages[2] = get_esrb_string (content_rating_strings[system][2], _("Everyone 10+"));
+		esrb_ages[3] = get_esrb_string (content_rating_strings[system][3], _("Teen"));
+		esrb_ages[4] = get_esrb_string (content_rating_strings[system][4], _("Mature"));
+		esrb_ages[5] = get_esrb_string (content_rating_strings[system][5], _("Adults Only"));
+		esrb_ages[6] = NULL;
+
+		return g_steal_pointer (&esrb_ages);
+	}
+
+	return g_strdupv ((gchar **) content_rating_strings[system]);
+}
+
+static guint content_rating_csm_ages[AS_CONTENT_RATING_SYSTEM_LAST][7] = {
+	/* AS_CONTENT_RATING_SYSTEM_UNKNOWN is handled in code */
+	[AS_CONTENT_RATING_SYSTEM_INCAA] = { 0, 13, 18 },
+	[AS_CONTENT_RATING_SYSTEM_ACB] = { 0, 15, 18 },
+	[AS_CONTENT_RATING_SYSTEM_DJCTQ] = { 0, 10, 12, 14, 16, 18 },
+	[AS_CONTENT_RATING_SYSTEM_GSRR] = { 0, 6, 12, 15, 18 },
+	[AS_CONTENT_RATING_SYSTEM_PEGI] = { 3, 7, 12, 16, 18 },
+	[AS_CONTENT_RATING_SYSTEM_KAVI] = { 3, 7, 12, 16, 18 },
+	[AS_CONTENT_RATING_SYSTEM_USK] = { 0, 6, 12, 16, 18 },
+	[AS_CONTENT_RATING_SYSTEM_ESRA] = { 3, 7, 12, 15, 18 },
+	[AS_CONTENT_RATING_SYSTEM_CERO] = { 0, 12, 15, 17, 18 },
+	[AS_CONTENT_RATING_SYSTEM_OFLCNZ] = { 0, 13, 15, 16, 18 },
+	[AS_CONTENT_RATING_SYSTEM_RUSSIA] = { 0, 6, 12, 16, 18 },
+	[AS_CONTENT_RATING_SYSTEM_MDA] = { 0, 16, 18 },
+	[AS_CONTENT_RATING_SYSTEM_GRAC] = { 0, 12, 15, 18 },
+	[AS_CONTENT_RATING_SYSTEM_ESRB] = { 0, 6, 10, 13, 17, 18 },
+	[AS_CONTENT_RATING_SYSTEM_IARC] = { 3, 7, 12, 16, 18 },
+};
+
+/**
+ * as_content_rating_system_get_csm_ages:
+ * @system: an #AsContentRatingSystem
+ * @length_out: (out) (not optional): return location for the length of the
+ *    returned array
+ *
+ * Get the CSM ages corresponding to the entries returned by
+ * as_content_rating_system_get_formatted_ages() for this @system.
+ *
+ * Returns: (transfer container) (array length=length_out): an array of CSM ages
+ * Since: 0.7.18
+ */
+const guint *
+as_content_rating_system_get_csm_ages (AsContentRatingSystem system, gsize *length_out)
+{
+	g_return_val_if_fail ((int) system < AS_CONTENT_RATING_SYSTEM_LAST, NULL);
+	g_return_val_if_fail (length_out != NULL, NULL);
+
+	/* IARC is the fallback for everything */
+	if (system == AS_CONTENT_RATING_SYSTEM_UNKNOWN)
+		system = AS_CONTENT_RATING_SYSTEM_IARC;
+
+	*length_out = g_strv_length ((gchar **) content_rating_strings[system]);
+	return content_rating_csm_ages[system];
+}
+
+/*
+ * parse_locale:
+ * @locale: (transfer full): a locale to parse
+ * @language_out: (out) (optional) (nullable): return location for the parsed
+ *    language, or %NULL to ignore
+ * @territory_out: (out) (optional) (nullable): return location for the parsed
+ *    territory, or %NULL to ignore
+ * @codeset_out: (out) (optional) (nullable): return location for the parsed
+ *    codeset, or %NULL to ignore
+ * @modifier_out: (out) (optional) (nullable): return location for the parsed
+ *    modifier, or %NULL to ignore
+ *
+ * Parse @locale as a locale string of the form
+ * `language[_territory][.codeset][@modifier]` — see `man 3 setlocale` for
+ * details.
+ *
+ * On success, %TRUE will be returned, and the components of the locale will be
+ * returned in the given addresses, with each component not including any
+ * separators. Otherwise, %FALSE will be returned and the components will be set
+ * to %NULL.
+ *
+ * @locale is modified, and any returned non-%NULL pointers will point inside
+ * it.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
+static gboolean
+parse_locale (gchar *locale  /* (transfer full) */,
+	      const gchar **language_out,
+	      const gchar **territory_out,
+	      const gchar **codeset_out,
+	      const gchar **modifier_out)
+{
+	gchar *separator;
+	const gchar *language = NULL, *territory = NULL, *codeset = NULL, *modifier = NULL;
+
+	separator = strrchr (locale, '@');
+	if (separator != NULL) {
+		modifier = separator + 1;
+		*separator = '\0';
+	}
+
+	separator = strrchr (locale, '.');
+	if (separator != NULL) {
+		codeset = separator + 1;
+		*separator = '\0';
+	}
+
+	separator = strrchr (locale, '_');
+	if (separator != NULL) {
+		territory = separator + 1;
+		*separator = '\0';
+	}
+
+	language = locale;
+
+	/* Parse failure? */
+	if (*language == '\0') {
+		language = NULL;
+		territory = NULL;
+		codeset = NULL;
+		modifier = NULL;
+	}
+
+	if (language_out != NULL)
+		*language_out = language;
+	if (territory_out != NULL)
+		*territory_out = territory;
+	if (codeset_out != NULL)
+		*codeset_out = codeset;
+	if (modifier_out != NULL)
+		*modifier_out = modifier;
+
+	return (language != NULL);
+}
+
+/**
+ * as_content_rating_system_from_locale:
+ * @locale: a locale, in the format described in `man 3 setlocale`
+ *
+ * Determine the most appropriate #AsContentRatingSystem for the given @locale.
+ * Content rating systems are selected by territory. If no content rating system
+ * seems suitable, %AS_CONTENT_RATING_SYSTEM_IARC is returned.
+ *
+ * Returns: the most relevant #AsContentRatingSystem
+ * Since: 0.7.18
+ */
+/* data obtained from https://en.wikipedia.org/wiki/Video_game_rating_system */
+AsContentRatingSystem
+as_content_rating_system_from_locale (const gchar *locale)
+{
+	g_autofree gchar *locale_copy = g_strdup (locale);
+	const gchar *territory;
+
+	/* Default to IARC for locales which can’t be parsed. */
+	if (!parse_locale (locale_copy, NULL, &territory, NULL, NULL))
+		return AS_CONTENT_RATING_SYSTEM_IARC;
+
+	/* Argentina */
+	if (g_strcmp0 (territory, "AR") == 0)
+		return AS_CONTENT_RATING_SYSTEM_INCAA;
+
+	/* Australia */
+	if (g_strcmp0 (territory, "AU") == 0)
+		return AS_CONTENT_RATING_SYSTEM_ACB;
+
+	/* Brazil */
+	if (g_strcmp0 (territory, "BR") == 0)
+		return AS_CONTENT_RATING_SYSTEM_DJCTQ;
+
+	/* Taiwan */
+	if (g_strcmp0 (territory, "TW") == 0)
+		return AS_CONTENT_RATING_SYSTEM_GSRR;
+
+	/* Europe (but not Finland or Germany), India, Israel,
+	 * Pakistan, Quebec, South Africa */
+	if ((g_strcmp0 (territory, "GB") == 0) ||
+	    g_strcmp0 (territory, "AL") == 0 ||
+	    g_strcmp0 (territory, "AD") == 0 ||
+	    g_strcmp0 (territory, "AM") == 0 ||
+	    g_strcmp0 (territory, "AT") == 0 ||
+	    g_strcmp0 (territory, "AZ") == 0 ||
+	    g_strcmp0 (territory, "BY") == 0 ||
+	    g_strcmp0 (territory, "BE") == 0 ||
+	    g_strcmp0 (territory, "BA") == 0 ||
+	    g_strcmp0 (territory, "BG") == 0 ||
+	    g_strcmp0 (territory, "HR") == 0 ||
+	    g_strcmp0 (territory, "CY") == 0 ||
+	    g_strcmp0 (territory, "CZ") == 0 ||
+	    g_strcmp0 (territory, "DK") == 0 ||
+	    g_strcmp0 (territory, "EE") == 0 ||
+	    g_strcmp0 (territory, "FR") == 0 ||
+	    g_strcmp0 (territory, "GE") == 0 ||
+	    g_strcmp0 (territory, "GR") == 0 ||
+	    g_strcmp0 (territory, "HU") == 0 ||
+	    g_strcmp0 (territory, "IS") == 0 ||
+	    g_strcmp0 (territory, "IT") == 0 ||
+	    g_strcmp0 (territory, "LZ") == 0 ||
+	    g_strcmp0 (territory, "XK") == 0 ||
+	    g_strcmp0 (territory, "LV") == 0 ||
+	    g_strcmp0 (territory, "FL") == 0 ||
+	    g_strcmp0 (territory, "LU") == 0 ||
+	    g_strcmp0 (territory, "LT") == 0 ||
+	    g_strcmp0 (territory, "MK") == 0 ||
+	    g_strcmp0 (territory, "MT") == 0 ||
+	    g_strcmp0 (territory, "MD") == 0 ||
+	    g_strcmp0 (territory, "MC") == 0 ||
+	    g_strcmp0 (territory, "ME") == 0 ||
+	    g_strcmp0 (territory, "NL") == 0 ||
+	    g_strcmp0 (territory, "NO") == 0 ||
+	    g_strcmp0 (territory, "PL") == 0 ||
+	    g_strcmp0 (territory, "PT") == 0 ||
+	    g_strcmp0 (territory, "RO") == 0 ||
+	    g_strcmp0 (territory, "SM") == 0 ||
+	    g_strcmp0 (territory, "RS") == 0 ||
+	    g_strcmp0 (territory, "SK") == 0 ||
+	    g_strcmp0 (territory, "SI") == 0 ||
+	    g_strcmp0 (territory, "ES") == 0 ||
+	    g_strcmp0 (territory, "SE") == 0 ||
+	    g_strcmp0 (territory, "CH") == 0 ||
+	    g_strcmp0 (territory, "TR") == 0 ||
+	    g_strcmp0 (territory, "UA") == 0 ||
+	    g_strcmp0 (territory, "VA") == 0 ||
+	    g_strcmp0 (territory, "IN") == 0 ||
+	    g_strcmp0 (territory, "IL") == 0 ||
+	    g_strcmp0 (territory, "PK") == 0 ||
+	    g_strcmp0 (territory, "ZA") == 0)
+		return AS_CONTENT_RATING_SYSTEM_PEGI;
+
+	/* Finland */
+	if (g_strcmp0 (territory, "FI") == 0)
+		return AS_CONTENT_RATING_SYSTEM_KAVI;
+
+	/* Germany */
+	if (g_strcmp0 (territory, "DE") == 0)
+		return AS_CONTENT_RATING_SYSTEM_USK;
+
+	/* Iran */
+	if (g_strcmp0 (territory, "IR") == 0)
+		return AS_CONTENT_RATING_SYSTEM_ESRA;
+
+	/* Japan */
+	if (g_strcmp0 (territory, "JP") == 0)
+		return AS_CONTENT_RATING_SYSTEM_CERO;
+
+	/* New Zealand */
+	if (g_strcmp0 (territory, "NZ") == 0)
+		return AS_CONTENT_RATING_SYSTEM_OFLCNZ;
+
+	/* Russia: Content rating law */
+	if (g_strcmp0 (territory, "RU") == 0)
+		return AS_CONTENT_RATING_SYSTEM_RUSSIA;
+
+	/* Singapore */
+	if (g_strcmp0 (territory, "SQ") == 0)
+		return AS_CONTENT_RATING_SYSTEM_MDA;
+
+	/* South Korea */
+	if (g_strcmp0 (territory, "KR") == 0)
+		return AS_CONTENT_RATING_SYSTEM_GRAC;
+
+	/* USA, Canada, Mexico */
+	if ((g_strcmp0 (territory, "US") == 0) ||
+	    g_strcmp0 (territory, "CA") == 0 ||
+	    g_strcmp0 (territory, "MX") == 0)
+		return AS_CONTENT_RATING_SYSTEM_ESRB;
+
+	/* everything else is IARC */
+	return AS_CONTENT_RATING_SYSTEM_IARC;
+}
+
+/* Table of the human-readable descriptions for each #AsContentRatingValue for
+ * each content rating category. @desc_none must be non-%NULL, but the other
+ * values may be %NULL if no description is appropriate. In that case, the next
+ * non-%NULL description for a lower #AsContentRatingValue will be used. */
+static const struct {
+	const gchar *id;  /* (not nullable) */
+	const gchar *desc_none;  /* (not nullable) */
+	const gchar *desc_mild;  /* (nullable) */
+	const gchar *desc_moderate;  /* (nullable) */
+	const gchar *desc_intense;  /* (nullable) */
+} oars_descriptions[] = {
+	{
+		"violence-cartoon",
+		/* TRANSLATORS: content rating description */
+		N_("No cartoon violence"),
+		/* TRANSLATORS: content rating description */
+		N_("Cartoon characters in unsafe situations"),
+		/* TRANSLATORS: content rating description */
+		N_("Cartoon characters in aggressive conflict"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic violence involving cartoon characters"),
+	},
+	{
+		"violence-fantasy",
+		/* TRANSLATORS: content rating description */
+		N_("No fantasy violence"),
+		/* TRANSLATORS: content rating description */
+		N_("Characters in unsafe situations easily distinguishable from reality"),
+		/* TRANSLATORS: content rating description */
+		N_("Characters in aggressive conflict easily distinguishable from reality"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic violence easily distinguishable from reality"),
+	},
+	{
+		"violence-realistic",
+		/* TRANSLATORS: content rating description */
+		N_("No realistic violence"),
+		/* TRANSLATORS: content rating description */
+		N_("Mildly realistic characters in unsafe situations"),
+		/* TRANSLATORS: content rating description */
+		N_("Depictions of realistic characters in aggressive conflict"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic violence involving realistic characters"),
+	},
+	{
+		"violence-bloodshed",
+		/* TRANSLATORS: content rating description */
+		N_("No bloodshed"),
+		/* TRANSLATORS: content rating description */
+		N_("Unrealistic bloodshed"),
+		/* TRANSLATORS: content rating description */
+		N_("Realistic bloodshed"),
+		/* TRANSLATORS: content rating description */
+		N_("Depictions of bloodshed and the mutilation of body parts"),
+	},
+	{
+		"violence-sexual",
+		/* TRANSLATORS: content rating description */
+		N_("No sexual violence"),
+		/* TRANSLATORS: content rating description */
+		N_("Rape or other violent sexual behavior"),
+		NULL,
+		NULL,
+	},
+	{
+		"drugs-alcohol",
+		/* TRANSLATORS: content rating description */
+		N_("No references to alcohol"),
+		/* TRANSLATORS: content rating description */
+		N_("References to alcoholic beverages"),
+		/* TRANSLATORS: content rating description */
+		N_("Use of alcoholic beverages"),
+		NULL,
+	},
+	{
+		"drugs-narcotics",
+		/* TRANSLATORS: content rating description */
+		N_("No references to illicit drugs"),
+		/* TRANSLATORS: content rating description */
+		N_("References to illicit drugs"),
+		/* TRANSLATORS: content rating description */
+		N_("Use of illicit drugs"),
+		NULL,
+	},
+	{
+		"drugs-tobacco",
+		/* TRANSLATORS: content rating description */
+		N_("No references to tobacco products"),
+		/* TRANSLATORS: content rating description */
+		N_("References to tobacco products"),
+		/* TRANSLATORS: content rating description */
+		N_("Use of tobacco products"),
+		NULL,
+	},
+	{
+		"sex-nudity",
+		/* TRANSLATORS: content rating description */
+		N_("No nudity of any sort"),
+		/* TRANSLATORS: content rating description */
+		N_("Brief artistic nudity"),
+		/* TRANSLATORS: content rating description */
+		N_("Prolonged nudity"),
+		NULL,
+	},
+	{
+		"sex-themes",
+		/* TRANSLATORS: content rating description */
+		N_("No references to or depictions of sexual nature"),
+		/* TRANSLATORS: content rating description */
+		N_("Provocative references or depictions"),
+		/* TRANSLATORS: content rating description */
+		N_("Sexual references or depictions"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic sexual behavior"),
+	},
+	{
+		"language-profanity",
+		/* TRANSLATORS: content rating description */
+		N_("No profanity of any kind"),
+		/* TRANSLATORS: content rating description */
+		N_("Mild or infrequent use of profanity"),
+		/* TRANSLATORS: content rating description */
+		N_("Moderate use of profanity"),
+		/* TRANSLATORS: content rating description */
+		N_("Strong or frequent use of profanity"),
+	},
+	{
+		"language-humor",
+		/* TRANSLATORS: content rating description */
+		N_("No inappropriate humor"),
+		/* TRANSLATORS: content rating description */
+		N_("Slapstick humor"),
+		/* TRANSLATORS: content rating description */
+		N_("Vulgar or bathroom humor"),
+		/* TRANSLATORS: content rating description */
+		N_("Mature or sexual humor"),
+	},
+	{
+		"language-discrimination",
+		/* TRANSLATORS: content rating description */
+		N_("No discriminatory language of any kind"),
+		/* TRANSLATORS: content rating description */
+		N_("Negativity towards a specific group of people"),
+		/* TRANSLATORS: content rating description */
+		N_("Discrimination designed to cause emotional harm"),
+		/* TRANSLATORS: content rating description */
+		N_("Explicit discrimination based on gender, sexuality, race or religion"),
+	},
+	{
+		"money-advertising",
+		/* TRANSLATORS: content rating description */
+		N_("No advertising of any kind"),
+		/* TRANSLATORS: content rating description */
+		N_("Product placement"),
+		/* TRANSLATORS: content rating description */
+		N_("Explicit references to specific brands or trademarked products"),
+		/* TRANSLATORS: content rating description */
+		N_("Users are encouraged to purchase specific real-world items"),
+	},
+	{
+		"money-gambling",
+		/* TRANSLATORS: content rating description */
+		N_("No gambling of any kind"),
+		/* TRANSLATORS: content rating description */
+		N_("Gambling on random events using tokens or credits"),
+		/* TRANSLATORS: content rating description */
+		N_("Gambling using “play” money"),
+		/* TRANSLATORS: content rating description */
+		N_("Gambling using real money"),
+	},
+	{
+		"money-purchasing",
+		/* TRANSLATORS: content rating description */
+		N_("No ability to spend money"),
+		/* TRANSLATORS: content rating description */
+		N_("Users are encouraged to donate real money"),
+		NULL,
+		/* TRANSLATORS: content rating description */
+		N_("Ability to spend real money in-app"),
+	},
+	{
+		"social-chat",
+		/* TRANSLATORS: content rating description */
+		N_("No way to chat with other users"),
+		/* TRANSLATORS: content rating description */
+		N_("User-to-user interactions without chat functionality"),
+		/* TRANSLATORS: content rating description */
+		N_("Moderated chat functionality between users"),
+		/* TRANSLATORS: content rating description */
+		N_("Uncontrolled chat functionality between users"),
+	},
+	{
+		"social-audio",
+		/* TRANSLATORS: content rating description */
+		N_("No way to talk with other users"),
+		/* TRANSLATORS: content rating description */
+		N_("Uncontrolled audio or video chat functionality between users"),
+		NULL,
+		NULL,
+	},
+	{
+		"social-contacts",
+		/* TRANSLATORS: content rating description */
+		N_("No sharing of social network usernames or email addresses"),
+		/* TRANSLATORS: content rating description */
+		N_("Sharing social network usernames or email addresses"),
+		NULL,
+		NULL,
+	},
+	{
+		"social-info",
+		/* TRANSLATORS: content rating description */
+		N_("No sharing of user information with third parties"),
+		/* TRANSLATORS: content rating description */
+		N_("Checking for the latest application version"),
+		/* TRANSLATORS: content rating description */
+		N_("Sharing diagnostic data that does not let others identify the user"),
+		/* TRANSLATORS: content rating description */
+		N_("Sharing information that lets others identify the user"),
+	},
+	{
+		"social-location",
+		/* TRANSLATORS: content rating description */
+		N_("No sharing of physical location with other users"),
+		/* TRANSLATORS: content rating description */
+		N_("Sharing physical location with other users"),
+		NULL,
+		NULL,
+	},
+
+	/* v1.1 */
+	{
+		"sex-homosexuality",
+		/* TRANSLATORS: content rating description */
+		N_("No references to homosexuality"),
+		/* TRANSLATORS: content rating description */
+		N_("Indirect references to homosexuality"),
+		/* TRANSLATORS: content rating description */
+		N_("Kissing between people of the same gender"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic sexual behavior between people of the same gender"),
+	},
+	{
+		"sex-prostitution",
+		/* TRANSLATORS: content rating description */
+		N_("No references to prostitution"),
+		/* TRANSLATORS: content rating description */
+		N_("Indirect references to prostitution"),
+		/* TRANSLATORS: content rating description */
+		N_("Direct references to prostitution"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic depictions of the act of prostitution"),
+	},
+	{
+		"sex-adultery",
+		/* TRANSLATORS: content rating description */
+		N_("No references to adultery"),
+		/* TRANSLATORS: content rating description */
+		N_("Indirect references to adultery"),
+		/* TRANSLATORS: content rating description */
+		N_("Direct references to adultery"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic depictions of the act of adultery"),
+	},
+	{
+		"sex-appearance",
+		/* TRANSLATORS: content rating description */
+		N_("No sexualized characters"),
+		NULL,
+		/* TRANSLATORS: content rating description */
+		N_("Scantily clad human characters"),
+		/* TRANSLATORS: content rating description */
+		N_("Overtly sexualized human characters"),
+	},
+	{
+		"violence-worship",
+		/* TRANSLATORS: content rating description */
+		N_("No references to desecration"),
+		/* TRANSLATORS: content rating description */
+		N_("Depictions of or references to historical desecration"),
+		/* TRANSLATORS: content rating description */
+		N_("Depictions of modern-day human desecration"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic depictions of modern-day desecration"),
+	},
+	{
+		"violence-desecration",
+		/* TRANSLATORS: content rating description */
+		N_("No visible dead human remains"),
+		/* TRANSLATORS: content rating description */
+		N_("Visible dead human remains"),
+		/* TRANSLATORS: content rating description */
+		N_("Dead human remains that are exposed to the elements"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic depictions of desecration of human bodies"),
+	},
+	{
+		"violence-slavery",
+		/* TRANSLATORS: content rating description */
+		N_("No references to slavery"),
+		/* TRANSLATORS: content rating description */
+		N_("Depictions of or references to historical slavery"),
+		/* TRANSLATORS: content rating description */
+		N_("Depictions of modern-day slavery"),
+		/* TRANSLATORS: content rating description */
+		N_("Graphic depictions of modern-day slavery"),
+	},
+};
+
+/**
+ * as_content_rating_attribute_get_description:
+ * @id: the subsection ID e.g. `violence-cartoon`
+ * @value: the #AsContentRatingValue, e.g. %AS_CONTENT_RATING_VALUE_INTENSE
+ *
+ * Get a human-readable description of what content would be expected to
+ * require the content rating attribute given by @id and @value.
+ *
+ * Returns: a human-readable description of @id and @value
+ * Since: 0.7.18
+ */
+const gchar *
+as_content_rating_attribute_get_description (const gchar *id, AsContentRatingValue value)
+{
+	gsize i;
+
+	if ((gint) value < AS_CONTENT_RATING_VALUE_NONE ||
+	    (gint) value > AS_CONTENT_RATING_VALUE_INTENSE)
+		return NULL;
+
+	for (i = 0; i < G_N_ELEMENTS (oars_descriptions); i++) {
+		if (!g_str_equal (oars_descriptions[i].id, id))
+			continue;
+
+		/* Return the most-intense non-NULL string. */
+		if (oars_descriptions[i].desc_intense != NULL && value >= AS_CONTENT_RATING_VALUE_INTENSE)
+			return _(oars_descriptions[i].desc_intense);
+		if (oars_descriptions[i].desc_moderate != NULL && value >= AS_CONTENT_RATING_VALUE_MODERATE)
+			return _(oars_descriptions[i].desc_moderate);
+		if (oars_descriptions[i].desc_mild != NULL && value >= AS_CONTENT_RATING_VALUE_MILD)
+			return _(oars_descriptions[i].desc_mild);
+		if (oars_descriptions[i].desc_none != NULL && value >= AS_CONTENT_RATING_VALUE_NONE)
+			return _(oars_descriptions[i].desc_none);
+		g_assert_not_reached ();
+	}
+
+	/* This means the requested @id is missing from @oars_descriptions, so
+	 * presumably the OARS spec has been updated but appstream-glib hasn’t. */
+	g_warn_if_reached ();
+
+	return NULL;
+}
+
 /* The struct definition below assumes we don’t grow more
  * #AsContentRating values. */
 G_STATIC_ASSERT (AS_CONTENT_RATING_VALUE_LAST == AS_CONTENT_RATING_VALUE_INTENSE + 1);
@@ -306,6 +1207,48 @@ as_content_rating_attribute_to_csm_age (const gchar *id, AsContentRatingValue va
 
 	/* @id not found. */
 	return 0;
+}
+
+/**
+ * as_content_rating_attribute_from_csm_age:
+ * @id: the subsection ID e.g. `violence-cartoon`
+ * @age: the CSM age
+ *
+ * Gets the highest #AsContentRatingValue which is allowed to be seen by the
+ * given Common Sense Media @age for the given subsection @id.
+ *
+ * For example, if the CSM age mappings for `violence-bloodshed` are:
+ *  * age ≥ 0 for %AS_CONTENT_RATING_VALUE_NONE
+ *  * age ≥ 9 for %AS_CONTENT_RATING_VALUE_MILD
+ *  * age ≥ 11 for %AS_CONTENT_RATING_VALUE_MODERATE
+ *  * age ≥ 18 for %AS_CONTENT_RATING_VALUE_INTENSE
+ * then calling this function with `violence-bloodshed` and @age set to 17 would
+ * return %AS_CONTENT_RATING_VALUE_MODERATE. Calling it with age 18 would
+ * return %AS_CONTENT_RATING_VALUE_INTENSE.
+ *
+ * Returns: the #AsContentRatingValue, or %AS_CONTENT_RATING_VALUE_UNKNOWN if
+ *    unknown
+ * Since: 0.7.18
+ */
+AsContentRatingValue
+as_content_rating_attribute_from_csm_age (const gchar *id, guint age)
+{
+	for (gsize i = 0; G_N_ELEMENTS (oars_to_csm_mappings); i++) {
+		if (g_strcmp0 (id, oars_to_csm_mappings[i].id) == 0) {
+			if (age >= oars_to_csm_mappings[i].csm_age_intense)
+				return AS_CONTENT_RATING_VALUE_INTENSE;
+			else if (age >= oars_to_csm_mappings[i].csm_age_moderate)
+				return AS_CONTENT_RATING_VALUE_MODERATE;
+			else if (age >= oars_to_csm_mappings[i].csm_age_mild)
+				return AS_CONTENT_RATING_VALUE_MILD;
+			else if (age >= oars_to_csm_mappings[i].csm_age_none)
+				return AS_CONTENT_RATING_VALUE_NONE;
+			else
+				return AS_CONTENT_RATING_VALUE_UNKNOWN;
+		}
+	}
+
+	return AS_CONTENT_RATING_VALUE_UNKNOWN;
 }
 
 /**

--- a/libappstream-glib/as-content-rating.h
+++ b/libappstream-glib/as-content-rating.h
@@ -52,11 +52,65 @@ typedef enum {
 	AS_CONTENT_RATING_VALUE_LAST
 } AsContentRatingValue;
 
+/**
+ * AsContentRatingSystem:
+ * @AS_CONTENT_RATING_SYSTEM_UNKNOWN: Unknown ratings system
+ * @AS_CONTENT_RATING_SYSTEM_INCAA: INCAA
+ * @AS_CONTENT_RATING_SYSTEM_ACB: ACB
+ * @AS_CONTENT_RATING_SYSTEM_DJCTQ: DJCTQ
+ * @AS_CONTENT_RATING_SYSTEM_GSRR: GSRR
+ * @AS_CONTENT_RATING_SYSTEM_PEGI: PEGI
+ * @AS_CONTENT_RATING_SYSTEM_KAVI: KAVI
+ * @AS_CONTENT_RATING_SYSTEM_USK: USK
+ * @AS_CONTENT_RATING_SYSTEM_ESRA: ESRA
+ * @AS_CONTENT_RATING_SYSTEM_CERO: CERO
+ * @AS_CONTENT_RATING_SYSTEM_OFLCNZ: OFLCNZ
+ * @AS_CONTENT_RATING_SYSTEM_RUSSIA: Russia
+ * @AS_CONTENT_RATING_SYSTEM_MDA: MDA
+ * @AS_CONTENT_RATING_SYSTEM_GRAC: GRAC
+ * @AS_CONTENT_RATING_SYSTEM_ESRB: ESRB
+ * @AS_CONTENT_RATING_SYSTEM_IARC: IARC
+ *
+ * A content rating system for a particular territory.
+ *
+ * Since: 0.7.18
+ */
+typedef enum {
+	AS_CONTENT_RATING_SYSTEM_UNKNOWN,
+	AS_CONTENT_RATING_SYSTEM_INCAA,
+	AS_CONTENT_RATING_SYSTEM_ACB,
+	AS_CONTENT_RATING_SYSTEM_DJCTQ,
+	AS_CONTENT_RATING_SYSTEM_GSRR,
+	AS_CONTENT_RATING_SYSTEM_PEGI,
+	AS_CONTENT_RATING_SYSTEM_KAVI,
+	AS_CONTENT_RATING_SYSTEM_USK,
+	AS_CONTENT_RATING_SYSTEM_ESRA,
+	AS_CONTENT_RATING_SYSTEM_CERO,
+	AS_CONTENT_RATING_SYSTEM_OFLCNZ,
+	AS_CONTENT_RATING_SYSTEM_RUSSIA,
+	AS_CONTENT_RATING_SYSTEM_MDA,
+	AS_CONTENT_RATING_SYSTEM_GRAC,
+	AS_CONTENT_RATING_SYSTEM_ESRB,
+	AS_CONTENT_RATING_SYSTEM_IARC,
+	/*< private >*/
+	AS_CONTENT_RATING_SYSTEM_LAST
+} AsContentRatingSystem;
+
 AsContentRating	*as_content_rating_new		(void);
 
 /* helpers */
 const gchar	*as_content_rating_value_to_string	(AsContentRatingValue	 value);
 AsContentRatingValue	 as_content_rating_value_from_string	(const gchar	*value);
+
+const gchar	*as_content_rating_system_to_string	(AsContentRatingSystem	 system);
+gchar		*as_content_rating_system_format_age	(AsContentRatingSystem	 system,
+							 guint			 age);
+
+AsContentRatingSystem	 as_content_rating_system_from_locale	(const gchar	*locale);
+
+gchar		**as_content_rating_system_get_formatted_ages	(AsContentRatingSystem	 system);
+const guint	 *as_content_rating_system_get_csm_ages		(AsContentRatingSystem	 system,
+								 gsize			*length_out);
 
 /* getters */
 const gchar	*as_content_rating_get_kind	(AsContentRating	*content_rating);
@@ -71,6 +125,10 @@ const gchar	**as_content_rating_get_rating_ids (AsContentRating	*content_rating)
 
 guint		as_content_rating_attribute_to_csm_age (const gchar		*id,
 							AsContentRatingValue 	 value);
+AsContentRatingValue	as_content_rating_attribute_from_csm_age	(const gchar	*id,
+									 guint		 age);
+const gchar	*as_content_rating_attribute_get_description (const gchar	*id,
+							      AsContentRatingValue	value);
 const gchar	**as_content_rating_get_all_rating_ids (void);
 
 /* setters */

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -1884,6 +1884,57 @@ as_test_content_rating_mappings (void)
 	g_assert_cmpuint (as_content_rating_attribute_to_csm_age ("not-valid-id", AS_CONTENT_RATING_VALUE_INTENSE), ==, 0);
 }
 
+/* Test that gs_utils_content_rating_system_from_locale() returns the correct
+ * rating system for various standard locales and various forms of locale name.
+ * See `locale -a` for the list of all available locales which some of these
+ * test vectors were derived from. */
+static void
+as_test_content_rating_from_locale (void)
+{
+	const struct {
+		const gchar *locale;
+		AsContentRatingSystem expected_system;
+	} vectors[] = {
+		/* Simple tests to get coverage of each rating system: */
+		{ "es_AR", AS_CONTENT_RATING_SYSTEM_INCAA },
+		{ "en_AU", AS_CONTENT_RATING_SYSTEM_ACB },
+		{ "pt_BR", AS_CONTENT_RATING_SYSTEM_DJCTQ },
+		{ "zh_TW", AS_CONTENT_RATING_SYSTEM_GSRR },
+		{ "en_GB", AS_CONTENT_RATING_SYSTEM_PEGI },
+		{ "hy_AM", AS_CONTENT_RATING_SYSTEM_PEGI },
+		{ "bg_BG", AS_CONTENT_RATING_SYSTEM_PEGI },
+		{ "fi_FI", AS_CONTENT_RATING_SYSTEM_KAVI },
+		{ "de_DE", AS_CONTENT_RATING_SYSTEM_USK },
+		{ "az_IR", AS_CONTENT_RATING_SYSTEM_ESRA },
+		{ "jp_JP", AS_CONTENT_RATING_SYSTEM_CERO },
+		{ "en_NZ", AS_CONTENT_RATING_SYSTEM_OFLCNZ },
+		{ "ru_RU", AS_CONTENT_RATING_SYSTEM_RUSSIA },
+		{ "en_SQ", AS_CONTENT_RATING_SYSTEM_MDA },
+		{ "ko_KR", AS_CONTENT_RATING_SYSTEM_GRAC },
+		{ "en_US", AS_CONTENT_RATING_SYSTEM_ESRB },
+		{ "en_US", AS_CONTENT_RATING_SYSTEM_ESRB },
+		{ "en_CA", AS_CONTENT_RATING_SYSTEM_ESRB },
+		{ "es_MX", AS_CONTENT_RATING_SYSTEM_ESRB },
+		/* Fallback (arbitrarily chosen Venezuela since it seems to use IARC): */
+		{ "es_VE", AS_CONTENT_RATING_SYSTEM_IARC },
+		/* Locale with a codeset: */
+		{ "nl_NL.iso88591", AS_CONTENT_RATING_SYSTEM_PEGI },
+		/* Locale with a codeset and modifier: */
+		{ "nl_NL.iso885915@euro", AS_CONTENT_RATING_SYSTEM_PEGI },
+		/* Locale with a less esoteric codeset: */
+		{ "en_GB.UTF-8", AS_CONTENT_RATING_SYSTEM_PEGI },
+		/* Locale with a modifier but no codeset: */
+		{ "fi_FI@euro", AS_CONTENT_RATING_SYSTEM_KAVI },
+		/* Invalid locale: */
+		{ "_invalid", AS_CONTENT_RATING_SYSTEM_IARC },
+	};
+
+	for (gsize i = 0; i < G_N_ELEMENTS (vectors); i++) {
+		g_test_message ("Test %" G_GSIZE_FORMAT ": %s", i, vectors[i].locale);
+		g_assert_cmpint (as_content_rating_system_from_locale (vectors[i].locale), ==, vectors[i].expected_system);
+	}
+}
+
 static void
 as_test_app_func (void)
 {
@@ -5717,6 +5768,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/AppStream/content_rating", as_test_content_rating_func);
 	g_test_add_func ("/AppStream/content_rating/empty", as_test_content_rating_empty);
 	g_test_add_func ("/AppStream/content_rating/mappings", as_test_content_rating_mappings);
+	g_test_add_func ("/AppStream/content_rating/from-locale", as_test_content_rating_from_locale);
 	g_test_add_func ("/AppStream/release", as_test_release_func);
 	g_test_add_func ("/AppStream/release{date}", as_test_release_date_func);
 	g_test_add_func ("/AppStream/release{appdata}", as_test_release_appdata_func);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,4 @@
 client/as-builder.c
 client/as-compose.c
 client/as-util.c
+libappstream-glib/as-content-rating.c

--- a/po/ca.po
+++ b/po/ca.po
@@ -12,10 +12,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-10-24 09:29+0000\n"
 "Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
-"Language-Team: Catalan (http://www.transifex.com/freedesktop/appstream-glib/language/ca/)\n"
+"Language-Team: Catalan (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/ca/)\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,399 +25,526 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Mostra la informació extra de depuració"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Afegeix un id. de memòria cau a cadascun dels components"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Inclou els resultats fallits a la sortida"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Afegeix les icones HiDPI als arxius tar"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Afegeix un id. de memòria cau a cadascun dels components"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Afegeix un idioma a un fitxer d'origen"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Afegeix un proporciona a un fitxer d'origen"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Afegeix les icones codificades al XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Afegit"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Àlies a %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitat d'AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Cancel·lat"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Comprova les dades de les aplicacions instal·lades"
-
-msgid "Command not found, valid commands are:"
-msgstr "No s'ha trobat l'ordre, les ordres vàlides són:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Compara el contingut de dos fitxers AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Compara els números de les versions"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "La conversió de %s a %s no està implementada"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Converteix un fitxer AppData al format NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Converteix un fitxer NEWS al format AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Converteix les metadades AppStream d'una versió a una altra"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Crea un document CSV de l'estat"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Crea una pàgina HTML amb la taula"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Crea una pàgina HTML de l'estat"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Mostra els marcadors de cerca de l'aplicació"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "No comprimeix les icones en un arxiu tar"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "No utilitzis l'accés a la xarxa"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Fet!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Bolca les aplicacions a les metadades AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Estableix el directori d'enregistrament"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Habilita el perfilament"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Estableix el directori dels paquets"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "S'ha produït un error en crear el directori de sortida"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Estableix el directori temporal"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "S'ha produït un error en carregar el fitxer AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Estableix el directori de la sortida"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "S'ha produït un error en carregar el fitxer d'escriptori"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Estableix el directori de les icones"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "S'ha produït un error en analitzar sintàcticament kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Estableix el directori de la memòria cau"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "S'ha produït un error en analitzar sintàcticament provides"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Estableix la base dels noms per als fitxers de sortida"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "S'ha produït un error en analitzar sintàcticament les transaccions"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Estableix el nom d'origen"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "S'ha produït un error en desar el fitxer d'AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Estableix el nombre de fils d'execució"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Exporta l'acord al text"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Estableix la mida màxima de la icona en píxels"
 
-#. list failures
-msgid "FAILED"
-msgstr "FALLIT"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Estableix la ubicació de les metadades antigues"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "No facis cas de certs tipus de vetos"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "No s'ha pogut afegir el paquet"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "No s'han pogut generar les metadades"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "No s'han pogut obrir els paquets"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "No s'han pogut analitzar els arguments"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "No s'ha pogut preparar el constructor"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "No s'han pogut obrir els paquets"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "S'estan escanejant els paquets..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "No s'ha pogut afegir el paquet"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "S'han analitzat %u/%u fitxers..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "No s'han pogut generar les metadades"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Fet!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "S'està desant la icona"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Estableix el prefix"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "S'està processant l'aplicació"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "S'ha produït un error en carregar el fitxer AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "S'ha produït un error en analitzar sintàcticament les transaccions"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "S'ha produït un error en analitzar sintàcticament kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "S'ha produït un error en analitzar sintàcticament provides"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "nom de fitxer d'escriptori no vàlid"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "S'ha produït un error en carregar el fitxer d'escriptori"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "S'ha produït un error en crear el directori de sortida"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "S'està desant l'AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "S'ha produït un error en desar el fitxer d'AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Àlies a %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "No s'ha trobat l'ordre, les ordres vàlides són:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr ""
+"Si us plau, reviseu el fitxer i corregiu qualsevol dels elements «FIXME»"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Versió antiga de l'API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nova versió de l'API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "No hi ha prou arguments, s'esperaven els fitxers antic.xml nou.xml"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "La conversió de %s a %s no està implementada"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "No hi ha prou arguments, s'esperava el fitxer.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "No es pot actualitzar el format de fitxer «%s»"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Format no reconegut"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Genera un GUID a partir d'una cadena de text"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "No facis cas de certs tipus de vetos"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importa un fitxer al llenguatge de marques d'AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Inclou els resultats fallits a la sortida"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorpora dades extres des d'un fitxer extern"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Instal·la les metadades AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Instal·la les metadades AppStream amb un origen nou"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "nom de fitxer d'escriptori no vàlid"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Llista les aplicacions que no compten amb el suport dels paquets"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Combina diversos fitxers a un fitxer AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Crea una rèplica de les captures de pantalla de la línia de treball principal"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modifica un fitxer AppStream"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nova versió de l'API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "No s'han trobat aplicacions d'escriptori"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "No hi ha prou arguments, s'esperava el fitxer.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "No hi ha prou arguments, s'esperaven els fitxers antic.xml nou.xml"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "CORRECTE"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Versió antiga de l'API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FALLIT"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Ha fallat la validació"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Ha fallat la validació dels fitxers"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "S'han analitzat %u/%u fitxers..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Si us plau, reviseu el fitxer i corregiu qualsevol dels elements «FIXME»"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Ha fallat la validació"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "S'està processant l'aplicació"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Ha fallat la validació dels fitxers"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Suprimit"
 
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Afegit"
+
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Cancel·lat"
+
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "No utilitzis l'accés a la xarxa"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4432
+msgid "Show version"
+msgstr "Mostra la versió"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Habilita el perfilament"
+
 #. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Substitueix les captures de pantalles en un fitxer d'origen"
-
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "S'està desant l'AppStream"
-
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "S'està desant la icona"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "S'estan escanejant els paquets..."
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Converteix les metadades AppStream d'una versió a una altra"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4473
+msgid "Upgrade AppData metadata to the latest version"
+msgstr ""
+"Actualitza a nivell de llançament les metadades AppData a l'última versió"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Bolca les aplicacions a les metadades AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
 msgid "Search for AppStream applications"
 msgstr "Cerca aplicacions AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Cerca aplicacions AppStream pel nom del paquet"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Mostra totes les aplicacions AppStream instal·lades"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
 msgid "Search for AppStream applications by category name"
 msgstr "Cerca aplicacions AppStream pel nom de la categoria"
 
 #. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Cerca aplicacions AppStream pel nom del paquet"
-
-#. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Estableix la base dels noms per als fitxers de sortida"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Estableix el directori de la memòria cau"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Estableix el directori de les icones"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Estableix el directori d'enregistrament"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Estableix la mida màxima de la icona en píxels"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Estableix el nombre de fils d'execució"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Estableix la ubicació de les metadades antigues"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Estableix el nom d'origen"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Estableix el directori de la sortida"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Estableix el directori dels paquets"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Estableix el prefix"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Estableix el directori temporal"
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Mostra els marcadors de cerca de l'aplicació"
 
 #. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Mostra totes les aplicacions AppStream instal·lades"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Mostra la informació extra de depuració"
-
-#. TRANSLATORS: command line option
-msgid "Show version"
-msgstr "Mostra la versió"
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Instal·la les metadades AppStream"
 
 #. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Descompon un fitxer AppStream als fitxers AppData i Metainfo"
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Instal·la les metadades AppStream amb un origen nou"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Prova una expressió regular"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4533
 msgid "Uninstalls AppStream metadata"
 msgstr "Desinstal·la les metadades AppStream"
 
 #. TRANSLATORS: command description
-msgid "Upgrade AppData metadata to the latest version"
-msgstr "Actualitza a nivell de llançament les metadades AppData a l'última versió"
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Crea una pàgina HTML de l'estat"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Crea un document CSV de l'estat"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Crea una pàgina HTML amb la taula"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Llista les aplicacions que no compten amb el suport dels paquets"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Valida un fitxer AppData o AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Valida un fitxer AppData o AppStream (relaxat)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Exporta l'acord al text"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Valida un fitxer AppData o AppStream (estricte)"
 
-msgid "Validation failed"
-msgstr "Ha fallat la validació"
-
-msgid "Validation of files failed"
-msgstr "Ha fallat la validació dels fitxers"
-
-msgid "Version:"
-msgstr "Versió:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Valida un fitxer AppData o AppStream (relaxat)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Converteix un fitxer AppData al format NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Converteix un fitxer NEWS al format AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Comprova les dades de les aplicacions instal·lades"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "comprova una aplicació instal·lada"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Substitueix les captures de pantalles en un fitxer d'origen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Afegeix un proporciona a un fitxer d'origen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Afegeix un idioma a un fitxer d'origen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr ""
+"Crea una rèplica de les captures de pantalla de la línia de treball principal"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Incorpora dades extres des d'un fitxer extern"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Compara el contingut de dos fitxers AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Genera un GUID a partir d'una cadena de text"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modifica un fitxer AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Descompon un fitxer AppStream als fitxers AppData i Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Combina diversos fitxers a un fitxer AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importa un fitxer al llenguatge de marques d'AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Observa les ubicacions AppStream per si hi ha canvis"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "comprova una aplicació instal·lada"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Compara els números de les versions"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Prova una expressió regular"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitat d'AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Versió:"

--- a/po/ca.po
+++ b/po/ca.po
@@ -548,3 +548,548 @@ msgstr "Utilitat d'AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versió:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "General"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "Tots"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Només adults"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Madur"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Adolescents"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Majors de 10 anys"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Tothom"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Infantesa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Sense violència en personatges animats"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personatges animats en situacions insegures"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personatges animats en conflictes agressius"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Violència gràfica amb personatges animats"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Sense violència fantàstica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Personatges en situacions insegures fàcilment distingibles de la realitat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Personatges en conflictes agressius fàcilment distingibles de la realitat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Violència gràfica fàcilment distingible de la realitat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Sense violència realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personatges mig reals en situacions insegures"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Representacions de personatges realistes en conflictes agressius"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Violència gràfica amb personatges realistes"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Sense matances"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Matances no realistes"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Matances realistes"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Representacions de matances i mutilacions de parts del cos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Sense violència sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Violació o altres comportaments sexuals violents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Sense referències a l'alcohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referències a begudes alcohòliques"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Ús de begudes alcohòliques"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Sense referències a drogues il·legals"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referències a drogues il·legals"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Ús de drogues il·legals"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Sense referències als productes del tàbac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referències als productes del tàbac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Ús de productes del tàbac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Sense nuesa de cap tipus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Nuesa artística breu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Nuesa prolongada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Sense referències o representacions sexuals"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Referències o representacions provocatives"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Referències o representacions sexuals"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Comportament sexual gràfic"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Sense blasfèmia de cap tipus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Ús lleu o poc freqüent de la blasfèmia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Ús moderat de la blasfèmia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Ús extensiu o freqüent de la blasfèmia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Sense humor inapropiat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Humor vulgar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Humor groller"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humor adult o sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Sense llenguatge discriminatori de cap tipus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatiu respecte a un grup específic de gent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminació pensada per causar dany emocional"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Discriminació explicita basada en gènere, sexualitat, raça o religió"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Sense publicitat de cap tipus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "﻿Emplaçament de producte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Referències explícites a marques específiques o productes de marques "
+"registrades"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "S'anima als usuaris a comprar coses específiques del món real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Sense apostes de cap tipus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Apostes en esdeveniments aleatoris utilitzant testimonis o crèdits"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Apostes usant moneda virtual al joc"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Apostes usant diners reals"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Sense possibilitat de gastar diners"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "S'anima als usuaris a comprar coses específiques del món real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Possibilitat de gastar diners de veritat al joc"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Sense possibilitat de fer xat amb els altres usuaris"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interaccions usuari a usuari sense funcionalitat xat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Funcionalitat de xat no supervisada entre usuaris"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Funcionalitat de xat no supervisada entre usuaris"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Sense possibilitat de parlar amb els altres usuaris"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Funcionalitat de xat d'àudio o vídeo no supervisada entre usuaris"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Sense compartició en les xarxes socials de noms d'usuari ni adreces de "
+"correu electrònic"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Compartició en les xarxes socials de noms d'usuari o adreces de correu "
+"electrònic"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "No es comparteix informació de l'usuari amb terceres parts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Comprova si hi ha una versió més nova de l'aplicació"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"La compartició de dades de diagnòstic no permet a altres identificar l'usuari"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"La compartició de dades de diagnòstic permet a altres identificar l'usuari"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "No es comparteix la ubicació física amb altres usuaris"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Es comparteix la ubicació física amb altres usuaris"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Sense referències a homosexualitat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Referències indirectes a l'homosexualitat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Petons entre persones del mateix sexe"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Comportament sexual gràfic entre gent del mateix sexe"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Sense referències a la prostitució"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Referències indirectes a la prostitució"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Referències directes a la prostitució"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Representacions gràfiques de l'acte de prostitució"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Sense referències a l'adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Referències indirectes a l'adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Referències directes a l'adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Representacions gràfiques de l'acte d'adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Sense personatges sexualitzats"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Personatges humans lleugers de roba"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Personatges humans obertament sexualitzats"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Sense referències a la profanació"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Representacions o referències històriques de profanació"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Representacions d'avui en dia de profanació"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Representacions gràfiques d'avui en dia de profanació"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Sense restes mortals humanes visibles"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Restes mortals humanes visibles"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Restes mortals humanes són exposades als elements"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Representacions gràfiques de profanació de cossos humans"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Sense referències a l'esclavitud"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Representacions o referències històriques d'esclavitud"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Representacions de l'esclavitud avui en dia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Representacions gràfiques de l'esclavitud avui en dia"

--- a/po/cs.po
+++ b/po/cs.po
@@ -548,3 +548,541 @@ msgstr "Pomůcka pro AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Verze:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Obecné"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "VŠECHNY"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "pouze dospělé"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "plnoleté"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "mládež"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "všechny 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "všechny"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "malé děti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Žádné kreslené násilí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Kreslené postavy v nebezpečných situacích"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Kreslené postavy v agresivních střetech"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Grafické vyobrazení násilí páchaného na kreslených postavách"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Žádné fantazie o násilí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Osoby v nebezpečných situacích snadno odlišitelných od skutečnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Osoby v agresivních střetech snadno odlišitelných od skutečnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Grafické násilí snadno odlišitelné od reality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Žádné realistické násilí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Mírně realistické osoby v nebezpečných situacích"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Vyobrazení skutečných osob v agresivních konfliktech"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Grafické násilí páchané na skutečných osobách"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Žádné zabíjení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Nerealistické zabíjení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistické zabíjení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Vyobrazení krveprolití a mrzačení lidí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Žádné sexuální násilí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Znásilnění nebo jiné násilné sexuální chování"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Žádné zmínky o alkoholu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Zmínky o alkoholických nápojích"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Požívání alkoholických nápojů"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Žádné zmínky o zakázaných drogách"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Zmínky o zakázaných drogách"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Používání zakázaných drog"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Žádné zmínky o tabákových výrobcích"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Zmínky o tabákových výrobcích"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Používání tabákových výrobků"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Žádná nahota jakéhokoliv typu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Občasná umělecká nahota"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Dlouhotrvající nahota"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Žádné zmínky o sexu nebo jeho vyobrazení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokativní zmínky nebo vyobrazení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Zmínky o sexu nebo jeho vyobrazení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Grafické znázornění sexuálního chování"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Žádné vulgární výrazy jakéhokoliv typu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Lehké nebo občasné používání vulgárních výrazů"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Střídmé používání vulgárních výrazů"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Hrubé nebo časté používání vulgárních výrazů"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Žádný nevhodný humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Bláznivý humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgární nebo postelový humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humor o sexu a pro dospělé"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Žádné diskriminační řeči jakéhokoliv druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Špatný pohled na konkrétní skupinu lidí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminace cílící na způsobení citové újmy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Výslovná diskriminace založená na pohlaví, sexuální orientaci, rase nebo "
+"náboženství"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Žádná reklama jakéhokoliv druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Vyobrazení produktů"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Výslovné odkazy na konkrétní výrobce nebo značky výrobků"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Uživatelé jsou vybízení k nákupu konkrétního skutečného zboží"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Žádné hraní jakéhokoliv druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Příležitostné hraní s žetony nebo kreditem"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Hraní o fiktivní peníze"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Hraní o skutečné peníze"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Žádná možnost prohrát skutečné peníze"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Uživatelé jsou vybízení k přispění skutečnými penězi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Možnost prohrát v aplikaci skutečné peníze"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Žádný způsob, jak komunikovat s ostatními uživateli"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interakce uživatel s uživatelem, bez textové komunikace"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Moderovaná textová komunikace mezi uživateli"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Neřízená textová komunikace mezi uživateli"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Žádný způsob, jako hovořit s ostatními uživateli"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Neřízená zvuková nebo obrazová komunikace mezi uživateli"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Žádné sdílení uživatelských jmen ze sociálních sítí a e-mailových adres"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Sdílení uživatelských jmen ze sociálních sítí a e-mailových adres"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Žádné sdílení informací o uživateli se třetími stranami"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Zjišťuje se nejnovější verze aplikace"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "Sdílení diagnostických dat, dle kterých se nedá identifikovat uživatel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Sdílení informací, dle kterých se dá identifikovat uživatel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Žádné sdílení fyzické polohy s ostatními uživateli"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Sdílení fyzické polohy s ostatními uživateli"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Žádné zmínky o homosexualitě"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Nepřímé zmínky o homosexualitě"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Polibky dvou lidí stejného pohlaví"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Grafické vyobrazení sexuálního chování mezi lidmi stejného pohlaví"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Žádné zmínky o prostituci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Nepřímé zmínky o prostituci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Přímé zmínky o prostituci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Grafické vyobrazení aktu prostituce"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Žádné zmínky o cizoložství"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Nepřímé zmínky o cizoložství"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Přímé zmínky o cizoložství"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Grafické vyobrazení aktu cizoložství"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Žádné sexualizované postavy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Skrovně oděné lidské postavy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Otevřeně sexualizované lidské postavy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Žádné zmínky o znesvěcení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Vyobrazení nebo zmínky o znesvěcení v dávné minulosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Vyobrazení znesvěcení lidmi v moderní době"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Grafické vyobrazení znesvěcení v moderní době"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Žádné viditelné pozůstatky lidských mrtvol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Viditelné pozůstatky lidských mrtvol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Ostatky lidských mrtvol zabrané do detailů"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Grafické vyobrazení znesvěcení lidských těl"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Žádné zmínky o otroctví"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Vyobrazení nebo zmínky o otroctví v dávné minulosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Vyobrazení otroctví v moderní době"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Grafické vyobrazení otroctví v moderní době"

--- a/po/cs.po
+++ b/po/cs.po
@@ -14,10 +14,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-06-06 02:23+0000\n"
 "Last-Translator: Michal Konečný <michalkonec666@gmail.com>\n"
-"Language-Team: Czech (http://www.transifex.com/freedesktop/appstream-glib/language/cs/)\n"
+"Language-Team: Czech (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/cs/)\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,395 +27,524 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Zobrazovat doplňující informace pro ladění"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Přidat ID mezipaměti do každé komponenty"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Do výstupu zahrnout i výsledky, které selhaly"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Přidat do balíčku tarball ikony s vysokým rozlišením"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Přidat ID mezipaměti do každé komponenty"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Přidání jazyka do zdrojového souboru"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Přidání poskytovatele do zdrojového souboru"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Přidat do XML zakódované ikony"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Přidáno"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias pro %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Pomůcka pro AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Zrušeno"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Zkontrolovat nainstalovaná data aplikací"
-
-msgid "Command not found, valid commands are:"
-msgstr "Příkaz nebyl nalezen, platné příkazy jsou:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Porovnat obsah dvou souborů AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Porovnat čísla verzí"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Převod %s na %s není implementován"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Převést soubor AppData do formátu NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Převést soubor NEWS do formátu AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Převést metadata AppStream z jedné verze do jiné"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Vytvořit dokument CSV s informacemi o stavu"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Vytvořit stránku HTML s tabulkou"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Vytvořit stránku HTML s informacemi o stavu"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Zobrazit slova indexovaná pro hledání aplikací"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Nekomprimovat ikony do balíčku tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Nepoužívat přístup k síti"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Hotovo!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Vypsat aplikace z metadat AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Nastavit adresář pro záznam"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Povolit profilování"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Nastavit adresář pro balíčky"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Chyba při vytváření výstupního adresáře"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Nastavit adresář pro dočasné soubory"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Chyba při načítání souboru AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Nastavit výstupní adresář"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Chyba při načítání souboru .desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Nastavit adresář s ikonami"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Chyba při zpracování renomé"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Nastavit adresář pro mezipaměť"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Chyba při zpracování, co poskytuje"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Nastavit základní název pro výstupní soubory"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Chyba při zpracování překladů"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Nastavit původní název"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Chyba při ukládání souboru AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Nastavit počet vláken"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Exportovat smlouvu jako text"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Nastavit minimální velikost ikony v pixelech"
 
-#. list failures
-msgid "FAILED"
-msgstr "SELHALO"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Nastavit umístění starých metadat"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignorovat určité typy zamítnutí"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Selhalo přidání balíčku"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Selhalo generování metadat"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Selhalo otevření balíčků"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Selhalo zpracování argumentů"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Selhalo vytvoření sestavení"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Selhalo otevření balíčků"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Procházejí se balíčky…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Selhalo přidání balíčku"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Zpracovány soubory %u/%u…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Selhalo generování metadat"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Hotovo!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Ukládá se ikona"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Nastavit prefix"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Zpracovává se aplikace"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Chyba při načítání souboru AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Chyba při zpracování překladů"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Chyba při zpracování renomé"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Chyba při zpracování, co poskytuje"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Chyba při načítání souboru .desktop"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Chyba při načítání souboru .desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Chyba při vytváření výstupního adresáře"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Ukládá se AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Chyba při ukládání souboru AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias pro %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Příkaz nebyl nalezen, platné příkazy jsou:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Projděte prosím soubor a opravte položky označené „FIXME“"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Stará verze API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nová verze API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Nedostatečný počet argumentů, očekávány: starý.mxl nový.xml verze"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Převod %s na %s není implementován"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Nedostatečný počet argumentů, očekáván: soubor.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Formát souboru „%s“ nelze převést na novější verzi"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Formát nebyl rozpoznán"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Vygenerovat GUID ze vstupního řetězce"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignorovat určité typy zamítnutí"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importovat soubor do značkovacího jazyka AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Do výstupu zahrnout i výsledky, které selhaly"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Začlenit doplňující metadata z externího souboru"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Nainstalovat metadata AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Instalovat metadata AppStream s novým původem"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Vypsat aplikace, které nejsou obsažené v balíčcích"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Sloučit několik souborů do souboru AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Zrcadlit snímky obrazovky z hlavního zdroje aplikace"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Upravit soubor AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nová verze API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nebyly nalezeny žádné aplikace pro grafické prostředí"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Nedostatečný počet argumentů, očekáván: soubor.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Nedostatečný počet argumentů, očekávány: starý.mxl nový.xml verze"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "V POŘÁDKU"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Stará verze API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "SELHALO"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Ověření selhalo"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Ověření souborů selhalo"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Zpracovány soubory %u/%u…"
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Projděte prosím soubor a opravte položky označené „FIXME“"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Ověření selhalo"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Zpracovává se aplikace"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Ověření souborů selhalo"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Odebráno"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Nahradit snímky obrazovky ve zdrojovém souboru"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Přidáno"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Ukládá se AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Zrušeno"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Ukládá se ikona"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Procházejí se balíčky…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Vyhledat v AppStream aplikace"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Vyhledat v AppStream aplikace podle jména kategorie"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Vyhledat v AppStream aplikace podle jména balíčku"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Nepoužívat přístup k síti"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Nastavit základní název pro výstupní soubory"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Nastavit adresář pro mezipaměť"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Nastavit adresář s ikonami"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Nastavit adresář pro záznam"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Nastavit minimální velikost ikony v pixelech"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Nastavit počet vláken"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Nastavit umístění starých metadat"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Nastavit původní název"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Nastavit výstupní adresář"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Nastavit adresář pro balíčky"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Nastavit prefix"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Nastavit adresář pro dočasné soubory"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Zobrazit všechny nainstalované AppStream aplikace"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Zobrazovat doplňující informace pro ladění"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Zobrazit verzi"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Rozdělit soubor AppStream na soubory AppData a Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Povolit profilování"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Testovat regulární výraz"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Převést metadata AppStream z jedné verze do jiné"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Odinstalovat metadata AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Povýšit metadata AppData na nejnovější verzi"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Vypsat aplikace z metadat AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Vyhledat v AppStream aplikace"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Vyhledat v AppStream aplikace podle jména balíčku"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Zobrazit všechny nainstalované AppStream aplikace"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Vyhledat v AppStream aplikace podle jména kategorie"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Zobrazit slova indexovaná pro hledání aplikací"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Nainstalovat metadata AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Instalovat metadata AppStream s novým původem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Odinstalovat metadata AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Vytvořit stránku HTML s informacemi o stavu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Vytvořit dokument CSV s informacemi o stavu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Vytvořit stránku HTML s tabulkou"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Vypsat aplikace, které nejsou obsažené v balíčcích"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Ověřit soubor AppData nebo AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Ověřit soubor AppData nebo AppStream (volně)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Exportovat smlouvu jako text"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Ověřit soubor AppData nebo AppStream (striktně)"
 
-msgid "Validation failed"
-msgstr "Ověření selhalo"
-
-msgid "Validation of files failed"
-msgstr "Ověření souborů selhalo"
-
-msgid "Version:"
-msgstr "Verze:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Ověřit soubor AppData nebo AppStream (volně)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Převést soubor AppData do formátu NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Převést soubor NEWS do formátu AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Zkontrolovat nainstalovaná data aplikací"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "zkontrolovat nainstalovanou aplikaci"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Nahradit snímky obrazovky ve zdrojovém souboru"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Přidání poskytovatele do zdrojového souboru"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Přidání jazyka do zdrojového souboru"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Zrcadlit snímky obrazovky z hlavního zdroje aplikace"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Začlenit doplňující metadata z externího souboru"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Porovnat obsah dvou souborů AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Vygenerovat GUID ze vstupního řetězce"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Upravit soubor AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Rozdělit soubor AppStream na soubory AppData a Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Sloučit několik souborů do souboru AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importovat soubor do značkovacího jazyka AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Sledovat umístění AppStream na změny"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "zkontrolovat nainstalovanou aplikaci"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Porovnat čísla verzí"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Testovat regulární výraz"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Pomůcka pro AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Verze:"

--- a/po/da.po
+++ b/po/da.po
@@ -543,3 +543,543 @@ msgstr "AppStream-redskab"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Generelt"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "ALLE"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Kun for voksne"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Voksne"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Teen"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Alle"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Småbørn"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Ingen tegneserie-vold"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Tegneseriefigurer i farlige situationer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Tegneseriefigurer i aggressiv konflikt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Visuel fremstilling af vold som involverer tegneseriefigurer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Ingen fantasy-vold"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Karakterer, som er nemme at skelne fra virkeligheden, i farlige situationer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Karakterer, som er nemme at skelne fra virkeligheden, i aggressiv konflikt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Visuel fremstilling af vold som er nemt at skelne fra virkeligheden"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Ingen realistisk vold"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Lettere realistiske karakterer i farlige situationer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Skildringer af realistiske karakterer i aggressiv konflikt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Visuel fremstilling af vold som involverer realistiske karakterer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Ingen blodsudgydelser"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Urealistiske blodsudgydelser"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistiske blodsudgydelser"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Skildringer af blodsudgydelser og lemlæstelse af kropsdele"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Ingen seksuel vold"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Voldtægt eller anden voldelig seksuel opførsel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Ingen referencer til alkohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referencer til alkoholiske drikke"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Brug af alkoholiske drikke"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Ingen referencer til ulovlige stoffer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referencer til ulovlige stoffer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Brug af ulovlige stoffer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Ingen referencer til tobaksvarer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referencer til tobaksvarer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Brug af tobaksvarer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Ingen nøgenhed af nogen art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Kortvarig kunstnerisk nøgenhed"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Længerevarende nøgenhed"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Ingen referencer til eller skildringer af seksuel art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokerende referencer eller skildringer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Seksuelle referencer eller skildringer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Visuel fremstilling af seksuel opførsel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Ingen bandeord af nogen art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Lettere eller sjælden brug af bandeord"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Moderat brug af bandeord"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Stærk eller udbredt brug af bandeord"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Ingen upassende humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Slapstick-humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Toilet- eller vulgær humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Voksen- eller seksuel humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Intet diskriminerende sprog af nogen art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negativitet mod en specifik gruppe af mennesker"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminering med følelsesmæssig skade som formål"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Eksplicit diskriminering baseret på køn, seksualitet, race eller religion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Ingen reklamer af nogen art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Product placement"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Eksplicitte referencer til specifikke brands eller varemærkede produkter"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Brugere opfordres til at købe specifikke ting fra den virkelige verden"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Ingen hasardspil af nogen art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr ""
+"Hasardspil om tilfældige lejligheder, med brug af spille-tokens eller kredit"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Hasardspil med “legetøjs”-penge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Hasardspil med rigtige penge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Ingen mulighed for at bruge penge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Brugere opfordres til at donere virkelige penge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Mulighed for at bruge rigtige penge i programmet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Ingen mulighed for at chatte med andre brugere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Bruger til bruger-interaktioner uden chatfunktionalitet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Modereret chat-funktionalitet mellem brugere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Ubegrænset chat-funktionalitet mellem brugere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Ingen mulighed for at tale med andre brugere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Ubegrænset lyd- eller video-chat-funktionalitet mellem brugere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Ingen deling af brugernavne eller e-mailadresser fra sociale netværk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Deling af brugernavne eller e-mailadresser fra sociale netværk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Ingen deling af brugerinformation med tredjeparter"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Søger efter den seneste version af programmet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "Deling af diagnostiske data som ikke lader andre identificere brugeren"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Deling af information som lader andre identificere brugeren"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Ingen deling af fysisk placering med andre brugere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Deler fysisk placering med andre brugere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Ingen referencer til homoseksualitet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Indirekte referencer til homoseksualitet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Personer af samme køn som kysser"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Visuel fremstilling af seksuel opførsel mellem mennesker af samme køn"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Ingen referencer til prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Indirekte referencer til prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Direkte referencer til prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Visuel fremstilling af prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Ingen referencer til utroskab"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Indirekte referencer til utroskab"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Direkte referencer til utroskab"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Visuel fremstilling af utroskab"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Ingen seksualiserede personer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Sparsomt påklædte personer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Åbenlyst seksualiserede personer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Ingen referencer til vanhelligelse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Fremstilling af eller referencer til historisk vanhelligelse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Fremstilling af nutidig vanhelligelse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Visuel fremstilling af nutidig vanhelligelse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Ingen synlige ligdele"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Synlige ligdele"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Ligdele i forfald"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Visuel fremstilling af ligskænding"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Ingen referencer til slaveri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Fremstilling af eller referencer til historisk slaveri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Fremstilling af nutidigt slaveri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Visuel fremstilling af nutidigt slaveri"

--- a/po/da.po
+++ b/po/da.po
@@ -10,10 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-02-11 08:19+0000\n"
 "Last-Translator: scootergrisen <scootergrisen@gmail.com>\n"
-"Language-Team: Danish (http://www.transifex.com/freedesktop/appstream-glib/language/da/)\n"
+"Language-Team: Danish (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/da/)\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,403 +23,523 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Vis ekstra fejlretningsinformation"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Tilføj et cache-id til hver komponent"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Inkluder mislykkede resultater i outputtet"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Tilføj HiDPI-ikoner til tarball'en"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Tilføj et cache-id til hver komponent"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Tilføj et sprog til en kildefil"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Tilføj en leverandør til en kildefil"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Tilføj kodede ikoner til XML'en"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Tilføjet"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias til %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream-redskab"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Annulleret"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Tjek installerede programdata"
-
-msgid "Command not found, valid commands are:"
-msgstr "Kommandoen blev ikke fundet, gyldige kommandoer er:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Sammenlign indholdet af to AppStream-filer"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Sammenlign versionsnumre"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Konvertering af %s til %s er ikke implementeret"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Konvertér en AppData-fil til NEWS-format"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Konvertér en NEWS-fil til AppData-format"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Konverterer AppStream-metadata fra en version til en anden"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Opret et CSV-statusdokument"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Opret en HTML-matriksside"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Opret en HTML-statusside"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Opretter en eksempel AppData-fil fra en .desktop-fil"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Vis symboler for programsøgning"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Komprimer ikke ikonerne til en tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Brug ikke netværksadgang"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Færdig!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Dumper programmerne i AppStream-metadataene"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Angiv logningsmappen"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Aktivér profilering"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Angiv pakkemappen"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Fejl ved oprettelse af outputmappe"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Angiv den midlertidige mappe"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Fejl ved indlæsning af AppData-fil"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Angiv outputmappen"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Fejl ved indlæsning af skrivebordsfil"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Angiv ikonmappen"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Fejl ved fortolkning af kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Angiv cache-mappe"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Fejl ved fortolkning af leverandører"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Angiv grundnavnene for outputfilerne"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Fejl ved fortolkning af oversættelser"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Angiv oprindelsesnavn"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Fejl ved gemning af AppStream-fil"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Angiv antallet af tråde"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Eksportér aftalen til tekst"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Angiv den mindste ikonstørrelse i pixels"
 
-#. list failures
-msgid "FAILED"
-msgstr "MISLYKKEDES"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Angiv den gamle metadataplacering"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignorer bestemte typer veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Kunne ikke tilføje pakke"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Kunne ikke oprette metadata"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Kunne ikke åbne pakker"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Kunne ikke fortolke argumenter"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Kunne ikke sætte byggeren op"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Kunne ikke åbne pakker"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Skanner pakker ..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Kunne ikke tilføje pakke"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Fortolkede %u/%u filer ..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Kunne ikke oprette metadata"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Færdig!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Gemmer ikon"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Angiv præfikset"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Behandler program"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Fejl ved indlæsning af AppData-fil"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Fejl ved fortolkning af oversættelser"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Fejl ved fortolkning af kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Fejl ved fortolkning af leverandører"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Ugyldige skrivebordsfilnavne"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Fejl ved indlæsning af skrivebordsfil"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Fejl ved oprettelse af outputmappe"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Gemmer AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Fejl ved gemning af AppStream-fil"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias til %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Kommandoen blev ikke fundet, gyldige kommandoer er:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Gennemse venligst filen og ret eventuelle 'FIXME'-punkter"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Gamle API-version"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Ny API-version"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Ikke nok argumenter, ventede gammel.xml ny.xml version"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Konvertering af %s til %s er ikke implementeret"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Ikke nok argumenter, ventede fil.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Filformatet '%s' kan ikke opgraderes"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Formatet genkendes ikke"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Genererer et GUID fra en inputstreng"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignorer bestemte typer veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importér en fil til AppStream-opmærkning"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Inkluder mislykkede resultater i outputtet"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Inkorporer ekstra metadata fra en ekstern fil"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Installerer AppStream-metadata"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Installerer AppStream-metadata med ny oprindelse"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Ugyldige skrivebordsfilnavne"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Vis programmer som ikke er bakket op af pakker"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Sammenlæg flere filer til en AppStream-fil"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Spejl skærmbilleder fra opstrøm"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Rediger en AppData-fil"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Ny API-version"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Fandt ikke nogen skrivebordsprogrammer"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Ikke nok argumenter, ventede fil.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Ikke nok argumenter, ventede gammel.xml ny.xml version"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Gamle API-version"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "MISLYKKEDES"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validering mislykkedes"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Validering af filer mislykkedes"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Fortolkede %u/%u filer ..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Gennemse venligst filen og ret eventuelle 'FIXME'-punkter"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validering mislykkedes"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Behandler program"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validering af filer mislykkedes"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Fjernet"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Erstat skærmbilleder i kildefil"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Tilføjet"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Gemmer AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Annulleret"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Gemmer ikon"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Skanner pakker ..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Søg efter AppStream-programmer"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Søg efter AppStream-programmer efter kategorinavn"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Søg efter AppStream-programmer efter programnavn"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Brug ikke netværksadgang"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Angiv grundnavnene for outputfilerne"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Angiv cache-mappe"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Angiv ikonmappen"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Angiv logningsmappen"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Angiv den mindste ikonstørrelse i pixels"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Angiv antallet af tråde"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Angiv den gamle metadataplacering"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Angiv oprindelsesnavn"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Angiv outputmappen"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Angiv pakkemappen"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Angiv præfikset"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Angiv den midlertidige mappe"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Vis alle installerede AppStream-programmer"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Vis ekstra fejlretningsinformation"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Vis version"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Opdel en AppStream-fil i AppData- og Metainfo-filer"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Aktivér profilering"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Test et regulært udtryk"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Konverterer AppStream-metadata fra en version til en anden"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Afinstallerer AppStream-metadata"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Opgrader AppData-metadata til den seneste version"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Opretter en eksempel AppData-fil fra en .desktop-fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Dumper programmerne i AppStream-metadataene"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Søg efter AppStream-programmer"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Søg efter AppStream-programmer efter programnavn"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Vis alle installerede AppStream-programmer"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Søg efter AppStream-programmer efter kategorinavn"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Vis symboler for programsøgning"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Installerer AppStream-metadata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Installerer AppStream-metadata med ny oprindelse"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Afinstallerer AppStream-metadata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Opret en HTML-statusside"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Opret et CSV-statusdokument"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Opret en HTML-matriksside"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Vis programmer som ikke er bakket op af pakker"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Valider en AppData- eller AppStream-fil"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Valider en AppData- eller AppStream-fil (afslappet)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Eksportér aftalen til tekst"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Valider en AppData- eller AppStream-fil (striks)"
 
-msgid "Validation failed"
-msgstr "Validering mislykkedes"
-
-msgid "Validation of files failed"
-msgstr "Validering af filer mislykkedes"
-
-msgid "Version:"
-msgstr "Version:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Valider en AppData- eller AppStream-fil (afslappet)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Konvertér en AppData-fil til NEWS-format"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Konvertér en NEWS-fil til AppData-format"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Tjek installerede programdata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "tjek et installeret program"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Erstat skærmbilleder i kildefil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Tilføj en leverandør til en kildefil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Tilføj et sprog til en kildefil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Spejl skærmbilleder fra opstrøm"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Inkorporer ekstra metadata fra en ekstern fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Sammenlign indholdet af to AppStream-filer"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Genererer et GUID fra en inputstreng"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Rediger en AppData-fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Opdel en AppStream-fil i AppData- og Metainfo-filer"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Sammenlæg flere filer til en AppStream-fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importér en fil til AppStream-opmærkning"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Hold øje med ændringer i AppStream-placeringer"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "tjek et installeret program"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Sammenlign versionsnumre"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Test et regulært udtryk"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream-redskab"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Version:"

--- a/po/de.po
+++ b/po/de.po
@@ -11,10 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-30 18:56+0100\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-05-10 12:51+0000\n"
 "Last-Translator: Tobias Weise <tobias.weise@web.de>\n"
-"Language-Team: German (http://www.transifex.com/freedesktop/appstream-glib/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/de/)\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,403 +24,524 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Zusätzliche Fehlerdiagnoseinformationen anzeigen"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Cachekennung zu jeder Komponente hinzufügen"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Fehlgeschlagene Ergebnisse in die Ausgabe miteinbeziehen"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "HiDPI-Symbole zum Tarball hinzufügen"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Cachekennung zu jeder Komponente hinzufügen"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Der Quelldatei eine Sprache hinzufügen"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Der QWu"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Kodierte Symbole zur XML hinzufügen"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Hinzugefügt"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias zu %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream-Dienstprogramm"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Abgebrochen"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Installierte Anwendungsdaten überprüfen"
-
-msgid "Command not found, valid commands are:"
-msgstr "Befehl nicht gefunden, gültige Befehle sind:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Inhalt zweier AppStream-Dateien vergleichen"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Versionsnummern vergleichen"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Konvertierung %s zu %s ist nicht implementiert"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "AppData-Datei in NEWS-Format konvertieren"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "NEWS-Datei in AppData-Format konvertieren"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Konvertiert AppStream-Metadaten von einer Version in eine andere"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "CSV-Statusdokument erstellen"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "HTML-Matrixseite erstellen"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "HTML-Statusseite erstellen"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Erstellt eine Beispiel-Appdata-Datei aus einer .desktop-Datei"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Anwendungssuchinformation anzeigen"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Symbole nicht in einen Tarball komprimieren"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Keinen Netzwerkzugriff verwenden"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Fertig!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Gibt die Anwendungen in den AppStream-Metadaten aus"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Protokollierungsverzeichnis festlegen"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Profilbildung aktivieren"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Paketeverzeichnis festlegen"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Fehler beim Erstellen des Ausgabeverzeichnisses"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Temporäres Verzeichnis festlegen"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Fehler beim Laden der AppData-Datei"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Ausgabeverzeichnis festlegen"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Fehler beim Laden der desktop-Datei"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Symbolverzeichnis festlegen"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Fehler beim Auswerten von kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Cacheverzeichnis festlegen"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Fehler beim Auswerten der »Provides«"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Basisnamen der Ausgabedateien festlegen"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Fehler beim Auswerten der Übersetzungen"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Ursprungsname festlegen"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Fehler beim Speichern der AppStream-Datei"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Anzahl an Threads festlegen"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Exportiert die Vereinbarung als Text"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Minimale Symbolgröße in Pixel festlegen"
 
-#. list failures
-msgid "FAILED"
-msgstr "FEHLGESCHLAGEN"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Alte Metadatenadresse festlegen"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Bestimmte Arten von Veto ignorieren"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Fehler beim Hinzufügen des Pakets"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Fehler beim Erzeugen der Metadaten"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Fehler beim Öffnen der Pakete"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Fehler beim Auswerten der Argumente"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Fehler beim Einrichten des Builders"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Fehler beim Öffnen der Pakete"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Pakete werden eingelesen …"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Fehler beim Hinzufügen des Pakets"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "%u von %u Dateien wurde ausgewertet …"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Fehler beim Erzeugen der Metadaten"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Fertig!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Symbol wird gespeichert"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Präfix festlegen"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Anwendung wird verarbeitet"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Fehler beim Laden der AppData-Datei"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Fehler beim Auswerten der Übersetzungen"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Fehler beim Auswerten von kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Fehler beim Auswerten der »Provides«"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Ungültiger Desktop Dateiname"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Fehler beim Laden der desktop-Datei"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Fehler beim Erstellen des Ausgabeverzeichnisses"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "AppStream wird gespeichert"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Fehler beim Speichern der AppStream-Datei"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias zu %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Befehl nicht gefunden, gültige Befehle sind:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr ""
+"Bitte begutachten Sie die Datei und beheben Sie etwaige \"FIXME\"-Einträge"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Alte API-Version"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Neue API-Version"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Nicht genügend Argumente, alt.xml neu.xml Version erwartet"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Konvertierung %s zu %s ist nicht implementiert"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Nicht genügend Argumente, Datei.xml erwartet"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Dateiformat »%s« kann nicht aktualisiert werden"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Format nicht erkannt"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Eine GUID aus einer Eingabezeichenfolge erzeugen"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Bestimmte Arten von Veto ignorieren"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Eine Datei in die AppStream-Auszeichnung importieren"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Fehlgeschlagene Ergebnisse in die Ausgabe miteinbeziehen"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Zusätzliche Metadaten aus einer externen Datei integrieren"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Installiert AppStream-Metadaten"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Installiert AppStream-Metadaten mit neuer Quelle"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Ungültiger Desktop Dateiname"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Nicht durch Pakete abgedeckte Anwendungen auflisten"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Mehrere Dateien zu einer AppStream-Datei zusammenführen"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Vorgeschaltete Bildschirmfotos spiegeln"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Ändern einer AppData-Datei"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Neue API-Version"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Keine Desktop-Anwendungen gefunden"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Nicht genügend Argumente, Datei.xml erwartet"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Nicht genügend Argumente, alt.xml neu.xml Version erwartet"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Alte API-Version"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FEHLGESCHLAGEN"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validierung fehlgeschlagen"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Validierung der Dateien ist fehlgeschlagen"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "%u von %u Dateien wurde ausgewertet …"
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Bitte begutachten Sie die Datei und beheben Sie etwaige \"FIXME\"-Einträge"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validierung fehlgeschlagen"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Anwendung wird verarbeitet"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validierung der Dateien ist fehlgeschlagen"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Entfernt"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Bildschirmfotos in Quelldatei ersetzen"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Hinzugefügt"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "AppStream wird gespeichert"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Abgebrochen"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Symbol wird gespeichert"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Pakete werden eingelesen …"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Nach AppStream-Anwendungen suchen"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Nach installierten Appstream-Anwendungen nach Kategorienamen suchen"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Nach AppStream-Anwendungen mit Paketname suchen"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Keinen Netzwerkzugriff verwenden"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Basisnamen der Ausgabedateien festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Cacheverzeichnis festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Symbolverzeichnis festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Protokollierungsverzeichnis festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Minimale Symbolgröße in Pixel festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Anzahl an Threads festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Alte Metadatenadresse festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Ursprungsname festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Ausgabeverzeichnis festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Paketeverzeichnis festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Präfix festlegen"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Temporäres Verzeichnis festlegen"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Alle installierten Appstream-Anwendungen anzeigen"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Zusätzliche Fehlerdiagnoseinformationen anzeigen"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Version anzeigen"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Eine AppStream-Datei in AppData- und Metainfo-Dateien aufspalten"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Profilbildung aktivieren"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Regulären Ausdruck (regex) testen"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Konvertiert AppStream-Metadaten von einer Version in eine andere"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Deinstalliert AppStream-Metadaten"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "AppData-Metadaten auf die neueste Version aktualisieren"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Erstellt eine Beispiel-Appdata-Datei aus einer .desktop-Datei"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Gibt die Anwendungen in den AppStream-Metadaten aus"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Nach AppStream-Anwendungen suchen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Nach AppStream-Anwendungen mit Paketname suchen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Alle installierten Appstream-Anwendungen anzeigen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Nach installierten Appstream-Anwendungen nach Kategorienamen suchen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Anwendungssuchinformation anzeigen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Installiert AppStream-Metadaten"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Installiert AppStream-Metadaten mit neuer Quelle"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Deinstalliert AppStream-Metadaten"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "HTML-Statusseite erstellen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "CSV-Statusdokument erstellen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "HTML-Matrixseite erstellen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Nicht durch Pakete abgedeckte Anwendungen auflisten"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "AppData- oder AppStream-Datei validieren"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "AppData- oder AppStream-Datei validieren (locker)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Exportiert die Vereinbarung als Text"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "AppData- oder AppStream-Datei (strikt) validieren"
 
-msgid "Validation failed"
-msgstr "Validierung fehlgeschlagen"
-
-msgid "Validation of files failed"
-msgstr "Validierung der Dateien ist fehlgeschlagen"
-
-msgid "Version:"
-msgstr "Version:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "AppData- oder AppStream-Datei validieren (locker)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "AppData-Datei in NEWS-Format konvertieren"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "NEWS-Datei in AppData-Format konvertieren"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Installierte Anwendungsdaten überprüfen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "Installierte Anwendung überprüfen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Bildschirmfotos in Quelldatei ersetzen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Der QWu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Der Quelldatei eine Sprache hinzufügen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Vorgeschaltete Bildschirmfotos spiegeln"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Zusätzliche Metadaten aus einer externen Datei integrieren"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Inhalt zweier AppStream-Dateien vergleichen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Eine GUID aus einer Eingabezeichenfolge erzeugen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Ändern einer AppData-Datei"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Eine AppStream-Datei in AppData- und Metainfo-Dateien aufspalten"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Mehrere Dateien zu einer AppStream-Datei zusammenführen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Eine Datei in die AppStream-Auszeichnung importieren"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "AppStream Pfade auf Änderungen überprüfen"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "Installierte Anwendung überprüfen"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Versionsnummern vergleichen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Regulären Ausdruck (regex) testen"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream-Dienstprogramm"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Version:"

--- a/po/de.po
+++ b/po/de.po
@@ -545,3 +545,550 @@ msgstr "AppStream-Dienstprogramm"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Allgemein"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "ALLE"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Nur Erwachsene"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Erwachsen"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Jugendliche"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Alle ab 10 Jahren"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Alle"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Frühe Kindheit"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Keine Gewalt in Cartoons"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Animationsfiguren in unsicheren Situationen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Animationsfiguren in aggressivem Konflikt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Grafische Gewaltdarstellung durch Animationsfiguren"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Keine Gewalt in Fantasy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Figuren in unsicheren Situationen, die einfach von der Realität zu "
+"unterscheiden sind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Figuren in aggressiven Konflikten, die einfach von der Realität zu "
+"unterscheiden sind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Graphische Gewalt, die realitätsfremd ist"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Keine realistische Gewalt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Harmlose realistische Figuren in unsicheren Situationen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr ""
+"Darstellung von realistischen Charakteren, die im aggressiven Konflikt "
+"zueinander stehen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Graphische Gewalt von realistischen Charakteren"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Kein Blutvergießen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Unrealistisches Blutvergießen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistisches Blutvergießen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Darstellung von Blutvergießen und Verstümmeln von Körperteilen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Keine sexuelle Gewalt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Vergewaltigung oder andere gewaltsame Sexualhandlungen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Keine Erwähnung alkoholischer Getränke"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Bezug auf alkoholische Getränke"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Genuss von alkoholischen Getränken"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Keine Erwähnung unerlaubter Drogen/Medikamente"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Erwähnung unerlaubter Drogen/Medikamente"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Konsum von unerlaubten Drogen/Medikamenten"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Kein Bezug auf Tabakprodukte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Bezug auf Tabakprodukte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Genuss von Tabakprodukten"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Keine Nacktszenen irgendeiner Form"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Kurzzeitige, künstlerische Darbietung von Nacktszenen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Ausgiebige Nacktszenen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Keine Anspielungen oder Darstellungen sexueller Natur"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokative Anspielungen oder Darstellungen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Sexuelle Anspielungen oder Darstellungen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Graphische Sexualhandlungen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Keine Obszönität irgendeiner Art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Geringe oder seltene Obszönität"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Gemäßigte Obszönität"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Starke oder häufige Obszönität"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Kein unangemessener Humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Slapstick-Humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgärer oder Kneipenstammtischhumor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Nicht jugendfreier oder sexueller Humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Keine diskriminierende Sprache irgendeiner Art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Abwertende Äußerungen gegenüber spezifischen Gruppierungen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminierung mit dem Ziel der emotionellen Kränkung"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Explizite Diskriminierung von Geschlecht, Sexualität, Rasse oder Religion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Keine Werbung irgendeiner Art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Produktplatzierung"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Explizite Anspielungen auf bestimmte Marken oder Handelsprodukte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Benutzer werden ermuntert, bestimmte reale Objekte zu erwerben"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Kein Glücksspiel irgendeiner Art"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Glücksspiele mit Jetons oder Guthaben"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Glücksspiel mit Spielgeld"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Glücksspiel mit echtem Geld"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Keine Möglichkeit, reales Geld auszugeben"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Benutzer werden ermuntert, echtes Geld zu spenden"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Möglichkeit, reales Geld in Anwendungen auszugeben"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Keine Möglichkeit zum Chat mit anderen Benutzern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Zwei-Teilnehmer-Interaktionen ohne Chat-Funktion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Moderierte Chat-Funktion zwischen Benutzern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Nicht kontrollierte Chat-Funktion zwischen Benutzern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Keine Möglichkeit zum Gespräch mit anderen Benutzern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Nicht kontrollierte Audio- oder Video-Chat-Funktion zwischen Benutzern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Kein Teilen von Benutzernamen in sozialen Netzwerken oder E-Mail-Adressen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Teilen von Benutzernamen in sozialen Netzwerken oder E-Mail-Adressen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Kein Teilen von Benutzerinformationen mit Dritten"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Suchen nach der neuesten Anwendungsversion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Teilen von Diagnosedaten, die eine Identifizierung des Benutzers durch "
+"andere nicht ermöglichen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Teilen von Informationen, die eine Identifizierung des Benutzers durch "
+"andere ermöglichen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Kein Teilen des physischen Aufenthaltsortes mit anderen Benutzern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Teilen des physischen Aufenthaltsortes mit anderen Benutzern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Keine Erwähnung von Homosexualität"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Indirekte Erwähnung von Homosexualität"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Küssen von Personen desselben Geschlechts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Grafisches Sexualverhalten von Personen desselben Geschlechts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Keine Erwähnung von Prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Indirekte Erwähnung von Prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Direkte Erwähnung von Prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Grafische Darstellungen des Akts der Prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Keine Erwähnung von Ehebruch"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Indirekte Erwähnung von Ehebruch"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Direkte Erwähnung von Ehebruch"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Grafische Darstellungen des Akts des Ehebruchs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Keine sexualisierten Charaktere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Leicht bekleidete menschliche Charaktere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Offen sexualisierte menschliche Charaktere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Keine Erwähnung von Schändung"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Darstellungen oder Erwähnungen von historischer Schändung"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Darstellungen von moderner menschlicher Schändung"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Grafische Darstellungen von moderner Schändung"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Keine sichtbaren menschlichen Überreste"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Sichtbare menschliche Überreste"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Menschliche Überreste, die der Natur ausgesetzt sind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Grafische Darstellungen von Schändung menschlicher Körper"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Keine Erwähnung von Sklaverei"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Darstellungen oder Erwähnungen von historischer Sklaverei"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Darstellungen oder Erwähnungen von moderner Sklaverei"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Grafische Darstellungen von moderner Sklaverei"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -10,10 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 02:59+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: English (United Kingdom) (http://www.transifex.com/freedesktop/appstream-glib/language/en_GB/)\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/"
+"freedesktop/appstream-glib/language/en_GB/)\n"
 "Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,350 +23,528 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "Add HiDPI icons to the tarball"
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Show extra debugging information"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
 msgid "Add a cache ID to each component"
 msgstr "Add a cache ID to each component"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Include failed results in the output"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "Add HiDPI icons to the tarball"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Add encoded icons to the XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Added"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias to %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream Utility"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Check installed application data"
-
-msgid "Command not found, valid commands are:"
-msgstr "Command not found, valid commands are:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Compare the contents of two AppStream files"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Conversion %s to %s is not implemented"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Convert an AppData file to NEWS format"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Convert an NEWS file to AppData format"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Converts AppStream metadata from one version to another"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Create an CSV status document"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Create an HTML matrix page"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Create an HTML status page"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Display application search tokens"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Do not compress the icons into a tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Do not use network access"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Done!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Dumps the applications in the AppStream metadata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Set the logging directory"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Enable profiling"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Set the packages directory"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Error creating output directory"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Set the temporary directory"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Error loading AppData file"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Set the output directory"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Error loading desktop file"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Set the icons directory"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Error parsing kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Set the cache directory"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Error parsing provides"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Set the basenames of the output files"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Error parsing translations"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Set the origin name"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Error saving AppStream file"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Set the number of threads"
 
-#. list failures
-msgid "FAILED"
-msgstr "FAILED"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Set the minimum icon size in pixels"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Set the old metadata location"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignore certain types of veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Failed to add package"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Failed to generate metadata"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Failed to open packages"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Failed to parse arguments"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Failed to set up builder"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Failed to open packages"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Scanning packages..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Failed to add package"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Failed to generate metadata"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Done!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Saving icon"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Set the prefix"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Processing application"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Error loading AppData file"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Error parsing translations"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Error parsing kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Error parsing provides"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Error loading desktop file"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Error loading desktop file"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Error creating output directory"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Saving AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Error saving AppStream file"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias to %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Command not found, valid commands are:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Please review the file and fix any 'FIXME' items"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Old API version"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "New API version"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Not enough arguments, expected old.xml new.xml version"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Conversion %s to %s is not implemented"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Not enough arguments, expected file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "File format '%s' cannot be upgraded"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Format not recognised"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Generate a GUID from an input string"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignore certain types of veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Import a file to AppStream markup"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Include failed results in the output"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorporate extra metadata from an external file"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Installs AppStream metadata"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Installs AppStream metadata with new origin"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "List applications not backed by packages"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Merge several files to an AppStream file"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Mirror upstream screenshots"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modify an AppData file"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "New API version"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "No desktop applications found"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Not enough arguments, expected file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Not enough arguments, expected old.xml new.xml version"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Old API version"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FAILED"
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Please review the file and fix any 'FIXME' items"
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validation failed"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Processing application"
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Validation of files failed"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validation failed"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validation of files failed"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Removed"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Replace screenshots in source file"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Added"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Saving AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Saving icon"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Scanning packages..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Search for AppStream applications"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Search for AppStream applications by package name"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Do not use network access"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Set the basenames of the output files"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Set the cache directory"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Set the icons directory"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Set the logging directory"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Set the minimum icon size in pixels"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Set the number of threads"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Set the old metadata location"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Set the origin name"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Set the output directory"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Set the packages directory"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Set the prefix"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Set the temporary directory"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Show extra debugging information"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Show version"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Split an AppStream file to AppData and Metainfo files"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Enable profiling"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Uninstalls AppStream metadata"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Converts AppStream metadata from one version to another"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Upgrade AppData metadata to the latest version"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Dumps the applications in the AppStream metadata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Search for AppStream applications"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Search for AppStream applications by package name"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Search for AppStream applications"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "Search for AppStream applications by package name"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Display application search tokens"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Installs AppStream metadata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Installs AppStream metadata with new origin"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Uninstalls AppStream metadata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Create an HTML status page"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Create an CSV status document"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Create an HTML matrix page"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "List applications not backed by packages"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Validate an AppData or AppStream file"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Validate an AppData or AppStream file (relaxed)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Validate an AppData or AppStream file (strict)"
 
-msgid "Validation failed"
-msgstr "Validation failed"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Validate an AppData or AppStream file (relaxed)"
 
-msgid "Validation of files failed"
-msgstr "Validation of files failed"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Convert an AppData file to NEWS format"
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Convert an NEWS file to AppData format"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Check installed application data"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Check installed application data"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Replace screenshots in source file"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Mirror upstream screenshots"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Incorporate extra metadata from an external file"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Compare the contents of two AppStream files"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Generate a GUID from an input string"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modify an AppData file"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Split an AppStream file to AppData and Metainfo files"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Merge several files to an AppStream file"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Import a file to AppStream markup"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "Search for AppStream applications by package name"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream Utility"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version:"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -548,3 +548,539 @@ msgstr "AppStream Utility"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "General"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "ALL"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Adults Only"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Mature"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Teen"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Everyone 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Everyone"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Early Childhood"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "No cartoon violence"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Cartoon characters in unsafe situations"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Cartoon characters in aggressive conflict"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Graphic violence involving cartoon characters"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "No fantasy violence"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Characters in unsafe situations easily distinguishable from reality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Characters in aggressive conflict easily distinguishable from reality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Graphic violence easily distinguishable from reality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "No realistic violence"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Mildly realistic characters in unsafe situations"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Depictions of realistic characters in aggressive conflict"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Graphic violence involving realistic characters"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "No bloodshed"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Unrealistic bloodshed"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistic bloodshed"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Depictions of bloodshed and the mutilation of body parts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "No sexual violence"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Rape or other violent sexual behaviour"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "No references to alcohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "References to alcoholic beverages"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Use of alcoholic beverages"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "No references to illicit drugs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "References to illicit drugs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Use of illicit drugs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+#, fuzzy
+msgid "No references to tobacco products"
+msgstr "References to tobacco products"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "References to tobacco products"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Use of tobacco products"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "No nudity of any sort"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Brief artistic nudity"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Prolonged nudity"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "No references to or depictions of sexual nature"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provocative references or depictions"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Sexual references or depictions"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Graphic sexual behaviour"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "No profanity of any kind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Mild or infrequent use of profanity"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Moderate use of profanity"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Strong or frequent use of profanity"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "No inappropriate humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Slapstick humour"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgar or bathroom humour"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Mature or sexual humour"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "No discriminatory language of any kind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negativity towards a specific group of people"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discrimination designed to cause emotional harm"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Explicit discrimination based on gender, sexuality, race or religion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "No advertising of any kind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Product placement"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Explicit references to specific brands or trademarked products"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Users are encouraged to purchase specific real-world items"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "No gambling of any kind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Gambling on random events using tokens or credits"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Gambling using “play” money"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Gambling using real money"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "No ability to spend money"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Users are encouraged to donate real money"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Ability to spend real money in-app"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "No way to chat with other users"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "User-to-user interactions without chat functionality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Moderated chat functionality between users"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Uncontrolled chat functionality between users"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "No way to talk with other users"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Uncontrolled audio or video chat functionality between users"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "No sharing of social network usernames or e-mail addresses"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Sharing social network usernames or e-mail addresses"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "No sharing of user information with third parties"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Checking for the latest application version"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "Sharing diagnostic data that does not let others identify the user"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Sharing information that lets others identify the user"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "No sharing of physical location with other users"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Sharing physical location with other users"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "No references to homosexuality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Indirect references to homosexuality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Kissing between people of the same gender"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Graphic sexual behavior between people of the same gender"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "No references to prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Indirect references to prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Direct references to prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Graphic depictions of the act of prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "No references to adultery"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Indirect references to adultery"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Direct references to adultery"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Graphic depictions of the act of adultery"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "No sexualised characters"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Scantily clad human characters"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Overtly sexualised human characters"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "No references to desecration"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Depictions of or references to historical desecration"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Depictions of modern-day human desecration"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Graphic depictions of modern-day desecration"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "No visible dead human remains"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Visible dead human remains"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Dead human remains that are exposed to the elements"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Graphic depictions of desecration of human bodies"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "No references to slavery"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Depictions of or references to historical slavery"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Depictions of modern-day slavery"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Graphic depictions of modern-day slavery"

--- a/po/es.po
+++ b/po/es.po
@@ -13,10 +13,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-11-22 03:51+0000\n"
 "Last-Translator: Emilio Herrera <ehespinosa57@gmail.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/freedesktop/appstream-glib/language/es/)\n"
+"Language-Team: Spanish (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -25,400 +26,524 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Mostrar información de depuración adicional"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Añadir un identificador de caché a cada componente"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Incluir resultados fallidos en la salida"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Agregar iconos HiDPI en el tarball"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Añadir un identificador de caché a cada componente"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Añade un idioma a un archivo de origen"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Agrega un suministro a un archivo de origen"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Añadir iconos codificados al XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Añadida"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias a %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitario AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Cancelado"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Comprobar los datos de aplicación instalados"
-
-msgid "Command not found, valid commands are:"
-msgstr "No se encontró el comando, los comandos válidos son:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Comparar el contenido de dos ficheros AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Compara números de versiones"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Conversión %s a %s no está implementada"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Convertir un fichero AppData a formato NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Convertir un archivo NEWS a formato AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Convertir metadatos de AppStream de una versión a otra"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Crear un documento de estado en CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Crear la página de matriz en HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Crear una página de estado en HTML"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Mostrando tokens de búsqueda de aplicaciones"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "No comprimir los iconos en un tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "No usar acceso a la red"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "¡Hecho!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Respalda las aplicaciones en la metadata de AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Establecer el directorio de bitácoras"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Habilitar perfilado"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Establecer el directorio de paquetes"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Error creando directorio de salida"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Establecer el directorio temporal"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Error cargando el fichero AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Establecer el directorio de salida"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Error cargando fichero de escritorio"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Establecer el directorio de íconos"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Error analizando prestigios"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Establecer el directorio de caché"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Error analizando aprovisionamientos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Establecer el nombre base de los ficheros de salida"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Error analizando traducciones"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Establecer el nombre del origen"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Error guardando fichero AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Establecer la cantidad de hilos"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Exportar el acuerdo al texto"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Establecer el tamaño mínimo en píxeles"
 
-#. list failures
-msgid "FAILED"
-msgstr "FALLIDO"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Establecer la ubicación de los metadatos anteriores"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignorar ciertos tipos de veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "No se pudo añadir el paquete"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "No se pudo generar los metadatos"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "No se pudo abrir los paquetes"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "No se pudo analizar los argumentos"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "No se pudo configurar el constructor"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "No se pudo abrir los paquetes"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Examinando los paquetes…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "No se pudo añadir el paquete"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Leídos %u/%u archivos..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "No se pudo generar los metadatos"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "¡Hecho!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Guardando icono"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Establecer el prefijo"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Procesando aplicación"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Error cargando el fichero AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Error analizando traducciones"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Error analizando prestigios"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Error analizando aprovisionamientos"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Nombre de escritorio no válido"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Error cargando fichero de escritorio"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Error creando directorio de salida"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Guardando AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Error guardando fichero AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias a %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "No se encontró el comando, los comandos válidos son:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Por favor, revise el fichero y corrija todos los elementos 'FIXME'"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Versión de API anterior"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Versión de API nueva"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Argumentos insuficientes, esperando viejo.xml nuevo.xml version"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Conversión %s a %s no está implementada"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Argumentos insuficientes, esperando fichero.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Formato de fichero '%s' no puede ser actualizado"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Formato no reconocido"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Generar un GUID de una cadena de entrada"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignorar ciertos tipos de veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importar un fichero a marcado AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Incluir resultados fallidos en la salida"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorporar metadata extra desde un archivo externo"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Instala los metadatos de AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Instala metadatos de AppStream con nuevo origen"
-
-#. TRANSLATORS: not a valid desktop filename
-#, fuzzy
-msgid "Invalid desktop filename"
-msgstr "Nombre de escritorio no válido"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Lista de aplicaciones no soportadas por paquetes"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Combinar varios ficheros en un fichero AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Pantallazos de espejos upstream"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modificar un fichero AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Versión de API nueva"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "No se encontró aplicaciones de escritorio"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Argumentos insuficientes, esperando fichero.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Argumentos insuficientes, esperando viejo.xml nuevo.xml version"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Versión de API anterior"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FALLIDO"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Falló la validación"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Falló la validación de los ficheros"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Leídos %u/%u archivos..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Por favor, revise el fichero y corrija todos los elementos 'FIXME'"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Falló la validación"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Procesando aplicación"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Falló la validación de los ficheros"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Eliminada"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Sustituir las captura de pantalla en el archivo de origen"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Añadida"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Guardando AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Cancelado"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Guardando icono"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Examinando los paquetes…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Buscar aplicaciones AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Buscar aplicaciones AppStream por nombre de categoría"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Buscar aplicaciones AppStream por nombre de paquete"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "No usar acceso a la red"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Establecer el nombre base de los ficheros de salida"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Establecer el directorio de caché"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Establecer el directorio de íconos"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Establecer el directorio de bitácoras"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Establecer el tamaño mínimo en píxeles"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Establecer la cantidad de hilos"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Establecer la ubicación de los metadatos anteriores"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Establecer el nombre del origen"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Establecer el directorio de salida"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Establecer el directorio de paquetes"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Establecer el prefijo"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Establecer el directorio temporal"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Mostras todas las aplicaciones AppStream instaladas"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Mostrar información de depuración adicional"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Mostrar versión"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Separar un fichero AppStream en ficheros AppData y Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Habilitar perfilado"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Prueba una expresión regular"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Convertir metadatos de AppStream de una versión a otra"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Desinstala los metadatos de AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Actualizar metadatos de AppData a la versión más reciente"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Respalda las aplicaciones en la metadata de AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Buscar aplicaciones AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Buscar aplicaciones AppStream por nombre de paquete"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Mostras todas las aplicaciones AppStream instaladas"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Buscar aplicaciones AppStream por nombre de categoría"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Mostrando tokens de búsqueda de aplicaciones"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Instala los metadatos de AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Instala metadatos de AppStream con nuevo origen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Desinstala los metadatos de AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Crear una página de estado en HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Crear un documento de estado en CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Crear la página de matriz en HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Lista de aplicaciones no soportadas por paquetes"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Validar un AppData o fichero AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Validar un AppData o fichero AppStream (relajado)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Exportar el acuerdo al texto"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Validar un AppData o fichero AppStream (estricto)"
 
-msgid "Validation failed"
-msgstr "Falló la validación"
-
-msgid "Validation of files failed"
-msgstr "Falló la validación de los ficheros"
-
-msgid "Version:"
-msgstr "Versión:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Validar un AppData o fichero AppStream (relajado)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Convertir un fichero AppData a formato NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Convertir un archivo NEWS a formato AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Comprobar los datos de aplicación instalados"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "Comprobar una aplicación instalada"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Sustituir las captura de pantalla en el archivo de origen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Agrega un suministro a un archivo de origen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Añade un idioma a un archivo de origen"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Pantallazos de espejos upstream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Incorporar metadata extra desde un archivo externo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Comparar el contenido de dos ficheros AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Generar un GUID de una cadena de entrada"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modificar un fichero AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Separar un fichero AppStream en ficheros AppData y Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Combinar varios ficheros en un fichero AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importar un fichero a marcado AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Espera las localizaciones de AppStream para los cambios"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "Comprobar una aplicación instalada"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Compara números de versiones"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Prueba una expresión regular"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitario AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Versión:"

--- a/po/es.po
+++ b/po/es.po
@@ -547,3 +547,547 @@ msgstr "Utilitario AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versión:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "General"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "TODO"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Sólo adultos"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Maduro"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Adolescentes"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Todos los de 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Todos"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Infantil"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Sin violencia con personajes animados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personajes animados en situaciones no seguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personajes animados en conflictos agresivos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Violencia gráfica con personajes animados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Sin violencia fantástica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Personajes en situaciones no seguras distinguibles fácilmente de la realidad"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Personajes en conflictos agresivos distinguibles fácilmente de la realidad"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Violencia gráfica distinguible fácilmente de la realidad"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Sin violencia realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personajes semi-realistas en situaciones no seguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Representaciones de personajes realistas en conflictos agresivos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Violencia gráfica con personajes realistas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Sin masacres"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Masacre no realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Masacre realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Representaciones de masacres y mutilación de partes del cuerpo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Sin violencia sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Violación u otro comportamiento sexual violento"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Sin referencias a bebidas alcohólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referencias a bebidas alcohólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Uso de bebidas alcohólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Sin referencias a drogas ilegales"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referencias a drogas ilegales"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Uso de drogas ilegales"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Si referencias al tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referencias al tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Uso de tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Sin desnudos de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Desnudez artística breve"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Desnudez prolongada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Sin representaciones o referencias sexuales"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Representaciones o referencias provocativas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Representaciones o referencias sexuales"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Comportamiento sexual gráfico"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Sin blasfemia de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Uso moderado o poco frecuente de la blasfemia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Uso moderado de la blasfemia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Uso amplio o frecuente de la blasfemia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Sin humor inapropiado"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Humor absurdo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Humor vulgar o escatológico"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humor adulto o sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Sin lenguaje discriminatorio de cualquier tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatividad hacia un determinado grupo de personas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminación para causar daño emocional"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Discriminación explícita basada en género, sexualidad, raza o religión"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Sin publicidad de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Venta de productos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Referencias explícitas a marcas concretas o productos de marcas registradas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr ""
+"Se incita a los jugadores a comprar determinados elementos del mundo real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Sin apuestas de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Juego en eventos aleatorios usando créditos o vidas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Juego usando dinero virtual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Juego usando dinero real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Sin posibilidad de gastar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Se incita a los jugadores a donar dinero real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Posibilidad de gastar dinero real en el juego"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Sin posibilidad de chatear con otros jugadores"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interacciones de jugador a jugador sin funcionalidad de chat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Funcionalidad de chat moderada entre jugadores"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Funcionalidad de chat sin controlar entre jugadores"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Sin posibilidad de hablar con otros jugadores"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Funcionalidad de sonido o vídeo sin controlar entre jugadores"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"No comparte en redes sociales de nombres de usuario o direcciones de correo-e"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Compartición en redes sociales de nombres de usuario o direcciones de correo-"
+"e"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "No comparte la información del usuario con terceros"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Comprobando la última versión de la aplicación"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Compartición de datos diagnósticos que no permiten a otros identificar al "
+"usuario"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Compartición de información que permite a otros identificar al usuario"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "No comparte la ubicación física con otros usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Compartición de la ubicación física con otros usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Sin referencias a la homosexualidad"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Referencias indirectas a la homosexualidad"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Besos entre personas del mismo sexo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Comportamiento sexual gráfico entre personas del mismo sexo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Sin referencias a la prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Referencias indirectas a la prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Referencias directas a la prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Representación gráfica del acto de prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Sin referencias al adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Referencias indirectas al adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Referencias directas al adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Representación gráfica del acto de adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Sin caracteres sexualizados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Caracteres humanos apenas vestidos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Caracteres humanos abiertamente sexualizados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Sin referencias a la profanación"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Representación gráfica o referencias a la profanación histórica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Representación gráfica de profanación humana actual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Representación gráfica de profanación actual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Sin restos mortales humanos visibles"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Restos mortales humanos visibles"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Restos mortales humanos expuestos a los elementos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Representación gráfica de profanación de cuerpos humanos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Sin referencias a la esclavitud"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Representaciones o referencias a la esclavitud histórica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Representaciones o referencias a la esclavitud actual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Representación gráfica de esclavitud actual"

--- a/po/fa.po
+++ b/po/fa.po
@@ -542,3 +542,539 @@ msgstr "ابزار AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "نسخه:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "عمومی"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "همه"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "فقط بزرگسالان"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "بالغ"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "نوجوان"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "هرکسی بالای ۱۰"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "هرکسی"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "کودک"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "بدون خشونت کارتونی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "شخصیت‌های کارتونی در وضعیت‌های نا امن"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "شخصیت‌های کارتونی در وضعیت‌های درگیری"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "خشونت شامل شخصیت‌های کارتونی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "بدون خشونت فانتزی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "شخصیت‌ها در موقعیت‌های نا امن که به راحتی از واقعیت قابل تشخیص هستند"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"شخصیت‌های کارتونی در وضعیت‌های درگیری که به راحتی از واقعیت قابل تشخیص هستند"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "شامل خشونت که به راحتی از واقعیت قابل تشخیص هستند"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "بدون خشونت واقعی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "شخصیت‌های تقریبا واقعی که در وضعیت‌های نا امن"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "تصاویر شخصیت‌های واقعی در وضعیت‌های درگیری"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "خشونت شامل شخصیت‌های واقعی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "بدون خون‌ریزی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "خون‌ریزی غیر واقعی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "خون‌ریزی واقعی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "تصاویر خون‌ریزی و قطع اعضای بدن"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "بدون خشونت جنسی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "تجاوز یا سایر اعمال جنسی خشونت‌آمیز"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "بدون اشاره به نوشیدنی‌های الکلی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "اشاره به نوشیدنی‌های الکلی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "استفاده از نوشیدنی‌های الکلی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "بدون اشاره به مخدرهای غیرقانونی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "اشاره به مخدرهای غیرقانونی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "استفاده از مخدرهای غیرقانونی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "بدون اشاره به محصولات تنباکو"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "اشاره به محصولات تنباکو"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "استفاده از محصولات تنباکو"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "بدون هیچ نوع برهنگی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "برهنگی هنری و مختصر"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "برهنگی ممتد"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "بدون اشاره یا ترسیم طبیعت جنسی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "اشاره و یا تصاویر تحریک‌آمیز"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "اشاره یا تصاویر جنسی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "رفتارهای جنسی گرافیکی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "بدون هیچ نوع ناسزا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "استفاده کم یا ملایم از ناسزا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "استفاده متوسط از ناسزا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "استفاده زیاد یا مکرر از ناسزا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "بدون شوخی‌های نامربوط"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "شوخی‌های هیجانی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "شوخی‌های مبتذل"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "شوخی‌های جنسی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "بدون هیچ نوع زبان تبعیض‌آمیز"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "اشاره منفی به گروه خاصی از مردم"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "طراحی خاص برای ایجاد آسیب عاطفی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "تبعیض آشکار بر اساس جنسیت، نژاد یا دین"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "بدون هیچ نوع تبلیغات"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "جایگذاری محصول"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "اشاره‌های واضح به برندهای مشخص یا محصولات تجاری"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "کاربران تشویق می‌شوند اجناسی در دنیای واقعی بخرند"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "بدون هیچ نوع قمار"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "شرط‌بندی روی رویداد اتفاقی با استفاده از توکن یا اعتبار"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "شرط‌بندی با استفاده از پولِ «بازی»"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "شرط‌بندی با استفاده از پول واقعی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "بدون امکان خرج کردن پول"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "کاربران تشویق می‌شوند پول واقعی اعانه کنند"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "امکان خرج کردن پول واقعی در کاره"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "بدون امکان چت با دیگر کاربران"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "ارتباط بازیکن با بازیکن بدون امکان گپ"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "امکان گپ نظارت‌شده بین کاربران"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "امکان گپ بدون نظارت بین کاربران"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "بدون امکان صحبت با دیگر کاربران"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "امکان گپ ویدیویی یا صوتی بدون نظارت بین کاربران"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "بدون هم‌رسانی نام‌کاربری شبکه‌های اجتماعی کاربر یا آدرس پست‌های الکترونیکی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "هم‌رسانی نام‌کاربری شبکه‌های اجتماعی کاربر یا آدرس پست‌های الکترونیکی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "بدون هم‌رسانی اطّلاعات کاربر با سوم‌شخص‌ها"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "در حال بررسی برای جدیدترین نگارش برنامه"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "هم‌رسانی داده‌های تشخیصی که نمی‌گذارد دیگران، کاربر را شناسایی کنند"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "هم‌رسانی اطّلاعاتی که به دیگران اجازهٔ شناسایی کاربر را می‌دهد"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "بدون هم‌رسانی موقعیت فیزیکی با دیگر کاربران"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "هم‌رسانی موقعیت فیزیکی با دیگر کاربران"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "بدون اشاره به هم‌جنسگرایی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "اشاره‌های غیرمستقیم به هم‌جنسگرایی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "بوسه میان افراد هم‌جنس"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "رفتار جنسی ترسیمی میان افراد هم‌جنس"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "بدون اشاره به فاحشگی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "اشاره‌های غیرمستقیم به فاحشگی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "اشاره‌های مستقیم به فاحشگی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "ترسیم‌های عمل فاحشگی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "بدون اشاره به زنا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "اشاره‌های غیرمستقیم به زنا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "اشاره‌های مستقیم به زنا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "ترسیم‌های عمل زنا"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "بدون شخثیت‌های جنسیت‌زده"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "شخصیت‌های انسانی کم‌پوشش"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "شخصیت‌های انسانی آشکارا جنسیت‌زده"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "بدون اشاره به هتک حرمت"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "ترسیم یا اشاره به هتک‌حرمت تاریخی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "ترسیم هتک‌حرمت انسانی نوین"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "تصویر هتک‌حرمت نوین"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "بقایای جسد انسانی نانمایان"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "بقایای جسد انسانی نمایان"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "جسدهای انسانی در معرض عناصر"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "ترسیم هتک‌حرمت به جسدهای انسان"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "بدون اشاره به بردگی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "ترسیم یا اشاره به بردگی تاریخی"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "ترسیم بردگی نوین"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "تصویر بردگی نوین"

--- a/po/fa.po
+++ b/po/fa.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-30 18:56+0100\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-06-22 06:20+0000\n"
 "Last-Translator: Alireza Baloochi <alirezab806@gmail.com>\n"
 "Language-Team: Persian\n"
@@ -15,267 +15,530 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "افزودن آیکون های HiDPI به tarball"
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "ارائه اطلاعات بیشتر دیباگ"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
 msgid "Add a cache ID to each component"
 msgstr "افزودن cache ID به هر جز‌ء"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "ارائه نتایج خطا دار در خروجی"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "افزودن آیکون های HiDPI به tarball"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "افزودن آیکون های کدگزاری شده به فایل XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "اضافه شد"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias to %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "ابزار AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "کنسل شد"
-
-msgid "Command not found, valid commands are:"
-msgstr "دستور پیدا نشد، دستور های معتبر عبارتند از:"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "تبدیل %s به %s پیاده سازی نشده است."
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "تبدیل متادیتای AppStream از یک نسخه به نسخه ی دیگر"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "نمونه ای از  فایل AppData از یک فایل .desktop ایجاد می کند."
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "فشرده نکردن آیکون ها درون tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "از دسترسی اینترنت استفاده نکن"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "تمام!"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "تنظیم دایرکتوری logging"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "فعال کردن profiling"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "تنظیم دایرکتوری پکیج ها"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "خطا در ایجاد دایرکتوری خروجی"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "تنظیم دایرکتوری موقت"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "خطا در بارگذاری فایل AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "تنظیم دایرکتوری خروجی"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "خطا در بارگذاری فایل دسکتاپ"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "تنظیم آیکون های دایرکتوری"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "خطا در تجزیه kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "تنظیم دایرکتوری cache"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "خطا در تجزیه provides"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "تنظیم اسم پایه برای فایل های خروجی"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "خطا در تجزیه ترجمه ها"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "تنظیم اسم مبدا"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "خطا در ذخیره فایل AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "تنظیم تعداد Thread ها"
 
-#. list failures
-msgid "FAILED"
-msgstr "با خطا مواجه شد"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "تنظیم حداقل سایز آیکون به پیکسل"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "تنظیم محل متادیتای قدیمی"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "چشم پوشی از بعضی از انواع veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "خطا در افزودن پکیج"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "خطا در بوجود آوردن متادیتا"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "خطا در باز کردن پکیج ها"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "خطا در "
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "خطا در برپایی builder"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "خطا در باز کردن پکیج ها"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "در حال اسکن پکیج ها..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "خطا در افزودن پکیج"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "اتمام تجزیه فایل های %u %u ..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "خطا در بوجود آوردن متادیتا"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "تمام!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "در حال ذخیره کردن آیکون"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "تنظیم پیشوند"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "پردازش برنامه"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "خطا در بارگذاری فایل AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "خطا در تجزیه ترجمه ها"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "خطا در تجزیه kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "خطا در تجزیه provides"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "فایل دسکتاپ نامعتبر است"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "خطا در بارگذاری فایل دسکتاپ"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "خطا در ایجاد دایرکتوری خروجی"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "در حال ذخیره AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "خطا در ذخیره فایل AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias to %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "دستور پیدا نشد، دستور های معتبر عبارتند از:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "لطفا فایل را مجددا بازبینی کنید و آیتم های FIXME را تصحیح کنید"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "نسخه قدیمی API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "نسخه جدید API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Argument ها کافی نیست،نسخه ‌old.xml و new.xml پیشبینی می شود."
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "تبدیل %s به %s پیاده سازی نشده است."
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Argument ها کافی نیست،‌file.xml پیش بینی میشود"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "فرمت فایل '%s' قابل ارتقا نیست"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "فرمت شناخته نشد"
 
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "چشم پوشی از بعضی از انواع veto"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "ارائه نتایج خطا دار در خروجی"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "فایل دسکتاپ نامعتبر است"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "نسخه جدید API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "هیچ اپلیکیشن دسکتاپی پیدا نشد"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Argument ها کافی نیست،‌file.xml پیش بینی میشود"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Argument ها کافی نیست،نسخه ‌old.xml و new.xml پیشبینی می شود."
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "نسخه قدیمی API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "با خطا مواجه شد"
 
-#. TRANSLATORS: information message
-#, c-format
-msgid "Parsed %u/%u files..."
-msgstr "اتمام تجزیه فایل های %u %u ..."
-
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "لطفا فایل را مجددا بازبینی کنید و آیتم های FIXME را تصحیح کنید"
-
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "پردازش برنامه"
-
-#. TRANSLATORS: application was removed
-msgid "Removed"
-msgstr "برداشته شد"
-
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "در حال ذخیره AppStream"
-
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "در حال ذخیره کردن آیکون"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "در حال اسکن پکیج ها..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "جست و جو در برنامه های AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "تنظیم اسم پایه برای فایل های خروجی"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "تنظیم دایرکتوری cache"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "تنظیم آیکون های دایرکتوری"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "تنظیم دایرکتوری logging"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "تنظیم حداقل سایز آیکون به پیکسل"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "تنظیم تعداد Thread ها"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "تنظیم محل متادیتای قدیمی"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "تنظیم اسم مبدا"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "تنظیم دایرکتوری خروجی"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "تنظیم دایرکتوری پکیج ها"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "تنظیم پیشوند"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "تنظیم دایرکتوری موقت"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "ارائه اطلاعات بیشتر دیباگ"
-
-#. TRANSLATORS: command line option
-msgid "Show version"
-msgstr "نشان دادن نسخه"
-
-#. TRANSLATORS: command description
-msgid "Upgrade AppData metadata to the latest version"
-msgstr "ارتقای متادیتای AppData به آخرین نسخه"
-
+#: client/as-util.c:2812
 msgid "Validation failed"
 msgstr "بررسی صحت با خطا رو به رو شد"
 
+#: client/as-util.c:2856
 msgid "Validation of files failed"
 msgstr "بررسی فایل ها با خطا رو به رو شد"
 
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "بررسی صحت با خطا رو به رو شد"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "بررسی فایل ها با خطا رو به رو شد"
+
+#. TRANSLATORS: application was removed
+#: client/as-util.c:4076
+msgid "Removed"
+msgstr "برداشته شد"
+
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "اضافه شد"
+
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "کنسل شد"
+
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "از دسترسی اینترنت استفاده نکن"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4432
+msgid "Show version"
+msgstr "نشان دادن نسخه"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "فعال کردن profiling"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "تبدیل متادیتای AppStream از یک نسخه به نسخه ی دیگر"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4473
+msgid "Upgrade AppData metadata to the latest version"
+msgstr "ارتقای متادیتای AppData به آخرین نسخه"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "نمونه ای از  فایل AppData از یک فایل .desktop ایجاد می کند."
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "جست و جو در برنامه های AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+#, fuzzy
+msgid "Search for AppStream applications by package name"
+msgstr "جست و جو در برنامه های AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "جست و جو در برنامه های AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "جست و جو در برنامه های AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+#, fuzzy
+msgid "Installs AppStream metadata with new origin"
+msgstr "تبدیل متادیتای AppStream از یک نسخه به نسخه ی دیگر"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
+msgid "Validate an AppData or AppStream file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4569
+msgid "Validate an AppData or AppStream file (relaxed)"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
+msgid "Validate an AppData or AppStream file (strict)"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+msgid "Validate that AppData file includes the specified release"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "پردازش برنامه"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+#, fuzzy
+msgid "Modify an AppData file"
+msgstr "خطا در بارگذاری فایل AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+#, fuzzy
+msgid "Merge several files to an AppStream file"
+msgstr "خطا در ذخیره فایل AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "جست و جو در برنامه های AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "ابزار AppStream"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "نسخه:"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,10 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2017-03-26 08:23+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
-"Language-Team: Finnish (http://www.transifex.com/freedesktop/appstream-glib/language/fi/)\n"
+"Language-Team: Finnish (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/fi/)\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,114 +23,538 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Zanata 4.6.2\n"
 
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Lisää kieli lähdetiedostoon"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
+msgid "Add encoded icons to the XML"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:91
+msgid "Do not compress the icons into a tarball"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
+#, fuzzy
+msgid "Failed to parse arguments"
+msgstr "Paketin lisääminen epäonnistui"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:246
+msgid "Failed to set up builder"
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+#, fuzzy
+msgid "Failed to open packages"
+msgstr "Paketin lisääminen epäonnistui"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Paketin lisääminen epäonnistui"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr ""
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Valmis!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Tallennetaan kuvake"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr ""
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr ""
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Virhe ladatessa AppData-tiedostoa"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Virhe jäsentäessä kielikäännöksiä"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+#, fuzzy
+msgid "Error parsing kudos"
+msgstr "Virhe jäsentäessä kielikäännöksiä"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+#, fuzzy
+msgid "Error parsing provides"
+msgstr "Virhe jäsentäessä kielikäännöksiä"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Virhe ladatessa desktop-tiedostoa"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Virhe ladatessa desktop-tiedostoa"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr ""
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Tallennetaan AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Virhe tallentaessa AppStream-tiedostoa"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr ""
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Komentoa ei löydy, kelvolliset komennot ovat:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr ""
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Vanha API-versio"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Uusi API-versio"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr ""
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr ""
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr ""
+
+#. TRANSLATORS: %s is a file type,
+#. * e.g. 'appdata'
+#: client/as-util.c:595
+#, c-format
+msgid "File format '%s' cannot be upgraded"
+msgstr ""
+
+#. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
+msgid "Format not recognised"
+msgstr "Muotoa ei tunnistettu"
+
+#. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
+msgid "No desktop applications found"
+msgstr ""
+
+#. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
+msgid "OK"
+msgstr "OK"
+
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "EPÄONNISTUI"
+
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Vahvistaminen epäonnistui"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Tiedostojen vahvistaminen epäonnistui"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Vahvistaminen epäonnistui"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Tiedostojen vahvistaminen epäonnistui"
+
+#. TRANSLATORS: application was removed
+#: client/as-util.c:4076
+msgid "Removed"
+msgstr "Poistettu"
 
 #. TRANSLATORS: application was added
+#: client/as-util.c:4089
 msgid "Added"
 msgstr "Lisätty"
 
 #. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
 msgid "Cancelled"
 msgstr "Peruttu"
 
-msgid "Command not found, valid commands are:"
-msgstr "Komentoa ei löydy, kelvolliset komennot ovat:"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4432
+msgid "Show version"
+msgstr "Näytä versio"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr ""
 
 #. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Luo CSV-tila-asiakirja"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr ""
 
 #. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Luo HTML-tilasivu"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Valmis!"
-
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Virhe ladatessa AppData-tiedostoa"
-
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Virhe ladatessa desktop-tiedostoa"
-
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Virhe jäsentäessä kielikäännöksiä"
-
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Virhe tallentaessa AppStream-tiedostoa"
-
-#. list failures
-msgid "FAILED"
-msgstr "EPÄONNISTUI"
-
-#. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Paketin lisääminen epäonnistui"
-
-#. TRANSLATORS: not a recognised file type
-msgid "Format not recognised"
-msgstr "Muotoa ei tunnistettu"
+#: client/as-util.c:4473
+msgid "Upgrade AppData metadata to the latest version"
+msgstr ""
 
 #. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Yhdistä useita tiedostoja AppStream-tiedostoon"
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
 
 #. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Muokkaa AppData-tiedostoa"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Uusi API-versio"
-
-#. TRANSLATORS: the file is valid
-msgid "OK"
-msgstr "OK"
-
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Vanha API-versio"
-
-#. TRANSLATORS: application was removed
-msgid "Removed"
-msgstr "Poistettu"
-
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Tallennetaan AppStream"
-
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Tallennetaan kuvake"
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr ""
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4491
 msgid "Search for AppStream applications"
 msgstr "Etsi AppStream-sovelluksia"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4497
+#, fuzzy
+msgid "Search for AppStream applications by package name"
+msgstr "Etsi AppStream-sovelluksia"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
 msgid "Show all installed AppStream applications"
 msgstr "Näytä kaikki asennetut AppStream-sovellukset"
 
-#. TRANSLATORS: command line option
-msgid "Show version"
-msgstr "Näytä versio"
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "Etsi AppStream-sovelluksia"
 
-msgid "Validation failed"
-msgstr "Vahvistaminen epäonnistui"
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr ""
 
-msgid "Validation of files failed"
-msgstr "Tiedostojen vahvistaminen epäonnistui"
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr ""
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+#, fuzzy
+msgid "Uninstalls AppStream metadata"
+msgstr "Näytä kaikki asennetut AppStream-sovellukset"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Luo HTML-tilasivu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Luo CSV-tila-asiakirja"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+#, fuzzy
+msgid "Create an HTML matrix page"
+msgstr "Luo HTML-tilasivu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
+msgid "Validate an AppData or AppStream file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4569
+msgid "Validate an AppData or AppStream file (relaxed)"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
+msgid "Validate an AppData or AppStream file (strict)"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+msgid "Validate that AppData file includes the specified release"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+#, fuzzy
+msgid "Check installed application data"
+msgstr "Näytä kaikki asennetut AppStream-sovellukset"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Näytä kaikki asennetut AppStream-sovellukset"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+#, fuzzy
+msgid "Add a provide to a source file"
+msgstr "Lisää kieli lähdetiedostoon"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Lisää kieli lähdetiedostoon"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+#, fuzzy
+msgid "Compare the contents of two AppStream files"
+msgstr "Yhdistä useita tiedostoja AppStream-tiedostoon"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Muokkaa AppData-tiedostoa"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Yhdistä useita tiedostoja AppStream-tiedostoon"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+#, fuzzy
+msgid "Import a file to AppStream markup"
+msgstr "Yhdistä useita tiedostoja AppStream-tiedostoon"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "Etsi AppStream-sovelluksia"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr ""
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versio:"

--- a/po/fi.po
+++ b/po/fi.po
@@ -558,3 +558,544 @@ msgstr ""
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versio:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Yleinen"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "KAIKKI"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Vain aikuiset"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Aikuiset"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Teinit"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "10+-vuotiaat"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Kaikki"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Varhaislapsuus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Ei piirroksilla esitettävää väkivaltaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Piirroshahmoja vaarallisissa tilanteissa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Piirroshahmot aggressiivisessa ristiriidassa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Graafista väkivaltaa, johon liittyy piirroshahmoja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Ei fantasiaan liittyvää väkivaltaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Hahmoja vaarallisissa tilanteissa, helposti todellisuudesta erotettavissa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Hahmoja aggressiivisessa ristiriidassa, helposti todellisuudesta "
+"erotettavissa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Graafista väkivaltaa, helposti todellisuudesta erotettavissa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Ei realistista väkivaltaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Tunnistettavia hahmoja vaarallisissa tilanteissa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Kuvauksia todellisista hahmoista aggressiivisessa ristiriidassa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Graafista väkivaltaa, johon sisältyy todellisia hahmoja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Ei verilöylyä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Epärealistinen verilöyly"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistinen verilöyly"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Kuvauksia verilöylystä ja ruumiinosien silpomista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Ei seksuaalista väkivaltaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Raiskaus tai muuta väkivaltaista seksuaalista käytöstä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Ei viittauksia alkoholituotteisiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Viittauksia alkoholituotteisiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Alkoholin käyttöä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Ei viittauksia laittomiin huumausaineisiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Viittauksia laittomiin huumausaineisiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Laittomien huumausaineiden käyttöä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Ei viittauksia tupakkatuotteisiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Viittauksia tupakkatuotteisiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Tupakan polttamista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Ei minkäänlaista alastomuutta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Hetkellistä taiteellista alastomuutta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Pitkäkestoista alastomuutta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Ei seksuaalisia viittauksia tai kuvauksia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokatiivisia viittauksia tai kuvauksia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Seksuaalisia viittauksia tai kuvauksia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Graafista seksuaalista käytöstä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Ei minkäänlaista kiroilua"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Vähäistä tai epäsäännöllistä kiroilua"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Keskitason kiroilua"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Vahvaa tai säännöllistä kiroilua"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Ei epäasiallista huumoria"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Kermakakkukomiikkaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Alatyylistä wc-huumoria"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Aikuismaista tai seksuaalista huumoria"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Ei minkäänlaista syrjivää kieltä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Kielteisyyttä tiettyä ihmisryhmää kohtaan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Syrjintää tarkoituksena aiheuttaa tunteellista epämukavuutta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Syrjintää kohdistuen sukupuoleen, seksuaalisuuteen, rotuun tai uskontoon"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Ei minkäänlaisia mainoksia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Tuotesijoittelua"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Selkeitä viittauksia tiettyyn brändiin tai tavaramerkkiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Käyttäjiä kehotetaan ostamaan tiettyjä todellisia esineitä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Ei minkäänlaista uhkapeliä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Satunnaista uhkapeliä pelinappuloita käyttäen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Uhkapeliä käyttäen pelin sisäistä rahaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Uhkapeliä käyttäen oikeaa rahaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Ei mahdollisuutta käyttää oikeaa rahaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Käyttäjiä kehotetaan lahjoittamaan oikeaa rahaa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Mahdollisuus käyttää oikeaa rahaa sovelluksessa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Ei mahdollisuutta keskustella muiden käyttäjien kanssa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Käyttäjien välistä vuorovaikutusta ilman keskustelumahdollisuutta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Valvottu keskusteluominaisuus käyttäjien välillä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Valvomaton keskusteluominaisuus käyttäjien välillä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Ei mahdollisuutta puhua muiden käyttäjien kanssa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Valvomaton ääni- tai videokeskusteluominaisuus käyttäjien välillä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Ei sosiaalisen median käyttäjätunnusten tai sähköpostiosoitteiden jakamista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Sosiaalisen median käyttäjätunnusten tai sähköpostiosoitteiden jakamista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Ei käyttäjätiedon jakamista kolmansien osapuolten kanssa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Tarkistetaan viimeisintä sovellusversiota"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "Jakaa diagnostiikkatietoja, jotka eivät ole yhdistettävissä käyttäjään"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Jakaa käyttäjään yhdistettävissä olevia tietoja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Ei fyysisen sijainnin jakamista muille käyttäjille"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Fyysisen sijainnin jakamista muille käyttäjille"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Ei viittauksia homoseksuaalisuuteen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Epäsuoria viittauksia homoseksuaalisuuteen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Suutelua samaa sukupuolta olevien kesken"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Graafista seksuaalista käyttäytymistä samaa sukupuolta olevien kesken"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Ei viittauksia prostituutioon"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Epäsuoria viittauksia prosituutioon"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Suoria viittauksia prosituutioon"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Graafisia kuvauksia prostituutioon liittyvistä toimista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Ei viittauksia haureuteen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Epäsuoria viittauksia haureuteen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Suoria viittauksia haureuteen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Graafisia kuvauksia haureuteen liittyvistä toimista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Ei seksualisoituja hahmoja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Vähävaatteisia ihmishahmoja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Avoimesti seksualisoituja ihmishahmoja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Ei viittauksia häpäisyyn"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Kuvauksia tai viittauksia historialliseen häpäisyyn"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Kuvauksia nykypäivän ihmishäpäisystä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Graafisia kuvauksia nykypäivän häpäisystä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Ei näkyviä kuolleen ihmisen jäännöksiä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Näkyviä kuolleen ihmisen jäännöksiä"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Kuolleen ihmisen jäännöksiä, jotka altistetaan elementeille"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Graafisia kuvauksia tai häpäisyä liittyen ihmisruumiisiin"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Ei viittauksia orjuuteen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Kuvauksia tai viittauksia historialliseen orjuuteen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Kuvauksia nykypäivän orjuudesta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Graafisia kuvauksia nykypäivän orjuudesta"

--- a/po/fr.po
+++ b/po/fr.po
@@ -545,3 +545,547 @@ msgstr "Utilitaire AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version :"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Général"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "TOUS"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Adultes uniquements"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Mature"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Adolescents"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "10 ans et plus"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Tout le monde"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Bas âge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Aucune violence de dessins animés"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personnages de dessins animés en situation de danger"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personnages de dessins animés en conflit agressif"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Illustration de violences impliquant les personnages de dessins animés"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Pas de violences fantastiques"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Personnages en situations dangereuses franchement irréelles"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Personnages en situation de conflit agressif franchement irréel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Illustration violente franchement irréelle"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Aucune violence réaliste"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personnages moyennement réalistes en situation dangereuse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Illustrations de personnages réalistes en conflit agressif"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Illustrations de violences impliquant des personnages réalistes"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Aucun massacre"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Massacre irréaliste"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Massacre réaliste"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Illustrations d’un massacre et de mutilations corporelles"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Aucune violence sexuelle"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Viol ou autre comportement sexuel violent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Aucune allusion à des boissons alcoolisées"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Allusions à des boissons alcoolisées"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Usage de boissons alcoolisées"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Aucune allusion à des stupéfiants illicites"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Allusions à des stupéfiants illicites"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Usage de stupéfiants illicites"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Aucune allusion à des produits dérivés du tabac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Allusions à des produits dérivés du tabac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Usage de produits dérivés du tabac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Aucun nu d’aucune sorte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Nu artistique de courte durée"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "État de nudité prolongée"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Aucune allusion ou image à caractère sexuel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Allusions ou images provocatrices"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Allusions ou images à caractère sexuel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Illustrations de comportements sexuels"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Aucune profanation d’aucune sorte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Utilisation modérée ou occasionnelle d’injures"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Utilisation modérée d’injures"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Utilisation forte ou fréquente d’injures"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Aucun humour déplacé"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Humour burlesque"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Humour vulgaire ou de caniveau"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humour pour adultes ou sexuel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Aucune allusion discriminatoire d’aucune sorte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Attitudes négatives vis à vis de groupes spécifiques de gens"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminations destinées à blesser émotionnellement"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Discriminations explicites basées sur le genre, le sexe, la race ou la "
+"religion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Aucune publicité d’aucune sorte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Placement de produits"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Allusions explicites à des produits de marque spécifique ou déposée"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr ""
+"Les utilisateurs sont encouragés à acheter des éléments spécifiques du monde "
+"réel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Aucun pari d’aucune sorte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Paris sur des événements aléatoires à l’aide de jetons ou à crédit"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Paris avec de la monnaie « fictive »"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Paris avec du vrai argent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Aucune possibilité de dépenser de l’argent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Les utilisateurs sont encouragés à donner de l’argent réel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Possibilité de dépenser du vrai argent dans l’application"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Aucune possibilité de discuter avec les autres utilisateurs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interactions entre utilisateurs sans possibilité de discussion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Possibilité modérée de discuter entre utilisateurs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Possibilité de discuter sans contrôle entre utilisateurs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Aucun moyen de parler avec les autres utilisateurs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Possibilité de discuter ou se voir sans contrôle entre utilisateurs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Aucun partage des noms d’utilisateur de réseaux sociaux ou des adresses "
+"courriel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Partage des noms d’utilisateur de réseaux sociaux ou des adresses courriel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Aucun partage des identifiants d’utilisateur avec des tierces parties"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Vérification s’il s’agit de la dernière version de l’application"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Partage des données de diagnostic ne permettant pas l’identification de "
+"l’utilisateur"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Partage d’informations permettant l’identification de l’utilisateur"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Aucun partage de géolocalisation avec les autres utilisateurs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Partage de géolocalisation avec les autres utilisateurs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Aucune allusion à l’homosexualité"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Allusions indirectes à l’homosexualité"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Étreintes entre personnes d’un même sexe"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Images de comportements sexuels entre personnes d’un même sexe"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Aucune allusion à la prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Allusions indirectes à la prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Allusions directes à la prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Images d’actes de prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Aucune allusion à l’adultère"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Allusions indirectes à l’adultère"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Allusions directes à l’adultère"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Images d’actes d’adultère"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Représentations humaines à caractère non sexuel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Représentations humaines légèrement vêtues"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Représentations humaines à caractère ouvertement sexuel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Aucune allusion à de la profanation"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Allusions ou images de profanations historiques"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Représentations d’actes de profanation contemporains sur humains"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Images d’actes de profanation contemporains sur humains"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Aucune image de restes humains"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Images de restes humains"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Restes humains exposés aux éléments"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Images de profanations sur des corps humains"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Aucune allusion à l’esclavagisme"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Représentations ou allusions à l’esclavagisme historique"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Représentations d’esclavagisme contemporain"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Images d’esclavagisme contemporain"

--- a/po/fr.po
+++ b/po/fr.po
@@ -11,10 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-01-21 08:07+0000\n"
 "Last-Translator: Jean-Baptiste Holcroft <jean-baptiste@holcroft.fr>\n"
-"Language-Team: French (http://www.transifex.com/freedesktop/appstream-glib/language/fr/)\n"
+"Language-Team: French (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/fr/)\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,403 +24,524 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Affiche des informations de débogage supplémentaires"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Ajoute un identifiant de cache à chaque composant"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Inclut les résultats qui ont échoué dans la sortie"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Ajoute les icônes haute définition dans l’archive tar"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Ajoute un identifiant de cache à chaque composant"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Ajoute une langue à un fichier source"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Ajoute une fourniture à un fichier source"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Ajoute les icônes codées dans le XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Ajoutée"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias de %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitaire AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Annulé"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Vérifie les données des applications installées"
-
-msgid "Command not found, valid commands are:"
-msgstr "Commande introuvable, les commandes valides sont :"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Compare le contenu de deux fichiers AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Compare les numéros de version"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "La conversion de %s vers %s n’est pas implémentée"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Convertit un fichier AppData au format NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Convertit un fichier NEWS au format AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Convertit les métadonnées AppStream d’une version à une autre"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Crée un document de synthèse CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Crée une page HTML avec matrice"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Crée une page de synthèse HTML"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Crée un fichier Appdata exemple à partir d’un fichier .desktop"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Affiche les jetons de recherche des applications"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Ne compresse pas les icônes dans une archive tar"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Ne pas utiliser l’accès réseau"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Terminé !"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Exporte les applications dans les métadonnées AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Définit le répertoire de journalisation"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Active le profilage"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Définit le répertoire des paquets"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Erreur lors de la création du répertoire de sortie"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Définit le répertoire temporaire"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Erreur lors du chargement du fichier AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Définit le répertoire de sortie"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Erreur lors du chargement du fichier desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Définit le répertoire des icônes"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Erreur lors de l’analyse des kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Définit le répertoire de cache"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Erreur lors de l’analyse des fournitures apportées par les paquets RPM"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Définit les noms de base des fichiers de sortie"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Erreur lors de l’analyse des traductions"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Définit le nom d’origine"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Erreur lors de l’enregistrement du fichier AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Définit le nombre de fils d’exécution"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Exporte l'accord au format texte"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Définit la taille minimale des icônes en pixels"
 
-#. list failures
-msgid "FAILED"
-msgstr "ÉCHEC"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Définit l’ancien emplacement des métadonnées"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignore certains types de veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "L’ajout du paquet a échoué"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "La génération de métadonnées a échoué"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Échec d’ouverture des paquets"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Échec de l’analyse des paramètres"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Échec de configuration du constructeur"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Échec d’ouverture des paquets"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Analyse des paquets…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "L’ajout du paquet a échoué"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "%u/%u fichiers analysés…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "La génération de métadonnées a échoué"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Terminé !"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Enregistrement de l’icône"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Définit le préfixe"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Traitement de l’application"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Erreur lors du chargement du fichier AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Erreur lors de l’analyse des traductions"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Erreur lors de l’analyse des kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Erreur lors de l’analyse des fournitures apportées par les paquets RPM"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Nom de fichier desktop non valide"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Erreur lors du chargement du fichier desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Erreur lors de la création du répertoire de sortie"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Enregistrement de AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Erreur lors de l’enregistrement du fichier AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias de %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Commande introuvable, les commandes valides sont :"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Veuillez réviser le fichier et résoudre les éléments « FIXME »"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Ancienne version d’API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nouvelle version d’API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Paramètres insuffisants, indiquez ancien.xml nouveau.xml version"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "La conversion de %s vers %s n’est pas implémentée"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Paramètres insuffisants, file.xml est attendu"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Le format de fichier « %s » ne peut pas être mis à niveau"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Format non reconnu"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Génère un GUID à partir d’une chaîne fournie"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignore certains types de veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importe un fichier en balisage AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Inclut les résultats qui ont échoué dans la sortie"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorpore des métadonnées supplémentaires à partir d’un fichier externe"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Installe les métadonnées AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Installe les métadonnées AppStream d’une nouvelle origine"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Nom de fichier desktop non valide"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Liste les applications non basées sur des paquets"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Fusionne plusieurs fichiers en un fichier AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Réplique les captures d’écran amont"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modifie un fichier AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nouvelle version d’API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Aucune application de bureau trouvée"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Paramètres insuffisants, file.xml est attendu"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Paramètres insuffisants, indiquez ancien.xml nouveau.xml version"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Ancienne version d’API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "ÉCHEC"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "La validation a échoué"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "La validation des fichiers a échoué"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "%u/%u fichiers analysés…"
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Veuillez réviser le fichier et résoudre les éléments « FIXME »"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "La validation a échoué"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Traitement de l’application"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "La validation des fichiers a échoué"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Supprimée"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Remplace les captures d’écran dans le fichier source"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Ajoutée"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Enregistrement de AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Annulé"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Enregistrement de l’icône"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Analyse des paquets…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Recherche des applications AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Recherche des applications AppStream par nom de catégorie"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Recherche des applications AppStream par nom de paquet"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Ne pas utiliser l’accès réseau"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Définit les noms de base des fichiers de sortie"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Définit le répertoire de cache"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Définit le répertoire des icônes"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Définit le répertoire de journalisation"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Définit la taille minimale des icônes en pixels"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Définit le nombre de fils d’exécution"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Définit l’ancien emplacement des métadonnées"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Définit le nom d’origine"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Définit le répertoire de sortie"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Définit le répertoire des paquets"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Définit le préfixe"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Définit le répertoire temporaire"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Affiche toutes les applications AppStream installées"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Affiche des informations de débogage supplémentaires"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Affiche la version"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Divise un fichier AppStream en fichiers AppData et Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Active le profilage"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Teste une expression régulière"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Convertit les métadonnées AppStream d’une version à une autre"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Désinstalle les métadonnées AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Met à jour les métadonnées AppData à la dernière version"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Crée un fichier Appdata exemple à partir d’un fichier .desktop"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Exporte les applications dans les métadonnées AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Recherche des applications AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Recherche des applications AppStream par nom de paquet"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Affiche toutes les applications AppStream installées"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Recherche des applications AppStream par nom de catégorie"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Affiche les jetons de recherche des applications"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Installe les métadonnées AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Installe les métadonnées AppStream d’une nouvelle origine"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Désinstalle les métadonnées AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Crée une page de synthèse HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Crée un document de synthèse CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Crée une page HTML avec matrice"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Liste les applications non basées sur des paquets"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Valide un fichier AppData ou AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Valide un fichier AppData ou AppStream (laxiste)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Exporte l'accord au format texte"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Valide un fichier AppData ou AppStream (strict)"
 
-msgid "Validation failed"
-msgstr "La validation a échoué"
-
-msgid "Validation of files failed"
-msgstr "La validation des fichiers a échoué"
-
-msgid "Version:"
-msgstr "Version :"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Valide un fichier AppData ou AppStream (laxiste)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Convertit un fichier AppData au format NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Convertit un fichier NEWS au format AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Vérifie les données des applications installées"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "Vérifie une application installée"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Remplace les captures d’écran dans le fichier source"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Ajoute une fourniture à un fichier source"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Ajoute une langue à un fichier source"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Réplique les captures d’écran amont"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr ""
+"Incorpore des métadonnées supplémentaires à partir d’un fichier externe"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Compare le contenu de deux fichiers AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Génère un GUID à partir d’une chaîne fournie"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modifie un fichier AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Divise un fichier AppStream en fichiers AppData et Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Fusionne plusieurs fichiers en un fichier AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importe un fichier en balisage AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Surveille les modifications dans les emplacements AppStream"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "Vérifie une application installée"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Compare les numéros de version"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Teste une expression régulière"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitaire AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Version :"

--- a/po/fur.po
+++ b/po/fur.po
@@ -537,3 +537,542 @@ msgstr "Utilitât AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Gjenerâl"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "DUCJ"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Dome grancj"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Madûr"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Fantat"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Ducj parsore dai 10"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Ducj"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Prime infanzie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Nissune violence dai cartons animâts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personaçs di cartons animâts in situazions pericolosis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personaçs di cartons animâts in conflit violent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Grafiche di violence che e cjape dentri personaçs di cartons animâts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Nissune violence fantasy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Personaçs in situazions pericolosis facilis di distingui de realtât"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Personaçs in conflit violent facil di distingui de realtât"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Grafiche di violence facil di distingui de realtât"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Nissune violence realistiche"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personaçs un pôc realistics in situazions pericolosis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Figuris di personaçs realistics in conflit violent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Grafiche di violence che e cjape dentri personaçs realistics"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Nissun maçament"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Maçaments no realistics"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Maçaments realistics"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Figuris di sassinaments e mutilazions di tocs di cuarp"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Nissune violence sessuâl"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Stupri o altris compuartaments sessuâi violents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Nissun riferiment a bevandis alcolichis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Riferiments a bevandis alcolichis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Ûs di bevandis alcolichis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Nissun riferiment a droghis ilecitis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Riferiments a droghis ilecitis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Ûs ilecit di droghis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Nissun riferiment a prodots derivâts dal tabac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Riferiments a tabacs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Ûs di tabacs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Nissune crotarie di cualsisei gjenar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Curte crotarie artistiche"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Crotarie sprolungjade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Nissun riferiment a o rafigurazions di nature sessuâl"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Figuris o riferiments provocants"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Riferiments o figuris sessuâi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Grafiche di compuartaments sessuâi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Nissune blasfemie di cualsisei gjenar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Ûs lizêr o no frecuent di profanitâts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Ûs moderât di blasfemie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Ûs frecuent e fuart di blasfemie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Nissun umorisim sconvenient"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Umorisim di comedie grese"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Umorisim volgâr o di cesso"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Umorisim soç o par grancj"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Nissun lengaç discriminatori di cualsisei gjenar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negativitât viers un specific grup di personis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminazion pensade par fâ mâl emotivamentri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Discriminazion esplicite basade su gjenar, sessualitât, raze o religjon"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Nissune publicitât di cualsisei gjenar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Vendite di prodots"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Riferiments esplicits a marcjis specifichis o prodots firmâts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "I utents a son incitâts a comprâ ogjets reâi specifics"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Nissun zûc di azart di cualsisei gjenar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Zûc di azart su events casuâi che al dopre gjetons o credits"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Zûc di azart che al dopre bêçs “dal zûc”"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Zûc di azart che al dopre bêçs vêrs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Nissune pussibilitât di spindi bêçs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "I utents a son incitâts a donâ bêçs vêrs"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Abilitât di spindi bêçs vêrs inte aplicazion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Nissune maniere par chatâ cun altris utents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interazions tra utents cence funzionalitât di chat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Funzionalitât no controllade di chat tra utents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Funzionalitât no controllade di chat tra utents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Nissune maniere par cjacarâ cun altris utents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Funzionalitât no controllade di chat video o audio tra utents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Nissune condivision di nons utent di social network o direzions e-mail"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Condivision di nons utent di social network o direzions e-mail"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Nissune condivision di informazions dal utent cun tiercis parts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Control pe ultime version de aplicazion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Condivision di dâts diagnostics che no permetin a altris di identificâ "
+"l'utent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Condivision di dâts diagnostics che a permetin a altris di identificâ l'utent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Nissune condivision di posizion fisiche cun altris utents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Condivision posizion fisiche cun altris utents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Nissun riferiment a omosessualitât"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Riferiments indirets ae omosessualitât"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Bussadis tra personis dal stes ses"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Compuartament sessuâl grafic tra personis dal stes ses"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Nissun riferiment a prostituzion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Riferiments indirets ae prostituzion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Riferiments direts ae prostituzion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Rapresentazions grafichis dal at di prostituzion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Nissun riferiment a adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Riferiments indirets al adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Riferiment direts al adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Rapresentazions grafichis dal at di adulteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Nissun personaç sessuât"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Personaçs umans pôc vistîts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Personaçs umans sessuâts in maniere anomale"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Nissun riferiment a profanazion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Rapresentazions o riferiments a profanazions storichis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Rapresentazion di profanazion umane moderne"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Rapresentazions grafichis di profanazion moderne"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Nissun rest visibil di oms muarts"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Rescj di oms muarts visibii"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Rescj di oms muarts che a son esposcj ai elements"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Rapresentazions grafichis di profanazion di cuarps umans"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Nissun riferiment a sclavitût"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Rapresentazions o riferiments a sclavitût storiche"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Rapresentazions de sclavitût moderne"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Rapresentazions grafichis de sclavitût moderne"

--- a/po/fur.po
+++ b/po/fur.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-03-21 04:19+0000\n"
 "Last-Translator: Fabio Tomat <f.t.public@gmail.com>\n"
 "Language-Team: Friulian\n"
@@ -16,391 +16,524 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Mostre informazions di debug adizionâls"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Zonte un ID di cache par ogni component"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Inclût i risultâts falîts te jessude/stampe"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Zonte iconis HiDPI al tarball"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Zonte un ID di cache par ogni component"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Zonte une lenghe a un file sorzint"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Zonte une furnidure a un file sorzint"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Zonte iconis codificadis al XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Zontade"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias a %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitât AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Anulade"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Controle i dâts de aplicazion instalade"
-
-msgid "Command not found, valid commands are:"
-msgstr "Comant no cjatât, i comants valits a son:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Confronte i contignûts di doi file AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Confronte numars di version"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "La conversion %s a %s no je implementade"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Convertìs un file AppData al formât NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Convertìs un file NEWS al formât AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Al convertìs i metadâts AppStream di une version a une altre"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Cree un document di stât in formât CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Cree une pagjine di matriç in formât HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Cree une pagjine di stât in formât HTML"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Mostre i token di ricercje aplicazions"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "No sta comprimi lis iconis intun tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "No sta doprâ l'acès ae rêt"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Fat!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Al discjarie lis aplicazions tai metadâts AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Stabilìs la cartele di regjistrazion"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Abilite il profilament"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Stabilìs la cartele dai pachets"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Erôr tal creâ la cartele di jessude"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Stabilìs la cartele temporanie"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Erôr tal cjariâ il file AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Stabilìs la cartele di jessude"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Erôr tal cjariâ il file desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Stabilìs la cartele des iconis"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Erôr tal analizâ i kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Stabilìs la cartele de cache"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Erôr tal analizâ i provides"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Stabilìs il non di base dai file di jessude"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Erôr tal analizâ lis traduzions"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Stabilìs il non de origjin"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Erôr tal salvâ il file AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Stabilìs il numar di thread"
 
-#. list failures
-msgid "FAILED"
-msgstr "FALÎT"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Stabilìs la dimension di icone minime in pixel"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Stabilìs la vecje posizion dai metadâts"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignore cierts gjenars di veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "No si è rivâts a zontâ il pachet"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "No si è rivâts a gjenerâ i metadâts"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "No si è rivâts a vierzi i pachets"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "No si è rivâts a analizâ i argoments"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "No si è rivâts a meti impins il gjeneradôr"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "No si è rivâts a vierzi i pachets"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Analisi dai pachets..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "No si è rivâts a zontâ il pachet"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Analizât %u/%u file..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "No si è rivâts a gjenerâ i metadâts"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Fat!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Salvament icone"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Stabilìs il prefìs"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Elaborazion aplicazion"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Erôr tal cjariâ il file AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Erôr tal analizâ lis traduzions"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Erôr tal analizâ i kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Erôr tal analizâ i provides"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Erôr tal cjariâ il file desktop"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Erôr tal cjariâ il file desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Erôr tal creâ la cartele di jessude"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Salvament AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Erôr tal salvâ il file AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias a %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Comant no cjatât, i comants valits a son:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Controle il file e comede ducj i elements 'FIXME'"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Version de API vecje"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Version de API gnove"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "No vonde argoments, si spietave version vieli.xml gnûf.xml"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "La conversion %s a %s no je implementade"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "No vonde argoments, si spietave file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Il formât di file '%s' nol pues jessi inzornât"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Formât no ricognossût"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Gjenere un GUID partint di une stringhe di jentrade"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignore cierts gjenars di veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Impuarte un file a segnalazion(markup) AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Inclût i risultâts falîts te jessude/stampe"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorpore metadâts adizionâi di un file esterni"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Al instale metadâts AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Al Instale metadâts AppStream cun gnove origjin"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Liste di aplicazions no supuartadis di pachets"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Unìs plui file intun file AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Copie lis caturis di schermi upstream"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modifiche un file AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Version de API gnove"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nissune aplicazion scritori cjatade"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "No vonde argoments, si spietave file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "No vonde argoments, si spietave version vieli.xml gnûf.xml"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Version de API vecje"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FALÎT"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validazion falide"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "No si è rivâts a validâ i file"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Analizât %u/%u file..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Controle il file e comede ducj i elements 'FIXME'"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validazion falide"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Elaborazion aplicazion"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "No si è rivâts a validâ i file"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Gjavade"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Sostituìs une cature di schermi tal file sorzint"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Zontade"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Salvament AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Anulade"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Salvament icone"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Analisi dai pachets..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Cîr aplicazions AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Cîr aplicazions AppStream par non di categorie"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Cîr aplicazions AppStream par non di pachet"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "No sta doprâ l'acès ae rêt"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Stabilìs il non di base dai file di jessude"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Stabilìs la cartele de cache"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Stabilìs la cartele des iconis"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Stabilìs la cartele di regjistrazion"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Stabilìs la dimension di icone minime in pixel"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Stabilìs il numar di thread"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Stabilìs la vecje posizion dai metadâts"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Stabilìs il non de origjin"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Stabilìs la cartele di jessude"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Stabilìs la cartele dai pachets"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Stabilìs il prefìs"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Stabilìs la cartele temporanie"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Mostre dutis lis aplicazions AppStream instaladis"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Mostre informazions di debug adizionâls"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Mostre version"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Divît un file AppStream in file AppData e Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Abilite il profilament"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Prove une espression regolâr"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Al convertìs i metadâts AppStream di une version a une altre"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Al disinstale metadâts AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Inzorne i metadâts AppData ae ultime version"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Al discjarie lis aplicazions tai metadâts AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Cîr aplicazions AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Cîr aplicazions AppStream par non di pachet"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Mostre dutis lis aplicazions AppStream instaladis"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Cîr aplicazions AppStream par non di categorie"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Mostre i token di ricercje aplicazions"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Al instale metadâts AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Al Instale metadâts AppStream cun gnove origjin"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Al disinstale metadâts AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Cree une pagjine di stât in formât HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Cree un document di stât in formât CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Cree une pagjine di matriç in formât HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Liste di aplicazions no supuartadis di pachets"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Valide un AppData o un file AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Valide un AppData o un file AppStream (rilassât)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Valide un AppData o un file AppStream (rigorôs)"
 
-msgid "Validation failed"
-msgstr "Validazion falide"
-
-msgid "Validation of files failed"
-msgstr "No si è rivâts a validâ i file"
-
-msgid "Version:"
-msgstr "Version:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Valide un AppData o un file AppStream (rilassât)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Convertìs un file AppData al formât NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Convertìs un file NEWS al formât AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Controle i dâts de aplicazion instalade"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "controle une aplicazion instalade"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Sostituìs une cature di schermi tal file sorzint"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Zonte une furnidure a un file sorzint"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Zonte une lenghe a un file sorzint"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Copie lis caturis di schermi upstream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Incorpore metadâts adizionâi di un file esterni"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Confronte i contignûts di doi file AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Gjenere un GUID partint di une stringhe di jentrade"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modifiche un file AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Divît un file AppStream in file AppData e Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Unìs plui file intun file AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Impuarte un file a segnalazion(markup) AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Ten di voli lis posizions di AppStream par modifichis"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "controle une aplicazion instalade"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Confronte numars di version"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Prove une espression regolâr"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitât AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Version:"

--- a/po/gl.po
+++ b/po/gl.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
-"Report-Msgid-Bugs-To: https://github.com/hughsie/appstream-glib/issues\n"
-"POT-Creation-Date: 2019-04-09 15:24+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-12-28 12:27+0100\n"
 "Last-Translator: Fran Diéguez <frandieguez@gnome.org>\n"
 "Language-Team: Galician (http://www.transifex.com/freedesktop/appstream-glib/"
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 2.2.4\n"
 
 #. TRANSLATORS: command line option
-#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4327
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
 msgid "Show extra debugging information"
 msgstr "Mostra información de depuración adicional"
 
@@ -113,7 +113,7 @@ msgid "Ignore certain types of veto"
 msgstr "Ignorar certos tipos de veto"
 
 #. TRANSLATORS: error message
-#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4606
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Produciuse un fallo ao analizar os argumentos"
 
@@ -277,12 +277,12 @@ msgid "No desktop applications found"
 msgstr "Non foi posíbel atopar aplicacións de escritorio"
 
 #. TRANSLATORS: the file is valid
-#: client/as-util.c:2711
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
 #. list failures
-#: client/as-util.c:2716
+#: client/as-util.c:2716 client/as-util.c:2920
 msgid "FAILED"
 msgstr "FALLIDA"
 
@@ -294,231 +294,252 @@ msgstr "Validación fallida"
 msgid "Validation of files failed"
 msgstr "Validación dos ficheiros fallida"
 
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validación fallida"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validación dos ficheiros fallida"
+
 #. TRANSLATORS: application was removed
-#: client/as-util.c:3974
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Retirado"
 
 #. TRANSLATORS: application was added
-#: client/as-util.c:3987
+#: client/as-util.c:4089
 msgid "Added"
 msgstr "Engadido"
 
 #. TRANSLATORS: this is when a device ctrl+c's a watch
-#: client/as-util.c:4270
+#: client/as-util.c:4372
 msgid "Cancelled"
 msgstr "Cancelado"
 
 #. TRANSLATORS: this is the --nonet argument
-#: client/as-util.c:4324
+#: client/as-util.c:4426
 msgid "Do not use network access"
 msgstr "Non usar o acceso á rede"
 
 #. TRANSLATORS: command line option
-#: client/as-util.c:4330
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Mostra a versión"
 
 #. TRANSLATORS: command line option
-#: client/as-util.c:4333
+#: client/as-util.c:4435
 msgid "Enable profiling"
 msgstr "Engadir perfilado"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4365
+#: client/as-util.c:4467
 msgid "Converts AppStream metadata from one version to another"
 msgstr "Convirte os metadatos AppStream dunha versión a outra"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4371
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Anovar os metadatos de AppData á última versión"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4377
+#: client/as-util.c:4479
 msgid "Creates an example AppData file from a .desktop file"
 msgstr "Crea un ficheiro Appdata de exemplo desde un ficheiro .desktop"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4383
+#: client/as-util.c:4485
 msgid "Dumps the applications in the AppStream metadata"
 msgstr "Emborca as aplicacións nos metadatos AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4389
+#: client/as-util.c:4491
 msgid "Search for AppStream applications"
 msgstr "Buscar aplicacións AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4395
+#: client/as-util.c:4497
 msgid "Search for AppStream applications by package name"
 msgstr "Buscar aplicacións en AppStream polo nome do paquete"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4401
+#: client/as-util.c:4503
 msgid "Show all installed AppStream applications"
 msgstr "Mostrar todas as aplicacións de AppStream instalados"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4407
+#: client/as-util.c:4509
 msgid "Search for AppStream applications by category name"
 msgstr "Buscar aplicacións en AppStream polo nome da categoría"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4413
+#: client/as-util.c:4515
 msgid "Display application search tokens"
 msgstr "Mostrar tokens de busca de aplicación"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4419
+#: client/as-util.c:4521
 msgid "Installs AppStream metadata"
 msgstr "Instala os metadatos de AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4425
+#: client/as-util.c:4527
 msgid "Installs AppStream metadata with new origin"
 msgstr "Instala os metadatos de AppStream con un novo orixe"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4431
+#: client/as-util.c:4533
 msgid "Uninstalls AppStream metadata"
 msgstr "Desinstala os metadatos de AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4437
+#: client/as-util.c:4539
 msgid "Create an HTML status page"
 msgstr "Crea unha páxina de estado HTML"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4443
+#: client/as-util.c:4545
 msgid "Create an CSV status document"
 msgstr "Crea un documento de estado CSV"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4449
+#: client/as-util.c:4551
 msgid "Create an HTML matrix page"
 msgstr "Crear unha páxina de matriz de HTML"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4455
+#: client/as-util.c:4557
 msgid "List applications not backed by packages"
 msgstr "Lista as aplicacións que non teñen un paquete"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4461
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Valida un ficheiro de AppData ou AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4467
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Valida un ficheiro de AppData ou AppStream (relaxado)"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4473
+#: client/as-util.c:4575
 msgid "Exports the agreement to text"
 msgstr "Exporta o acordo a texto"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4479
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Valida un ficheiro de AppData ou AppStream (estricto)"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4485
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Valida un ficheiro de AppData ou AppStream (relaxado)"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
 msgid "Convert an AppData file to NEWS format"
 msgstr "Conveter un ficheiro AppData ao formato NEWS"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4491
+#: client/as-util.c:4599
 msgid "Convert an NEWS file to AppData format"
 msgstr "Converter un ficheiro NEWS ao formato AppData"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4497
+#: client/as-util.c:4605
 msgid "Check installed application data"
 msgstr "Comproba os datos de aplicación instaladas"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4503
+#: client/as-util.c:4611
 msgid "check an installed application"
 msgstr "comprobar unha aplicación instalada"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4509
+#: client/as-util.c:4617
 msgid "Replace screenshots in source file"
 msgstr "Substituír capturas de pantallas no ficheiro de orixe"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4515
+#: client/as-util.c:4623
 msgid "Add a provide to a source file"
 msgstr "Engadir un «provide» a un ficheiro fonte"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4521
+#: client/as-util.c:4629
 msgid "Add a language to a source file"
 msgstr "Engadir un idioma a ficheiro fonte"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4527
+#: client/as-util.c:4635
 msgid "Mirror upstream screenshots"
 msgstr "Copiar as capturas de pantalla de «upstream»"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4533
+#: client/as-util.c:4641
 msgid "Incorporate extra metadata from an external file"
 msgstr "Incorporar metadatos adicionais desde un ficheiro externo"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4539
+#: client/as-util.c:4647
 msgid "Compare the contents of two AppStream files"
 msgstr "Comparar os contidos de dous ficheiros AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4545
+#: client/as-util.c:4653
 msgid "Generate a GUID from an input string"
 msgstr "Xerar un GUID dunha cadea de entrada"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4551
+#: client/as-util.c:4659
 msgid "Modify an AppData file"
 msgstr "Modificar un ficheiro AppData"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4557
+#: client/as-util.c:4665
 msgid "Split an AppStream file to AppData and Metainfo files"
 msgstr "Dividir un ficheiro de AppStream en ficheiros AppData e Metainfo"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4563
+#: client/as-util.c:4671
 msgid "Merge several files to an AppStream file"
 msgstr "Combinar varios ficheiros nun ficheiro AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4569
+#: client/as-util.c:4677
 msgid "Import a file to AppStream markup"
 msgstr "Importar un ficheiro a marcado de AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4575
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Observar cambios nas localizacións de AppStream"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4581
+#: client/as-util.c:4689
 msgid "Compare version numbers"
 msgstr "Comparar números de versión"
 
 #. TRANSLATORS: command description
-#: client/as-util.c:4587
+#: client/as-util.c:4695
 msgid "Test a regular expression"
 msgstr "Probar unha expresión regular"
 
 #. TRANSLATORS: program name
-#: client/as-util.c:4600
+#: client/as-util.c:4708
 msgid "AppStream Utility"
 msgstr "Utilidade de AppStream"
 
-#: client/as-util.c:4624
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versión:"

--- a/po/gl.po
+++ b/po/gl.po
@@ -543,3 +543,546 @@ msgstr "Utilidade de AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versión:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Xeral"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "TODO"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Só adultos"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Maduro"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Adolescentes"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Con máis de 10 anos"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Calquera"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Nenos pequenos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Sen violencia con personaxes animados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personaxes de banda deseñada en situacións non seguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personaxes animados en conflitos agresivos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Violencia gráfica con personaxes animados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Sen violencia fantástica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Personaxes en situacións non seguras distinguíbeis facilmante da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Personaxes en conflitos agresivos distinguíbeis facilmente da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Violencia gráfica distinguíbel facilmente da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Sen violencia realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personaxes semi-realistas en situacións non seguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Representacións de personaxes realistas en conflitos agresivos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Violencia gráfica con personaes realistas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Sen masacres"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Masacre non realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Masacre realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Representacións de masacres e mutilación de partes do corpo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Sen violencia sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Violación ou outro comportamento sexual violento"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Sen referencias a bebidas alcohólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referencias a bebeidas alcohólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Use de bebidas alcohólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Sen referencias a drogas ilegais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referencias a drogas ilegais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Uso de drogas ilegais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Sen referencias a produtos de tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referencias ao tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Uso de tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Sen desnudos de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Desnudez artística breve"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Desnudez prolongada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Sen representacións ou referencias sexuais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Representacións ou referencias provocativas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Representacións ou referencias sexuais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Comportamento sexual gráfico"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Sen blasfemia de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Uso moderado ou pouco frecuente da blasfemia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Uso moderado da blasfemia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Uso amplio ou frecuente da blasfemia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Sen humor non axeitado"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Humor vulgar ou estolóxico"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humor adulto ou sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Sen idioma discriminatorio de calqueira tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatividade cara un determinado grupo de persoas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminación para causar dano emocional"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Discriminación explícita baseada en xénero, sexualidade, raza ou relixión"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Sen publicidade de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Venta de produtos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Referencias explícitas a marcas concretas ou produtos de marcas rexistradas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Incítase aos xogadores a comprar determian dos elementos do mundo real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Sen apostas de ningún tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Xogo en eventos aleatorios usando créditos ou vidas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Xogo usando diñeiro virtual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Xogo usando diñeiro real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Sen posibilidade de gastar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Incítase aos xogadores a donar diñeiro real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Posibilidade de gastar diñeiro real no xogo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Sen posibilidade de chatear con outros usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interaccións de usuario a usuario sen a funcionalidade de chat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Funcionalidade de chat moderado entre usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Funcionalidade de chat sen controlar entre usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Sen posibilidade de falar con outros usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Funcionalidade de son ou vídeo sen controlar entre usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Non comparte nas redes socaiais de nomes de usuario ou enderezos de correo-e"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Compartición en redes sociais de nomes de usuario ou enderezos de correo-e"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Non comnparte a información do usuario con terceiros"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Buscando a última versión da aplicación"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Compartición de datos de diagnóstico que non lle permite a outros "
+"identificar ao usuario"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Compartición de información identificable ao usuario"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Non comparte a localización física con outros usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Compartición da localización física con outros usuarios"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Sen referencias a homosexualidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Referencias indirectas á homosexualidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Bicos entre persoas do mesmo xénero"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Comportamento sexual gráfico entre persoas do mesmo sexo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Sen referencias a prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Referencias indirectas á prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Referencias directas á prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Representacións gráficas do acto da prostitución"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Sen referencias ao adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Referencias indirectas ao adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Referencias directas ao adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Representacións gráficas ao acto do adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Sen personaxes sexualizados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Personaxes humanos escasamente vestidos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Caracteres humanos abertamente sexualizados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Sen referencias á profanación"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Representacións ou referencias á profanación histórica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Representacións da profanación humana moderna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Representacións gráficas da profanación moderna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Non hai restos humanos mortos visíbeis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Restos humanos mortos visíbeis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Restos humanos mortos que están expostos aos elementos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Representacións gráficas de profanación de corpos humanos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Sen referencias á escravitude"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Representacións ou referencias á escravitude histórica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Representacións de escravitude moderna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Representacións gráficas de escravitude moderna"

--- a/po/hu.po
+++ b/po/hu.po
@@ -13,10 +13,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-12-06 06:30+0000\n"
 "Last-Translator: Meskó Balázs <meskobalazs@gmail.com>\n"
-"Language-Team: Hungarian (http://www.transifex.com/freedesktop/appstream-glib/language/hu/)\n"
+"Language-Team: Hungarian (http://www.transifex.com/freedesktop/appstream-"
+"glib/language/hu/)\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -25,403 +26,523 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "További hibakeresési információk megjelenítése"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Gyorsítótár-azonosító hozzáadása minden komponenshez"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Sikertelen találatok felvétele a kimenetbe"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "HiDPI ikonok hozzáadása a tömörített fájlhoz"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Gyorsítótár-azonosító hozzáadása minden komponenshez"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Nyelv hozzáadása a forrásfájlhoz"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Hozzáadás a forrásfájlhoz fájlt"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Kódolt ikonok hozzáadása az XML-hez"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Hozzáadva"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Álnév erre: %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream segédprogram"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Visszavonva"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Telepített alkalmazások adatainak ellenőrzése"
-
-msgid "Command not found, valid commands are:"
-msgstr "A parancs nem található, az érvényes parancsok:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Két AppStream fájl tartalmának összehasonlítása"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Verziószámok összehasonlítása"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "A(z) %s – %s átalakítás nincs megvalósítva"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Egy AppData fájl átalakítása NEWS formátumra"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Egy NEWS fájl átalakítása AppData formátumra"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Átalakítja az AppStream metaadatokat az egyik verzióról a másikra"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Egy CSV állapotdokumentum létrehozása"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Egy HTML mátrixoldal létrehozása"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Egy HTML állapotoldal létrehozása"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Egy példa AppData fájlt hoz létre egy .desktop fájlból"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Alkalmazáskeresési jelsorok megjelenítése"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Ne tömörítse az ikonokat a tömörített fájlba"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Ne használjon hálózati hozzáférést"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Kész!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Kiírja az alkalmazásokat az AppStream metaadatokba"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "A naplózási könyvtár beállítása"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Profilalkotás engedélyezése"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "A csomagkönyvtár beállítása"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Hiba a kimeneti könyvtár létrehozásakor"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Az átmeneti könyvtár beállítása"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Hiba az AppData fájl betöltésekor"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "A kimeneti könyvtár beállítása"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Hiba a .desktop fájl betöltésekor"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Az ikonkönyvtár beállítása"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Hiba a köszönetnyilvánítások feldolgozásakor"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "A gyorsítótár könyvtár beállítása"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Hiba a biztosítottak feldolgozásakor"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "A kimeneti fájlok alapneveinek beállítása"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Hiba a fordítások feldolgozásakor"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Az eredet nevének beállítása"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Hiba az AppStream fájl mentésekor"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "A szálak számának beállítása"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "A megállapodás exportálása szövegként"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "A legkisebb ikonméret beállítása képpontokban"
 
-#. list failures
-msgid "FAILED"
-msgstr "SIKERTELEN"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "A régi metaadatok helyének beállítása"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Bizonyos vétótípusok mellőzése"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Nem sikerült a csomag hozzáadása"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Nem sikerült a metaadatok előállítása"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Nem sikerült a csomagok megnyitása"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Nem sikerült az argumentumok feldolgozása"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Nem sikerült a fordító beállítása"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Nem sikerült a csomagok megnyitása"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Csomagok keresése…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Nem sikerült a csomag hozzáadása"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "%u / %u fájl feldolgozva…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Nem sikerült a metaadatok előállítása"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Kész!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Ikon mentése"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Előtag beállítása"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Alkalmazás feldolgozása"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Hiba az AppData fájl betöltésekor"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Hiba a fordítások feldolgozásakor"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Hiba a köszönetnyilvánítások feldolgozásakor"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Hiba a biztosítottak feldolgozásakor"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Érvénytelen .desktop fájlnév"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Hiba a .desktop fájl betöltésekor"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Hiba a kimeneti könyvtár létrehozásakor"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "AppStream mentése"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Hiba az AppStream fájl mentésekor"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Álnév erre: %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "A parancs nem található, az érvényes parancsok:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Nézze át a fájlt, és javítson minden „FIXME” elemet"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Régi API verzió"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Új API verzió"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Nincs elég argumentum, a következő az elvárt: old.xml new.xml verzió"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "A(z) %s – %s átalakítás nincs megvalósítva"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Nincs elég argumentum, a következő az elvárt: file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "A(z) „%s” fájlformátum nem frissíthető"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "A formátum ismeretlen"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "GUID előállítása egy bemeneti szövegből"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Bizonyos vétótípusok mellőzése"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Fájl importálása AppStream jelölőnyelvbe"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Sikertelen találatok felvétele a kimenetbe"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "További metaadatok használata külső fájlból"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Telepíti az AppStream metaadatokat"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Telepíti az AppStream metaadatokat egy új eredettel"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Érvénytelen .desktop fájlnév"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Alkalmazások felsorolása, melyek mögött nincsenek csomagok"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Több fájl egy AppStream fájlba fésülése"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Az upstream képernyőképek tükrözése"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Egy AppData fájl módosítása"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Új API verzió"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nem találhatók asztali alkalmazások"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Nincs elég argumentum, a következő az elvárt: file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Nincs elég argumentum, a következő az elvárt: old.xml new.xml verzió"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Régi API verzió"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "SIKERTELEN"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Az ellenőrzés nem sikerült"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "A fájlok ellenőrzése nem sikerült"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "%u / %u fájl feldolgozva…"
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Nézze át a fájlt, és javítson minden „FIXME” elemet"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Az ellenőrzés nem sikerült"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Alkalmazás feldolgozása"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "A fájlok ellenőrzése nem sikerült"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Eltávolítva"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Képernyőképek cseréje a forrásfájlban"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Hozzáadva"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "AppStream mentése"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Visszavonva"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Ikon mentése"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Csomagok keresése…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "AppStream alkalmazások keresése"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Appstream alkalmazások keresése kategória nevek alapján"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "AppStream alkalmazások keresése csomagnév alapján"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Ne használjon hálózati hozzáférést"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "A kimeneti fájlok alapneveinek beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "A gyorsítótár könyvtár beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Az ikonkönyvtár beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "A naplózási könyvtár beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "A legkisebb ikonméret beállítása képpontokban"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "A szálak számának beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "A régi metaadatok helyének beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Az eredet nevének beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "A kimeneti könyvtár beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "A csomagkönyvtár beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Előtag beállítása"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Az átmeneti könyvtár beállítása"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Megjeleníti a telepített AppStream alkalmazásokat"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "További hibakeresési információk megjelenítése"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Verzió megjelenítése"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Egy AppStream fájl felosztása AppData és Metainfo fájlokká"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Profilalkotás engedélyezése"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Egy reguláris kifejezés tesztelése"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Átalakítja az AppStream metaadatokat az egyik verzióról a másikra"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Eltávolítja az AppStream metaadatokat"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Az AppData metaadatok frissítése a legújabb verzióra"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Egy példa AppData fájlt hoz létre egy .desktop fájlból"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Kiírja az alkalmazásokat az AppStream metaadatokba"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "AppStream alkalmazások keresése"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "AppStream alkalmazások keresése csomagnév alapján"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Megjeleníti a telepített AppStream alkalmazásokat"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Appstream alkalmazások keresése kategória nevek alapján"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Alkalmazáskeresési jelsorok megjelenítése"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Telepíti az AppStream metaadatokat"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Telepíti az AppStream metaadatokat egy új eredettel"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Eltávolítja az AppStream metaadatokat"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Egy HTML állapotoldal létrehozása"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Egy CSV állapotdokumentum létrehozása"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Egy HTML mátrixoldal létrehozása"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Alkalmazások felsorolása, melyek mögött nincsenek csomagok"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Egy AppData vagy AppStream fájl ellenőrzése"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Egy AppData vagy AppStream fájl ellenőrzése (megengedő)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "A megállapodás exportálása szövegként"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Egy AppData vagy AppStream fájl ellenőrzése (szigorú)"
 
-msgid "Validation failed"
-msgstr "Az ellenőrzés nem sikerült"
-
-msgid "Validation of files failed"
-msgstr "A fájlok ellenőrzése nem sikerült"
-
-msgid "Version:"
-msgstr "Verzió:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Egy AppData vagy AppStream fájl ellenőrzése (megengedő)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Egy AppData fájl átalakítása NEWS formátumra"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Egy NEWS fájl átalakítása AppData formátumra"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Telepített alkalmazások adatainak ellenőrzése"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "egy telepített alkalmazás ellenőrzése"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Képernyőképek cseréje a forrásfájlban"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Hozzáadás a forrásfájlhoz fájlt"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Nyelv hozzáadása a forrásfájlhoz"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Az upstream képernyőképek tükrözése"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "További metaadatok használata külső fájlból"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Két AppStream fájl tartalmának összehasonlítása"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "GUID előállítása egy bemeneti szövegből"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Egy AppData fájl módosítása"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Egy AppStream fájl felosztása AppData és Metainfo fájlokká"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Több fájl egy AppStream fájlba fésülése"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Fájl importálása AppStream jelölőnyelvbe"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "AppStream helyek változásainak figyelése"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "egy telepített alkalmazás ellenőrzése"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Verziószámok összehasonlítása"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Egy reguláris kifejezés tesztelése"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream segédprogram"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Verzió:"

--- a/po/hu.po
+++ b/po/hu.po
@@ -546,3 +546,553 @@ msgstr "AppStream segédprogram"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Verzió:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Általános"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "ÖSSZES"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Csak felnőtt"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Érett"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Tizenéves"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Mindenki 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Mindenki"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Fiatal gyermekkor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Nincs rajzfilmes erőszak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Rajzfilmfigurák veszélyes helyzetekben"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Rajzfilmfigurák agresszív konfliktusban"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Rajzfilmfigurákat érintő grafikus erőszak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Nincs kitalált erőszak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Karakterek veszélyes helyzetekben, amely könnyen megkülönböztethető a "
+"valóságtól"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Karakterek agresszív konfliktusban, amely könnyen megkülönböztethető a "
+"valóságtól"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Grafikus erőszak, amely könnyen megkülönböztethető a valóságtól"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Nincs valósághű erőszak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Enyhén valósághű karakterek veszélyes helyzetekben"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Valósághű karakterek ábrázolása agresszív konfliktusban"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Valósághű karaktereket érintő grafikus erőszak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Nincs vérontás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Nem valósághű vérontás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Valósághű vérontás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Várontás és a testrészek megcsonkításának ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Nincs szexuális erőszak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Megerőszakolás vagy egyéb erőszakos szexuális viselkedés"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Nincs alkoholtartalmú italokra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Alkoholtartalmú italokra való hivatkozások"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Alkoholtartalmú italok használata"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Nincs tiltott kábítószerekre való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Tiltott kábítószerekre való hivatkozások"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Tiltott kábítószerek használata"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Nincs dohánytermékekre való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Dohánytermékekre való hivatkozások"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Dohánytermékek használata"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Nincs semmiféle meztelenség"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Rövid művészi meztelenség"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Hosszan tartó meztelenség"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Nincs szexuális természetű hivatkozás vagy annak ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Kihívó hivatkozások vagy ábrázolások"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Szexuális hivatkozások vagy ábrázolások"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Grafikus szexuális viselkedés"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Nincs káromkodás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Enyhe vagy ritka káromkodáshasználat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Mérsékelt káromkodáshasználat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Erős vagy gyakori káromkodáshasználat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Nincs helytelen humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Helyzethumor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgáris vagy fürdőszoba humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Felnőtt vagy szexuális humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Nincs semmiféle diszkriminatív nyelvezet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatívság egy bizonyos embercsoport felé"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Érzelmi károsodást okozó tervezett diszkrimináció"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Kifejezetten nemi, szexuális, faji vagy vallási alapú diszkrimináció"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Nincs semmiféle hirdetés"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Termékelhelyezés"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Közvetlen utalások egy bizonyos márkára vagy védjeggyel védett termékre"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr ""
+"A felhasználókat arra ösztönzik, hogy a valódi világban bizonyos tárgyakat "
+"vásároljanak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Nincs semmiféle szerencsejáték"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr ""
+"Szerencsejáték véletlenszerű eseményeken zsetonok vagy kreditek használatával"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Szerencsejáték „játékpénz” használatával"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Szerencsejáték valódi pénz használatával"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Nem lehet valódi pénzt elkölteni"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "A felhasználókat arra ösztönzik, hogy valós pénzt adományozzanak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Lehetőség az alkalmazáson belül valódi pénzt elkölteni"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Nincs mód a csevegésre más felhasználókkal"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Felhasználók közötti interakciók, csevegés funkcionalitás nélkül"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Moderált csevegés funkcionalitás a felhasználók között"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Ellenőrizetlen csevegés funkcionalitás a felhasználók között"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Nincs mód a beszélgetésre más felhasználókkal"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr ""
+"Ellenőrizetlen hang- vagy videocsevegés funkcionalitás a felhasználók között"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Nincs közösségi hálózatokon használt felhasználónevek vagy e-mail címek "
+"megosztása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Közösségi hálózatokon használt felhasználónevek vagy e-mail címek megosztása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Nincs felhasználói információk megosztása harmadik féllel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "A legfrissebb alkalmazásverzió ellenőrzése"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Diagnosztikai adatok megosztása, amelyek mások számára nem azonosítják a "
+"felhasználót"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Információk megosztása, amelyek mások számára azonosítják a felhasználót"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Nincs fizikai hely megosztása más felhasználók számára"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Fizikai hely megosztása más felhasználók számára"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Nincs homoszexualitásra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Közvetett homoszexualitásra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Csókolózás azonos nemű emberek között"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Grafikus szexuális viselkedés azonos nemű emberek között"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Nincs prostitúcióra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Közvetett prostitúcióra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Közvetlen prostitúcióra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Prostitúció grafikus ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Nincs házasságtörésre való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Közvetett házasságtörésre való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Közvetlen házasságtörésre való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Házasságtörés grafikus ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Nincsenek szexualizált karakterek"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Hiányosan öltözött emberi karakterek"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Nyíltan szexualizált emberi karakterek"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Nincs gyalázásra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Gyalázás történelmi ábrázolása vagy arra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Modern kori emberi gyalázás ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Modern kori emberi gyalázás grafikus ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Nincsenek látható emberi maradványok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Látható emberi maradványok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Emberi maradványok, kitéve az időjárási viszonyoknak"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Emberi testek gyalázásának grafikus ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Nincs rabszolgaságra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Rabszolgaság történelmi ábrázolása vagy arra való hivatkozás"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Modern kori rabszolgaság ábrázolása"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Modern kori rabszolgaság grafikus ábrázolása"

--- a/po/id.po
+++ b/po/id.po
@@ -10,10 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2017-09-01 05:13+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
-"Language-Team: Indonesian (http://www.transifex.com/freedesktop/appstream-glib/language/id/)\n"
+"Language-Team: Indonesian (http://www.transifex.com/freedesktop/appstream-"
+"glib/language/id/)\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,391 +23,524 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Tampilkan informasi debug ekstra"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Tambahkan ID singgahan ke setiap komponen"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Sertakan hasil gagal dalam keluaran"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Tambah ikon HiDPI ke tarball"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Tambahkan ID singgahan ke setiap komponen"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Tambahkan bahasa ke suatu berkas sumber"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Tambahkan penyedia ke suatu berkas sumber"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Tambah ikon terenkode ke XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Ditambahkan"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias untuk %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitas AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Dibatalkan"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Periksa data aplikasi yang terpasang"
-
-msgid "Command not found, valid commands are:"
-msgstr "Perintah tak ditemukan, perintah yang valid adalah:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Bandingkan isi dari dua berkas AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Bandingkan nomor-nomor versi"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Konversi %s ke %s tidak diimplementasi"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Konversikan berkas AppData ke format NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Konversikan berkas NEWS ke format AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Konversikan metadata AppStream dari satu versi ke lainnya"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Buat sebuah dokumen status CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Buat sebuah halaman matriks HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Buat sebuah halaman status HTML"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Tampilkan token pencarian aplikasi"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Jangan mampatkan ikon ke dalam tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Jangan pakai akses jaringan"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Selesai!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Mencurahkan aplikasi dalam metadata AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Tata direktori log"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Fungsikan pemrofilan"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Atur direktori paket"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Kesalahan saat membuat direktori keluaran"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Atur direktori temporer"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Kesalahan saat memuat berkas AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Atur direktori keluaran"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Kesalahan saat memuat berkas desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Atur direktori ikon"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Kesalahan mengurai pujian"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Atur direktori singgahan"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Kesalahan saat mengurai penyedia"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Atur nama basis dari berkas keluaran"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Kesalahan saat mengurai terjemahan"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Atur nama asli"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Kesalahan saat menyimpan berkas AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Atur cacah thread"
 
-#. list failures
-msgid "FAILED"
-msgstr "GAGAL"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Atur ukuran ikon minimum dalam piksel"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Atur lokasi metadata lama"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Abaikan tipe veto tertentu"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Gagal menambah paket"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Gagal menghasilkan metadata"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Gagal membuka paket"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Gagal mengurai argumen"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Gagal menyiapkan builder"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Gagal membuka paket"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Memindai paket..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Gagal menambah paket"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Diurai %u/%u berkas..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Gagal menghasilkan metadata"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Selesai!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Menyimpan ikon"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Atur prefiks"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Memroses aplikasi"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Kesalahan saat memuat berkas AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Kesalahan saat mengurai terjemahan"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Kesalahan mengurai pujian"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Kesalahan saat mengurai penyedia"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Kesalahan saat memuat berkas desktop"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Kesalahan saat memuat berkas desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Kesalahan saat membuat direktori keluaran"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Menyimpan AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Kesalahan saat menyimpan berkas AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias untuk %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Perintah tak ditemukan, perintah yang valid adalah:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Harap periksa berkas dan perbaiki sebarang butir 'FIXME'"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Versi API lama"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Versi API baru"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Argumen tidak cukup, yang diharapkan lama.xml baru.xml versi"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Konversi %s ke %s tidak diimplementasi"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Argumen tidak cukup yang diharapkan berkas.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Format berkas '%s' tidak bisa ditingkatkan"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Format tidak dikenali"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Buat suatu GUID dari string masukan"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Abaikan tipe veto tertentu"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Impor sebuah berkas ke markup AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Sertakan hasil gagal dalam keluaran"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Sertakan medatada ekstra dari berkas eksternal"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Pasang metadata AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Pasang metadata AppStream dengan origin baru"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Daftar aplikasi yang tidak didukung oleh paket"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Gabungkan beberapa berkas ke sebuh berkas AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Cerminkan cuplikan layar upstream"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Ubah berkas AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Versi API baru"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Tidak ditemukan aplikasi desktop"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Argumen tidak cukup yang diharapkan berkas.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Argumen tidak cukup, yang diharapkan lama.xml baru.xml versi"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Versi API lama"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "GAGAL"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validasi gagal"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Validasi berkas gagal"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Diurai %u/%u berkas..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Harap periksa berkas dan perbaiki sebarang butir 'FIXME'"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validasi gagal"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Memroses aplikasi"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validasi berkas gagal"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Dihapus"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Gantikan cuplikan layar dalam berkas sumber"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Ditambahkan"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Menyimpan AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Dibatalkan"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Menyimpan ikon"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Memindai paket..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Mencari aplikasi AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Cari aplikasi AppStream berdasarkan nama kategori"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Mencari aplikasi AppStream menurut namanya"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Jangan pakai akses jaringan"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Atur nama basis dari berkas keluaran"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Atur direktori singgahan"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Atur direktori ikon"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Tata direktori log"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Atur ukuran ikon minimum dalam piksel"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Atur cacah thread"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Atur lokasi metadata lama"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Atur nama asli"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Atur direktori keluaran"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Atur direktori paket"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Atur prefiks"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Atur direktori temporer"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Tampilkan semua aplikasi AppStream yang terpasang"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Tampilkan informasi debug ekstra"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Tampilkan versi"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Pecah berkas AppData ke berkas Metainfo dan AppData"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Fungsikan pemrofilan"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Uji suatu ekspresi reguler"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Konversikan metadata AppStream dari satu versi ke lainnya"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Bongkar metadata AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Tingkatkan metadata AppData ke versi terakhir"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Mencurahkan aplikasi dalam metadata AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Mencari aplikasi AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Mencari aplikasi AppStream menurut namanya"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Tampilkan semua aplikasi AppStream yang terpasang"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Cari aplikasi AppStream berdasarkan nama kategori"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Tampilkan token pencarian aplikasi"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Pasang metadata AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Pasang metadata AppStream dengan origin baru"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Bongkar metadata AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Buat sebuah halaman status HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Buat sebuah dokumen status CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Buat sebuah halaman matriks HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Daftar aplikasi yang tidak didukung oleh paket"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Validasikan sebuah berkas AppData atau AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Validasikan sebuah berkas AppData atau AppStream (longgar)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Validasikan sebuah berkas AppData atau AppSteram (ketat)"
 
-msgid "Validation failed"
-msgstr "Validasi gagal"
-
-msgid "Validation of files failed"
-msgstr "Validasi berkas gagal"
-
-msgid "Version:"
-msgstr "Versi:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Validasikan sebuah berkas AppData atau AppStream (longgar)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Konversikan berkas AppData ke format NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Konversikan berkas NEWS ke format AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Periksa data aplikasi yang terpasang"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "memeriksa suatu aplikasi yang terpasang"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Gantikan cuplikan layar dalam berkas sumber"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Tambahkan penyedia ke suatu berkas sumber"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Tambahkan bahasa ke suatu berkas sumber"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Cerminkan cuplikan layar upstream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Sertakan medatada ekstra dari berkas eksternal"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Bandingkan isi dari dua berkas AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Buat suatu GUID dari string masukan"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Ubah berkas AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Pecah berkas AppData ke berkas Metainfo dan AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Gabungkan beberapa berkas ke sebuh berkas AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Impor sebuah berkas ke markup AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Amati lokasi AppStream atas adanya perubahan"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "memeriksa suatu aplikasi yang terpasang"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Bandingkan nomor-nomor versi"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Uji suatu ekspresi reguler"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitas AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Versi:"

--- a/po/id.po
+++ b/po/id.po
@@ -544,3 +544,543 @@ msgstr "Utilitas AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versi:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Umum"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "SEMUA"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Hanya untuk orang dewasa"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Dewasa"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Remaja"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Semua orang 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Semua orang"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Anak usia dini"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Tidak ada kekerasan kartun"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Karakter kartun dalam situasi yang tidak aman"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Karakter kartun dalam konflik agresif"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Kekerasan grafis yang melibatkan karakter kartun"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Tidak ada kekerasan fantasi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Karakter dalam situasi yang tidak aman dengan mudah dibedakan dari realitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Karakter dalam konflik agresif dengan mudah dibedakan dari realitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Kekerasan grafis dengan mudah dibedakan dari realitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Tidak ada kekerasan realistis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Sedikit karakter realistis dalam situasi yang tidak aman"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Penggambaran karakter yang realistis dalam konflik agresif"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Kekerasan grafis yang melibatkan karakter yang realistis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Tidak ada pertumpahan darah"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Pertumpahan darah yang tidak realistis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Pertumpahan darah yang realistis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Penggambaran pertumpahan darah dan mutilasi bagian tubuh"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Tidak ada kekerasan seksual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Perkosaan atau perilaku seksual kekerasan lainnya"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Tidak ada referensi untuk alkohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referensi untuk minuman beralkohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Penggunaan minuman beralkohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Tidak ada referensi untuk obat-obatan terlarang"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referensi untuk obat-obatan terlarang"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Penggunaan obat-obatan terlarang"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Tidak ada referensi untuk produk tembakau"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referensi untuk produk tembakau"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Penggunaan produk tembakau"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Tidak ada ketelanjangan apapun"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Ketelanjangan artistik singkat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Ketelanjangan berkepanjangan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Tidak ada referensi atau penggambaran sifat seksual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Referensi provokatif atau penggambaran"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Referensi seksual atau penggambaran"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Perilaku seksual grafis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Tidak ada kata-kata tidak senonoh apapun"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Penggunaan ringan atau jarang kata-kata tidak senonoh"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Penggunaan sedang kata-kata tidak senonoh"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Penggunaan kuat atau sering kata-kata tidak senonoh"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Tidak ada humor yang tidak pantas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Humor slapstick"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgar atau humor kamar mandi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humor dewasa atau seksual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Tidak ada bahasa diskriminatif apapun"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatif terhadap sekelompok orang tertentu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminasi dirancang untuk menyebabkan kerusakan emosional"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Diskriminasi eksplisit berdasarkan gender, seksualitas, ras atau agama"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Tidak ada iklan jenis apapun"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Penempatan produk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Referensi eksplisit untuk merek tertentu atau produk dengan merek dagang"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Pengguna dianjurkan untuk membeli barang dunia nyata tertentu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Tidak ada perjudian jenis apapun"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Perjudian pada peristiwa acak menggunakan token atau kredit"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Perjudian menggunakan \"permainan\" uang"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Perjudian menggunakan uang riil"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Tidak ada kemampuan membelanjakan uang"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Pengguna dianjurkan untuk menyumbangkan uang sungguhan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Kemampuan untuk menghabiskan uang riil dalam aplikasi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Tidak ada cara untuk mengobrol dengan pengguna lain"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interaksi antar pengguna tanpa fungsi obrolan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Moderasi fungsi obrolan antar pengguna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Fungsi obrolan yang tidak terkontrol antara pengguna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Tidak ada cara untuk berbicara dengan pengguna lain"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Fungsi obrolan audio atau video yang tidak terkontrol antara pengguna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Tidak berbagi alamat surel atau nama pengguna media sosial"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Berbagai nama pengguna jejaring sosial atau alamat surel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Tidak berbagi informasi pengguna dengan pihak ketiga"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Memeriksa versi aplikasi terbaru"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Berbagi data diagnostik yang tidak membiarkan orang lain mengidentifikasi "
+"pengguna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Berbagi informasi yang memungkinkan orang lain mengidentifikasi pengguna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Tidak berbagi lokasi fisik dengan pengguna lain"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Berbagi lokasi fisik dengan pengguna lain"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Tidak ada referensi untuk homoseksualitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Tidak ada referensi untuk homoseksualitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Berciuman antara orang-orang dengan jenis kelamin yang sama"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Perilaku seksual grafis antara orang dengan jenis kelamin yang sama"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Tidak ada referensi untuk prostitusi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Referensi tidak langsung untuk prostitusi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Referensi langsung ke prostitusi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Penggambaran grafis dari prostitusi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Tidak ada referensi untuk perzinaan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Referensi tidak langsung untuk perzinaan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Referensi langsung ke perzinaan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Penggambaran grafis dari tindakan perzinaan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Tidak ada karakter seksual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Karakter manusia berpakaian minim"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Karakter manusia seksual secara menyeluruh"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Tidak ada referensi untuk penodaan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Penggambaran atau referensi tentang penodaan sejarah"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Penggambaran tentang penodaan manusia zaman modern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Penggambaran grafis tentang penodaan modern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Tidak ada sisa manusia mati yang terlihat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Sisa manusia mati yang terlihat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Sisa manusia mati yang terpapar unsur"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Penggambaran grafis penodaan tubuh manusia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Tidak ada referensi untuk perbudakan"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Penggambaran atau referensi tentang perbudakan sejarah"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Penggambaran perbudakan modern"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Penggambaran grafis tentang perbudakan modern"

--- a/po/it.po
+++ b/po/it.po
@@ -9,10 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-11-21 01:39+0000\n"
 "Last-Translator: Milo Casagrande <milo@milo.name>\n"
-"Language-Team: Italian (http://www.transifex.com/freedesktop/appstream-glib/language/it/)\n"
+"Language-Team: Italian (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/it/)\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,403 +22,523 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Mostra informazioni aggiuntive di debug"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Aggiunge un ID cache a ciascun componente"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Include i risultati non riusciti nell'output"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Aggiunge icone HiDPI al tarball"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Aggiunge un ID cache a ciascun componente"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Aggiunge una lingua a un file sorgente"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Aggiunge un fornitore a un file sorgente"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Aggiunge icone codificate all'XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Aggiunta"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias a %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Strumento AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Annullato"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Verifica i dati dell'applicazione installata"
-
-msgid "Command not found, valid commands are:"
-msgstr "Comando non trovato. Comandi validi sono:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Compare i contenuti di due file AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Confronta i numeri di versione"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "La conversione di %s in %s non è implementata"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Converte un file AppData nel formato NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Converte un file NEWS nel formato AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Converte i metadati AppStream da una versione all'altra"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Crea un documento di stato in formato CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Crea una pagina matrice in formato HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Crea una pagina di stato in formato HTML"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Crea un file AppData di esempio da un file .desktop"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Visualizza i token di ricerca applicazione"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Non comprime le icone nel tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Non usa la rete"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Fatto"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Registra le applicazioni nei metadati AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Imposta la directory di registrazione"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Abilita profiling"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Imposta la directory dei pacchetti"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Errore nel creare la directory di output"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Imposta la directory temporanea"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Errore nel caricare il file AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Imposta la directory di uscita"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Errore nel caricare il file desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Imposta la directory delle icone"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Errore nell'analizzare i kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Imposta la directory della cache"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Errore nell'analizzare i provides"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Imposta il nome di base dei file di uscita"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Errore nell'analizzare le traduzioni"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Imposta il nome dell'origine"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Errore nel salvare il file AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Imposta il numero di thread"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Esporta il testo dell'accordo"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Imposta la dimensione minima in pixel delle icone"
 
-#. list failures
-msgid "FAILED"
-msgstr "Non riuscito"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Imposta la vecchia posizione dei metadati"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignora certi tipi di veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Aggiunta pacchetto non riuscita"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Generazione metadati non riuscita"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Apertura dei pacchetti non riuscita"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Analisi argomenti non riuscita"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Impostazione del generatore non riuscita"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Apertura dei pacchetti non riuscita"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Analisi dei pacchetti..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Aggiunta pacchetto non riuscita"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Analizzati %u/%u file..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Generazione metadati non riuscita"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Fatto"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Salvataggio icona"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Impostazione prefisso"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Elaborazione applicazione"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Errore nel caricare il file AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Errore nell'analizzare le traduzioni"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Errore nell'analizzare i kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Errore nell'analizzare i provides"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Nome file desktop non valido"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Errore nel caricare il file desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Errore nel creare la directory di output"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Salvataggio AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Errore nel salvare il file AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias a %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Comando non trovato. Comandi validi sono:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Controllare il file e correggere gli elementi \"FIXME\""
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Vecchia versione di API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nuova versione API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Argomenti non sufficienti: atteso vecchio.xml nuovo.xml versione"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "La conversione di %s in %s non è implementata"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Argomenti non sufficienti: atteso file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Il formato di file «%s» non può essere aggiornato"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Formato non riconosciuto"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Genera uno GUID da una stringa in ingresso"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignora certi tipi di veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importa un file in sintassi AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Include i risultati non riusciti nell'output"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorpora meta-dati aggiuntivi da un file esterno"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Installa i metadati AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Installa i metadati AppStream con nuova origine"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Nome file desktop non valido"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Elenca le applicazioni non supportate da pacchetti"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Unisce più file in un unico file AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Copia le schermate upstream"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modifica un file AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nuova versione API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nessuna applicazione desktop trovata"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Argomenti non sufficienti: atteso file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Argomenti non sufficienti: atteso vecchio.xml nuovo.xml versione"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "Ok"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Vecchia versione di API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "Non riuscito"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validazione non riuscita"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Validazione dei file non riuscita"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Analizzati %u/%u file..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Controllare il file e correggere gli elementi \"FIXME\""
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validazione non riuscita"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Elaborazione applicazione"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validazione dei file non riuscita"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Rimossa"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Sostituisce le schermate nel file sorgente"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Aggiunta"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Salvataggio AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Annullato"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Salvataggio icona"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Analisi dei pacchetti..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Cerca applicazioni AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Cerca applicazioni AppStream per categoria"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Cerca applicazioni AppStream per nome di pacchetto"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Non usa la rete"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Imposta il nome di base dei file di uscita"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Imposta la directory della cache"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Imposta la directory delle icone"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Imposta la directory di registrazione"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Imposta la dimensione minima in pixel delle icone"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Imposta il numero di thread"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Imposta la vecchia posizione dei metadati"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Imposta il nome dell'origine"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Imposta la directory di uscita"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Imposta la directory dei pacchetti"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Impostazione prefisso"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Imposta la directory temporanea"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Mostra tutte le applicazioni AppStream installate"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Mostra informazioni aggiuntive di debug"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Mostra la versione"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Divide un file AppStream nei file AppData e Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Abilita profiling"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Verifica un'espressione regolare"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Converte i metadati AppStream da una versione all'altra"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Rimuove i metadati AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Aggiorna i metadati AppData all'ultima versione"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Crea un file AppData di esempio da un file .desktop"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Registra le applicazioni nei metadati AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Cerca applicazioni AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Cerca applicazioni AppStream per nome di pacchetto"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Mostra tutte le applicazioni AppStream installate"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Cerca applicazioni AppStream per categoria"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Visualizza i token di ricerca applicazione"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Installa i metadati AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Installa i metadati AppStream con nuova origine"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Rimuove i metadati AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Crea una pagina di stato in formato HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Crea un documento di stato in formato CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Crea una pagina matrice in formato HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Elenca le applicazioni non supportate da pacchetti"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Valida un file AppData o AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Valida un file AppData o AppStream (relaxed)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Esporta il testo dell'accordo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Valida un file AppData o AppStream (strict)"
 
-msgid "Validation failed"
-msgstr "Validazione non riuscita"
-
-msgid "Validation of files failed"
-msgstr "Validazione dei file non riuscita"
-
-msgid "Version:"
-msgstr "Versione:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Valida un file AppData o AppStream (relaxed)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Converte un file AppData nel formato NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Converte un file NEWS nel formato AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Verifica i dati dell'applicazione installata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "Verifica un'applicazione installata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Sostituisce le schermate nel file sorgente"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Aggiunge un fornitore a un file sorgente"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Aggiunge una lingua a un file sorgente"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Copia le schermate upstream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Incorpora meta-dati aggiuntivi da un file esterno"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Compare i contenuti di due file AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Genera uno GUID da una stringa in ingresso"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modifica un file AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Divide un file AppStream nei file AppData e Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Unisce più file in un unico file AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importa un file in sintassi AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Controlla le modifiche sulle posizioni AppStream"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "Verifica un'applicazione installata"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Confronta i numeri di versione"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Verifica un'espressione regolare"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Strumento AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Versione:"

--- a/po/it.po
+++ b/po/it.po
@@ -542,3 +542,546 @@ msgstr "Strumento AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versione:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Generale"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "Tutto"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Solo per adulti"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Maturo"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Adolescente"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Chiunque di 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Chiunque"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Prima infanzia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Nessuna violenza nel cartone animato"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personaggi dei cartoni animati in situazioni rischiose"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personaggi dei cartoni animati in conflitti aggressivi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Violenza grafica che coinvolge personaggi dei cartoni animati"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Nessuna violenza nel fantasy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Personaggi in situazioni rischiose facilmente distinguibili dalla realtà"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Personaggi in conflitti aggressivi facilmente distinguibili dalla realtà"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Violenza grafica facilmente distinguibile dalla realtà"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Nessuna violenza realistica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personaggi lievemente realistici in situazioni rischiose"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Raffigurazioni di personaggi realistici in conflitti aggressivi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Violenza grafica che coinvolge personaggi realistici"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Nessun eccidio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Eccidio non realistico"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Eccidio realistico"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Raffigurazioni di eccidi e mutilazioni di parti del corpo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Nessuna violenza sessuale"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Stupro o altri comportamenti sessuali violenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Nessun riferimento all'alcol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Riferimenti a bevande alcoliche"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Uso di bevande alcoliche"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Nessun riferimento a droghe illecite"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Riferimenti a droghe illecite"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Uso di droghe illecite"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Nessun riferimento a prodotti del tabacco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Riferimenti a prodotti del tabacco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Uso di prodotti del tabacco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Nessuna nudità di qualsiasi sorta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Breve nudità artistica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Nudità prolungata"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Nessun riferimento a/o raffigurazione di natura sessuale"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Riferimenti o raffigurazioni provocanti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Riferimenti o raffigurazioni sessuali"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Comportamento grafico sessuale"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Nessuna volgarità di qualsiasi tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Lieve o infrequente uso di volgarità"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Moderato uso di volgarità"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Forte o frequente uso di volgarità"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Nessun umorismo inappropriato"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Umorismo da pagliacciata"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Umorismo volgare o da gabinetto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Umorismo maturo o sessuale"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Nessun linguaggio discriminatorio di qualsiasi tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatività verso un gruppo specifico di persone"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminazione progettata per causare danni emotivi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Discriminazione esplicita basata sul sesso, sessualità, razza o religione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Nessuna pubblicità di qualsiasi tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Inserimento prodotto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Riferimenti espliciti a specifici marchi o prodotti commerciali"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr ""
+"Gli utenti sono incoraggiati ad acquistare specifici oggetti del mondo reale"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Nessun gioco d'azzardo di qualsiasi tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Gioco d'azzardo su eventi casuali che usano gettoni o crediti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Gioco d'azzardo che usa soldi «di gioco»"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Gioco d'azzardo che usa soldi veri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Nessuna possibilità di spendere soldi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Gli utenti sono incoraggiati a donare moneta reale"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Possibilità di spendere soldi veri nell'applicazione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Nessuna possibilità di conversare con altri utenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interazioni fra utenti senza funzionalità di chat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Funzionalità di chat moderata fra utenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Funzionalità di chat non controllata fra utenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Nessuna possibilità di parlare con altri utenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Funzionalità di chat audio e video non controllata fra utenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Nessuna condivisione di nomi utente di social network o di indirizzi email"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Condivisione di nomi utente di social network o di indirizzi email"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Nessuna condivisione di informazioni dell'utente con terze parti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Verifica dell'ultima versione dell'applicazione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Condivisione di dati diagnostici che non consentono agli altri di "
+"identificare l'utente"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Condivisione di informazioni che consentono ad altri di identificare l'utente"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Nessuna condivisione della posizione fisica con altri utenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Condivisione della posizione fisica con altri utenti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Neessun riferimento all'omosessualità"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Riferimenti indiretti all'omosessualità"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Effusioni fra persone dello stesso sesso"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Comportamento sessuale grafico fra persone dello stesso sesso"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Nessun riferimento alla prostituzione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Riferimenti indiretti alla prostituzione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Riferimenti diretti alla prostituzione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Rappresentazioni grafiche dell'atto di prostituzione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Nessun riferimento all'adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Riferimenti indiretti all'adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Riferimenti diretti all'adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Rappresentazioni grafiche dell'atto dell'adulterio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Nessuna personaggio sessualizzato"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Personaggi umani poco vestiti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Personaggi umani sessualizzati in modo anomalo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Nessun riferimento alla profanazione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Raffigurazioni o riferimenti alla profanazione storica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Rappresentazioni della moderna dissacrazione umana"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Rappresentazioni grafiche di moderna profanazione"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Nessun resto visibile di umano morto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Resti visibili di umano morto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Resti di umano morto che è stato esposto agli elementi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Rappresentazioni grafiche della profanazione di corpi umani"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Nessun riferimento alla schiavitù"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Raffigurazioni o riferimenti alla schiavitù storica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Rappresentazioni della schiavitù moderna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Rappresentazioni grafiche della schiavitù moderna"

--- a/po/ko.po
+++ b/po/ko.po
@@ -549,3 +549,538 @@ msgstr "AppStream 유틸리티"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "버전:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "일반"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "모두"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "성인 전용"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "성인용"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "10대"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "10세이상 전연령용"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "전연령용"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "영유아용"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "만화 수준 폭력 내용 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "안전하지 않은 상황의 만화 주인공 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "적극적 폭력 상황의 만화 주인공 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "만화 주인공의 그래픽 폭력"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "판타지 폭력 내용 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "실제와 구분할 수 있는 안전하지 않은 상황의 등장 인물 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "실제와 구분할 수 있는 적극적 폭력 상황의 등장 인물 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "실제와 구분할 수 있는 그래픽 폭력"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "폭력 재현 내용 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "실제와 비슷하게 안전하지 않은 상황의 등장 인물 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "실제에 가깝게 적극적 폭력 상황의 등장 인물 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "실제에 가까운 적극적 그래픽 폭력"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "유혈 장면 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "비현실적 혈흔"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "현실적 혈흔"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "혈흔 묘사 및 사지 절단"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "성폭력 내용 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "강간/기타 금지 성 행위"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "알콜 음료 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "알콜 음료 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "알콜 음료 활용"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "불법 약물 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "불법 약물 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "불법 약물 활용"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "담배 상품 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "담배 상품 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "담배 상품 활용"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "나체 표현 내용 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "대략적인 예술 전라 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "지속적인 전라 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "성적 표현 언급 또는 묘사 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "도발적 표현 언급 또는 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "성적 표현 언급 또는 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "그래픽 성 행위"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "비속어 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "온화하거나 드문 모독 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "어중간한 모독 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "강렬하거나 빈번한 모독 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "부적절한 유머 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "슬랩스틱 유머"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "3류/화장실 유머"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "성인/성 유머"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "차별 문구 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "특정 인물 집단에 대한 부정"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "감정적 해를 끼치도록 의도한 차별"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "성, 인종, 종교에 기반한 적나라한 차별"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "광고 내용 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "제품 배치"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "특정 브랜드 및 상표 등록 제품을 명백하게 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "특정 실물 구매를 장려"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "도박 내용 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "토큰 또는 크레딧을 활용한 임의 이벤트 도박"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "“게임” 머니 활용 도박"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "현금 활용 도박"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "현금 소비 기능 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "현금 기부 장려"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "앱 내 현금 소비성"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "다른 사용자와의 문장 대화 기능 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "문장 대화 없는 사용자간 교류"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "사용자간 중재 문장 대화 기능"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "사용자간 비통제 문장 대화 기능"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "다른 사용자와의 음성 대화 기능 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "사용자간 비통제 영상/음성 대화 기능"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "소셜 네트워크 사용자 이름 또는 전자메일 주소를 공유하지 않음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "소셜 네트워크 사용자 이름 또는 전자메일 주소를 공유함"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "사용자 정보를 제 3자와 공유하지 않음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "프로그램 최신 버전 확인"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "사용자를 식별할 수 없는 진단 데이터 공유"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "사용자 상호 식별 가능한 정보 공유"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "실제 위치를 다른 사용자에게 공유하지 않음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "실제 위치를 다른 사용자에게 공유함"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "동성애 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "동성애 간접 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "동성간의 키스"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "동성간의 성적 행동 화면 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "매춘 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "매춘 간접 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "매춘 직접 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "매춘 행위 화면 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "간통 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "간통 간접 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "간통 직접 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "간통 행위 화면 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "성적 대상화 주인공 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "반라 인간상"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "명백히 성적 매력을 부여한 인간상"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "신성 모독 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "역사적 신성 모독 표현 또는 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "현대식 인간 모독 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "현대식 모독 화면 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "명확하지 않은 죽은 인간 시신 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "명확한 죽은 인간 시신 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "실외에 노출된 죽은 인간 시신 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "인간 신체 모독 화면 묘사"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "노예제도 언급 없음"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "역사적 노예 모독 표현 또는 언급"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "현대식 노예제도 표현"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "현대식 노예제도 화면 묘사"

--- a/po/ko.po
+++ b/po/ko.po
@@ -11,10 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 03:00+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: Korean (http://www.transifex.com/freedesktop/appstream-glib/language/ko/)\n"
+"Language-Team: Korean (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/ko/)\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,350 +24,528 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "타르볼에 초고해상도 아이콘 추가"
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "추가 디버깅 정보 보이기"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
 msgid "Add a cache ID to each component"
 msgstr "각각 구성 요소에 캐시 ID 추가"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "출력 내용에 실패 결과 포함"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "타르볼에 초고해상도 아이콘 추가"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "XML에 인코딩한 아이콘 추가"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "추가함"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "%s의 명령 별칭"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream 유틸리티"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "설치된 프로그램 데이터 검사"
-
-msgid "Command not found, valid commands are:"
-msgstr "명령이 존재하지 않습니다. 유효한 명령은 다음과 같습니다:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "두 AppStream 파일 내용 비교"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "%s에서 %s(으)로의 변환은 아직 지원하지 않습니다"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "AppData 파일을 NEWS 형식으로 변환 "
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "NEWS 파일을 AppData 형식으로 변환"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "AppStream 메타데이터 버전을 변환"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "CSV 상태 문서 생성"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "HTML 매트릭스 페이지 만들기"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "HTML 상태 페이지 생성"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "프로그램 검색 토큰 표시"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "타르볼에 아이콘 압축 안 함"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "네트워크 접근 사용하지 않음"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "완료!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "AppStream 메타데이터의 프로그램을 모두 출력"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "로그 디렉터리 지정"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "프로파일링 활성화"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "꾸러미 디렉터리 설정"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "출력 디렉터리 만드는 중 오류"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "임시 디렉터리 설정"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "AppData 파일 불러오는 중 오류"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "출력 디렉터리 설정"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "desktop 파일 불러오는 중 오류"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "아이콘 디렉터리 설정"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "kudos 해석중 오류"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "캐시 디렉터리 설정"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "제공 요소 해석중 오류"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "출력 파일 기본 이름 설정"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "번역 해석중 오류"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "원본 이름 설정"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "AppStream 파일 저장중 오류"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "스레드 개수 설정"
 
-#. list failures
-msgid "FAILED"
-msgstr "실패"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "픽셀 단위 최소 아이콘 크기 설정"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "과거 메타데이터 위치 설정"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "veto 형식 무시"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "꾸러미를 추가할 수 없음"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "메타데이터를 생성할 수 없음"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "꾸러미를 열 수 없음"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "인자 해석에 실패함"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "빌더를 설정할 수 없음"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "꾸러미를 열 수 없음"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "꾸러미 검사 중..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "꾸러미를 추가할 수 없음"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "메타데이터를 생성할 수 없음"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "완료!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "아이콘 저장중"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "접두부 설정"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "프로그램 처리중"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "AppData 파일 불러오는 중 오류"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "번역 해석중 오류"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "kudos 해석중 오류"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "제공 요소 해석중 오류"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "desktop 파일 불러오는 중 오류"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "desktop 파일 불러오는 중 오류"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "출력 디렉터리 만드는 중 오류"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "AppStream 저장중"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "AppStream 파일 저장중 오류"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "%s의 명령 별칭"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "명령이 존재하지 않습니다. 유효한 명령은 다음과 같습니다:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "파일을 확인하여 'FIXME' 항목을 수정하십시오"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "오래된 API 버전"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "새 API 버전"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "인자가 충분하지 않습니다. old.xml new.xml version이 필요합니다"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "%s에서 %s(으)로의 변환은 아직 지원하지 않습니다"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "인자가 충분하지 않습니다. file.xml이 필요합니다"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "'%s' 파일 형식을 업그레이드할 수 없습니다"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "인식할 수 없는 형식"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "입력 문자열의 GUID 만들기"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "veto 형식 무시"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "AppStream 마크업으로 파일 가져오기"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "출력 내용에 실패 결과 포함"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "외부 파일에서 추가 메타데이터 가져오기"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "AppStream 메타데이터 설치"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "새로운 위치에서 AppStream 메타데이터 설치"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "꾸러미가 없는 프로그램 목록 출력"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "여러 파일을 AppStream 파일에 병합"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "업스트림 스크린샷 반전"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "AppData 파일 수정"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "새 API 버전"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "데스크톱 프로그램이 없습니다"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "인자가 충분하지 않습니다. file.xml이 필요합니다"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "인자가 충분하지 않습니다. old.xml new.xml version이 필요합니다"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "확인"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "오래된 API 버전"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "실패"
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "파일을 확인하여 'FIXME' 항목을 수정하십시오"
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "검증 실패"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "프로그램 처리중"
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "파일 검증 실패"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "검증 실패"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "파일 검증 실패"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "제거함"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "원본 파일 스크린샷 바꾸기"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "추가함"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "AppStream 저장중"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "아이콘 저장중"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "꾸러미 검사 중..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr " AppStream 프로그램 검색"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "꾸러미 이름으로 AppStream 프로그램 검색"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "네트워크 접근 사용하지 않음"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "출력 파일 기본 이름 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "캐시 디렉터리 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "아이콘 디렉터리 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "로그 디렉터리 지정"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "픽셀 단위 최소 아이콘 크기 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "스레드 개수 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "과거 메타데이터 위치 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "원본 이름 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "출력 디렉터리 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "꾸러미 디렉터리 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "접두부 설정"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "임시 디렉터리 설정"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "추가 디버깅 정보 보이기"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "버전 표시"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "AppStream 파일을 AppData 파일과 Metainfo 파일로 분리"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "프로파일링 활성화"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "AppStream 메타데이터 삭제"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "AppStream 메타데이터 버전을 변환"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "AppData 메타데이터를 최신 버전으로 업그레이드"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "AppStream 메타데이터의 프로그램을 모두 출력"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr " AppStream 프로그램 검색"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "꾸러미 이름으로 AppStream 프로그램 검색"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr " AppStream 프로그램 검색"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "꾸러미 이름으로 AppStream 프로그램 검색"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "프로그램 검색 토큰 표시"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "AppStream 메타데이터 설치"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "새로운 위치에서 AppStream 메타데이터 설치"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "AppStream 메타데이터 삭제"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "HTML 상태 페이지 생성"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "CSV 상태 문서 생성"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "HTML 매트릭스 페이지 만들기"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "꾸러미가 없는 프로그램 목록 출력"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "AppData 또는 AppStream 파일 검증"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "AppData 또는 AppStream 파일 검증(유연)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "AppData 또는 AppStream 파일 검증(엄격)"
 
-msgid "Validation failed"
-msgstr "검증 실패"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "AppData 또는 AppStream 파일 검증(유연)"
 
-msgid "Validation of files failed"
-msgstr "파일 검증 실패"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "AppData 파일을 NEWS 형식으로 변환 "
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "NEWS 파일을 AppData 형식으로 변환"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "설치된 프로그램 데이터 검사"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "설치된 프로그램 데이터 검사"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "원본 파일 스크린샷 바꾸기"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "업스트림 스크린샷 반전"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "외부 파일에서 추가 메타데이터 가져오기"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "두 AppStream 파일 내용 비교"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "입력 문자열의 GUID 만들기"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "AppData 파일 수정"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "AppStream 파일을 AppData 파일과 Metainfo 파일로 분리"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "여러 파일을 AppStream 파일에 병합"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "AppStream 마크업으로 파일 가져오기"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "꾸러미 이름으로 AppStream 프로그램 검색"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream 유틸리티"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "버전:"

--- a/po/lt.po
+++ b/po/lt.po
@@ -536,3 +536,541 @@ msgstr "AppStream paslaugų programa"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versija:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Bendra"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "VISKAS"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Tik suaugusiems"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Subrendusiems"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Paaugliams"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Visiems nuo 10-ies"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Visiems"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Ankstyvai vaikystei"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Nėra animacinio smurto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Animaciniai personažai nesaugiose situacijose"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Animaciniai personažai agresyviame konflikte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Grafinis smurtas, įtraukiantis animacinius personažus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Nėra fantastinio smurto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Personažai nesaugiose, lengvai nuo realybės atskiriamose, situacijose"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Personažai agresyviame, lengvai nuo realybės atskiriamame, konflikte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Grafinis, lengvai nuo realybės atskiriamas, smurtas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Nėra tikroviško smurto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Švelnūs tikroviški personažai nesaugiose situacijose"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Tikroviškų personažų vaizdavimai agresyviame konflikte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Grafinis smurtas, įtraukiantis tikroviškus personažus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Nėra kraujo praliejimo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Netikroviškas kraujo praliejimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Tikroviškas kraujo praliejimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Kraujo praliejimo ir kūno dalių sužalojimo vaizdavimai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Nėra seksualinio smurto"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Išprievartavimai ar kita smurtinė seksualinė elgsena"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Nėra nuorodos į alkoholinius gėrimus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Nuorodos į alkoholinius gėrimus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Alkoholinių gėrimų vartojimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Nėra nuorodų į uždraustus narkotikus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Nuorodos į uždraustus narkotikus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Uždraustų narkotikų vartojimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Nėra nuorodos į tabako gaminius"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Nuorodos į tabako gaminius"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Tabako gaminių vartojimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Nėra jokio tipo nuogumo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Trumpas meninis nuogumas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Užsitęsęs nuogumas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Nėra nuorodų į seksualinį pobūdžio vaizdavimus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokuojančios nuorodos ar vaizdavimai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Seksualinės nuorodos ar vaizdavimai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Grafinė seksualinė elgsena"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Nėra jokių keiksmažodžių"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Nesmarkus ar nedažnas keiksmų naudojimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Vidutinis keiksmų naudojimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Smarkus ar dažnas keiksmų naudojimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Nėra netinkamo humoro"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Papliauškų humoras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgarus ar tualeto humoras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Suaugusiųjų ar seksualinis humoras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Nėra jokio pobūdžio diskriminuojančios kalbos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Priešiškumas, nukreiptas į tam tikrą žmonių grupę"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminacija, sukurta sukelti emocinę žalą"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Atvira diskriminacija dėl lyties, rasės ar religijos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Nėra jokio pobūdžio reklamų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Produktų išdėstymas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Atviros nuorodos į tam tikrus prekės ženklus ar produktus su prekyženkliu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Naudotojai yra skatinami įsigyti tam tikrus realaus pasaulio daiktus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Nėra jokio pobūdžio azartinių lošimų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Lošimas iš atsitiktinių įvykių, naudojantis žetonais ar kreditais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Lošimai naudojant „žaidimo“ pinigus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Lošimai naudojant tikrus pinigus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Nėra galimybės išleisti pinigus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Naudotojai yra skatinami aukoti realius pinigus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Galimybė žaidime išleisti tikrus pinigus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Nėra galimybės susirašinėti su kitais žaidėjais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Žaidėjo su žaidėju sąveikos žaidime be pokalbių funkcionalumo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Prižiūrimas pokalbių funkcionalumas tarp žaidėjų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Neprižiūrimas pokalbių funkcionalumas tarp žaidėjų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Nėra galimybės kalbėti su kitais žaidėjais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Neprižiūrimas garso ir vaizdo pokalbių funkcionalumas tarp žaidėjų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Nėra dalinimosi socialinių tinklų naudotojų vardais ar el. pašto adresais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Dalinimasis socialinių tinklų naudotojų vardais ar el. pašto adresais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Nėra dalinimosi naudotojo informacija su trečiosiomis šalimis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Tikrinama, ar naujausia programos versija"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Dalinimasis diagnostikos duomenimis neleidžia kitiems identifikuoti naudotojų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Dalinimasis informacija, kuri leidžia kitiems identifikuoti naudotoją"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Nėra dalinimosi savo fizine buvimo vieta su kitais naudotojais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Dalinimasis savo fizine buvimo vieta su kitais naudotojais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Nėra nuorodos į homoseksualumą"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Netiesioginės nuorodos į homoseksualumą"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Bučiniai tarp tos pačios lyties asmenų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Vazdinis seksualus elgesys tarp tos pačios lyties asmenų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Nėra nuorodų į prostituciją"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Netiesioginės nuorodos į prostituciją"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Tiesioginės nuorodos į prostituciją"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Vaizdinis prostitucijos akto atvaizdavimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Nėra nuorodos į turinį suaugusiems"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Netiesioginės nuorodos į turinį suaugusiems"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Tiesioginės nuorodos į turinį suaugusiems"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Vaizdinis turinio suaugusiems atvaizdavimas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Nėra išreikšto seksualumo veikėjų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Mažai apsirengę žmonės/herojai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Itin seksualūs žmonės/herojai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Nėra nuorodų į išniekinimą"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Vaizdavimai arba nuorodos į istorinį išniekinimą"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Šiuolaikinio žmonių išniekinimo vaizdavimai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Šiuolaikinio žmonių išniekinimo vaizdai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Nėra matomų mirusių žmonių palaikų"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Matomi mirusių žmonių palaikai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Detaliai vaizduojami mirusių žmonių palaikai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Žmonių kūnų išniekinimo vaizdai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Nėra nuorodos į vergiją"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Vaizdavimai arba nuorodos į istorinę vergiją"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Šiuolaikinės vergijos vaizdavimai"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Šiuolaikinės vergijos vaizdai"

--- a/po/lt.po
+++ b/po/lt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-10-08 07:11+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian\n"
@@ -11,407 +11,528 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2)\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Rodyti papildomą derinimo informaciją"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Pridėti kiekvienam komponentui podėlio ID"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Įtraukti į išvestį nepavykusius rezultatus"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Pridėti į TAR paką HiDPI piktogramas"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Pridėti kiekvienam komponentui podėlio ID"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Pridėti kalbą į šaltinio failą"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Pridėti pateikimą į šaltinio failą"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Pridėti į XML koduotas piktogramas"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Pridėta"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alternatyvusis %s pavadinimas"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream paslaugų programa"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Atsisakyta"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Tikrinti įdiegtus programos duomenis"
-
-msgid "Command not found, valid commands are:"
-msgstr "Komanda nerasta, teisingos komandos yra:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Palyginti dviejų AppStream failų turinį"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Palyginti versijų numerius"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Konvertavimas %s į %s nėra įgyvendintas"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Konvertuoti AppData failą į NEWS formatą"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Konvertuoti NEWS failą į AppData formatą"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Konvertuoja AppStream metaduomenis iš vienos versijos į kitą"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Sukurti CSV būsenos dokumentą"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Sukurti HTML matricos puslapį"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Sukurti HTML būsenos puslapį"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Sukuria pavyzdinį AppData failą iš .desktop failo"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Rodyti programų paieškos prieigos raktus"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Neglaudinti piktogramų į TAR paką"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Nenaudoti tinklo prieigos"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Atlikta!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Padaro programų išklotinę AppStream metaduomenyse"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Nustatyti registravimo katalogą"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Įjungti profiliavimą"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Nustatyti paketų katalogą"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Klaida kuriant išvesties katalogą"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Nustatyti laikinąjį katalogą"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Klaida įkeliant AppData failą"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Nustatyti išvesties katalogą"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Klaida įkeliant darbalaukio failą"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Nustatyti piktogramų katalogą"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Klaida nagrinėjant kudo"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Nustatyti podėlio katalogą"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Klaida nagrinėjant pateikimus"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Nustatyti pagrindinius išvesties failų pavadinimus"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Klaida nagrinėjant vertimus"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Nustatyti kilmės pavadinimą"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Klaida įrašant AppStream failą"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Nustatyti gijų skaičių"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Eksportuoja sutikimą į tekstą"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Nustatyti mažiausią piktogramos dydį, pikseliais"
 
-#. list failures
-msgid "FAILED"
-msgstr "NEPAVYKO"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Nustatyti seną metaduomenų vietą"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Nepaisyti tam tikrų veto tipų"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Nepavyko pridėti paketo"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Nepavyko sugeneruoti metaduomenų"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Nepavyko atverti paketų"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Nepavyko išnagrinėti argumentų"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Nepavyko nustatyti kūrėjo"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Nepavyko atverti paketų"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Peržiūrimi paketai..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Nepavyko pridėti paketo"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Išnagrinėta %u/%u failų..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Nepavyko sugeneruoti metaduomenų"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Atlikta!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Įrašoma piktograma"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Nustatyti priešdėlį"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Apdorojama programa"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Klaida įkeliant AppData failą"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Klaida nagrinėjant vertimus"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Klaida nagrinėjant kudo"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Klaida nagrinėjant pateikimus"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Neteisingas darbalaukio failo pavadinimas"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Klaida įkeliant darbalaukio failą"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Klaida kuriant išvesties katalogą"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Įrašoma AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Klaida įrašant AppStream failą"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alternatyvusis %s pavadinimas"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Komanda nerasta, teisingos komandos yra:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Peržiūrėkite failą ir pataisykite visus \"FIXME\" elementus"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Sena API versija"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nauja API versija"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Nepakanka argumentų, buvo tikėtasi senas.xml naujas.xml versijos"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Konvertavimas %s į %s nėra įgyvendintas"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Nepakanka argumentų, buvo tikėtasi failas.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Failo formatas \"%s\" negali būti atnaujintas"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Neatpažintas formatas"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Generuoti GUID iš įvesties eilutės"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Nepaisyti tam tikrų veto tipų"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importuoti failą į AppStream ženklinimą"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Įtraukti į išvestį nepavykusius rezultatus"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Prijungti papildomus metaduomenis iš išorinio failo"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Įdiegia AppStream metaduomenis"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Įdiegia AppStream metaduomenis su nauja kilme"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Neteisingas darbalaukio failo pavadinimas"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Išvardyti programas, kurios nėra palaikomos paketų"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Sulieti kelis failus į AppStream failą"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Dubliuoti pirminio kūrimo srauto ekrano kopijas"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modifikuoti AppData failą"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nauja API versija"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nerasta jokių darbalaukio programų"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Nepakanka argumentų, buvo tikėtasi failas.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Nepakanka argumentų, buvo tikėtasi senas.xml naujas.xml versijos"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "GERAI"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Sena API versija"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "NEPAVYKO"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Patvirtinimas nepavyko"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Failų patvirtinimas nepavyko"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Išnagrinėta %u/%u failų..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Peržiūrėkite failą ir pataisykite visus \"FIXME\" elementus"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Patvirtinimas nepavyko"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Apdorojama programa"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Failų patvirtinimas nepavyko"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Pašalinta"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Pakeisti ekrano kopijas šaltinio faile"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Pridėta"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Įrašoma AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Atsisakyta"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Įrašoma piktograma"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Peržiūrimi paketai..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Ieškoti AppStream programų"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Ieškoti AppStream programų pagal kategorijos pavadinimą"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Ieškoti AppStream programų pagal paketo pavadinimą"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Nenaudoti tinklo prieigos"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Nustatyti pagrindinius išvesties failų pavadinimus"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Nustatyti podėlio katalogą"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Nustatyti piktogramų katalogą"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Nustatyti registravimo katalogą"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Nustatyti mažiausią piktogramos dydį, pikseliais"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Nustatyti gijų skaičių"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Nustatyti seną metaduomenų vietą"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Nustatyti kilmės pavadinimą"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Nustatyti išvesties katalogą"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Nustatyti paketų katalogą"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Nustatyti priešdėlį"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Nustatyti laikinąjį katalogą"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Rodyti visas įdiegtas AppStream programas"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Rodyti papildomą derinimo informaciją"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Rodyti versiją"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Padalyti AppStream failą į AppData ir metainformacijos failą"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Įjungti profiliavimą"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Išbandyti reguliarųjį reiškinį"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Konvertuoja AppStream metaduomenis iš vienos versijos į kitą"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Pašalina AppStream metaduomenis"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Naujinti AppData metaduomenis į naujausią versiją"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Sukuria pavyzdinį AppData failą iš .desktop failo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Padaro programų išklotinę AppStream metaduomenyse"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Ieškoti AppStream programų"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Ieškoti AppStream programų pagal paketo pavadinimą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Rodyti visas įdiegtas AppStream programas"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Ieškoti AppStream programų pagal kategorijos pavadinimą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Rodyti programų paieškos prieigos raktus"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Įdiegia AppStream metaduomenis"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Įdiegia AppStream metaduomenis su nauja kilme"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Pašalina AppStream metaduomenis"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Sukurti HTML būsenos puslapį"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Sukurti CSV būsenos dokumentą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Sukurti HTML matricos puslapį"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Išvardyti programas, kurios nėra palaikomos paketų"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Patvirtinti AppData ar AppStream failą"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Patvirtinti AppData ar AppStream failą (atpalaiduotas)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Eksportuoja sutikimą į tekstą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Patvirtinti AppData ar AppStream failą (griežtas)"
 
-msgid "Validation failed"
-msgstr "Patvirtinimas nepavyko"
-
-msgid "Validation of files failed"
-msgstr "Failų patvirtinimas nepavyko"
-
-msgid "Version:"
-msgstr "Versija:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Patvirtinti AppData ar AppStream failą (atpalaiduotas)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Konvertuoti AppData failą į NEWS formatą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Konvertuoti NEWS failą į AppData formatą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Tikrinti įdiegtus programos duomenis"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "tikrinti įdiegtą programą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Pakeisti ekrano kopijas šaltinio faile"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Pridėti pateikimą į šaltinio failą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Pridėti kalbą į šaltinio failą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Dubliuoti pirminio kūrimo srauto ekrano kopijas"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Prijungti papildomus metaduomenis iš išorinio failo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Palyginti dviejų AppStream failų turinį"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Generuoti GUID iš įvesties eilutės"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modifikuoti AppData failą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Padalyti AppStream failą į AppData ir metainformacijos failą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Sulieti kelis failus į AppStream failą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importuoti failą į AppStream ženklinimą"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Stebėti ar AppStream vietose yra pakeitimų"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "tikrinti įdiegtą programą"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Palyginti versijų numerius"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Išbandyti reguliarųjį reiškinį"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream paslaugų programa"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Versija:"

--- a/po/oc.po
+++ b/po/oc.po
@@ -11,203 +11,545 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
-"Report-Msgid-Bugs-To: richard@hughsie.com\n"
-"POT-Creation-Date: 2016-06-13 10:53+0100\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-06-12 22:44+0000\n"
 "Last-Translator: Tot en òc <totenoc@gmail.com>\n"
-"Language-Team: Occitan (post 1500) (http://www.transifex.com/freedesktop/appstream-glib/language/oc/)\n"
+"Language-Team: Occitan (post 1500) (http://www.transifex.com/freedesktop/"
+"appstream-glib/language/oc/)\n"
+"Language: oc\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: oc\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Apond un identificant de cache a cada component"
-
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Apondut"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Aliàs de %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitari AppStream"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Verificar las donadas d'aplicacions installadas"
-
-msgid "Command not found, valid commands are:"
-msgstr "Comanda introbabla, las comandas validas son :"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Convertís las metadonadas AppStream d'una version a una autra"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Crear un document de sintèsi CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Crear una pagina de sintèsi HTML"
-
-#. TRANSLATORS: command description
-msgid "Creates an example Appdata file from a .desktop file"
-msgstr "Crèa un fichièr Appdata exemple a partir d'un fichièr .desktop"
-
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Utilizatz pas l'accès ret"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Acabat !"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Expòrta las aplicacions dins las metadonadas AppStream"
-
-#. list failures
-msgid "FAILED"
-msgstr "FRACÀS"
-
-#. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "L'apondon del paquet a fracassat"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "La generacion de metadonadas a fracassat"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Fracàs de dobertura dels paquets"
-
-#. TRANSLATORS: error message
-msgid "Failed to parse arguments"
-msgstr "Fracàs d'analisi dels paramètres"
-
-#. TRANSLATORS: error message
-msgid "Failed to set up builder"
-msgstr "Fracàs de configuracion del constructor"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Installa las metadonadas AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Installa las metadonadas AppStream d'una novèla origina"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Lista de las aplicacions non basadas sus de paquets"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Novèla version d'API"
-
-msgid "Not enough arguments, expected file.xml"
-msgstr "Paramètres insufisents, file.xml es esperat"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Paramètres insufisents, indicatz ancian.xml novel.xml version"
-
-#. TRANSLATORS: the file is valid
-msgid "OK"
-msgstr "D'ACÒRDI"
-
-#. TRANSLATORS: information message
-#, c-format
-msgid "Parsed %i/%i files..."
-msgstr "%i/%i fichièrs analisats…"
-
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Revisatz lo fichièr e resolvètz los elements « FIXME »"
-
-#. TRANSLATORS: application was removed
-msgid "Removed"
-msgstr "Suprimit"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Analisi dels paquets…"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Definís lo repertòri de cache"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Definís lo repertòri de jornalizacion"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Definís lo nombre de fials d'execucion"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Definís l'ancian emplaçament de las metadonadas"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Definís lo nom d'origina"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Definís lo repertòri de sortida"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Definís lo repertòri dels paquets"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Definís lo repertòri temporari"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
 msgid "Show extra debugging information"
 msgstr "Aficha d'informacions de desbugatge suplementàrias"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Apond un identificant de cache a cada component"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
+msgid "Add encoded icons to the XML"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:91
+msgid "Do not compress the icons into a tarball"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Definís lo repertòri de jornalizacion"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Definís lo repertòri dels paquets"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Definís lo repertòri temporari"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Definís lo repertòri de sortida"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+#, fuzzy
+msgid "Set the icons directory"
+msgstr "Definís lo repertòri de jornalizacion"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Definís lo repertòri de cache"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+#, fuzzy
+msgid "Set the basenames of the output files"
+msgstr "Definís lo nombre de fials d'execucion"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Definís lo nom d'origina"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Definís lo nombre de fials d'execucion"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Definís l'ancian emplaçament de las metadonadas"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
+msgid "Failed to parse arguments"
+msgstr "Fracàs d'analisi dels paramètres"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:246
+msgid "Failed to set up builder"
+msgstr "Fracàs de configuracion del constructor"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Fracàs de dobertura dels paquets"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Analisi dels paquets…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "L'apondon del paquet a fracassat"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, fuzzy, c-format
+msgid "Parsed %u/%u files..."
+msgstr "%i/%i fichièrs analisats…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "La generacion de metadonadas a fracassat"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Acabat !"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+#, fuzzy
+msgid "Set the prefix"
+msgstr "Definís lo nom d'origina"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr ""
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr ""
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr ""
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr ""
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr ""
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+#, fuzzy
+msgid "Error creating output directory"
+msgstr "Definís lo repertòri de sortida"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr ""
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr ""
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Aliàs de %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Comanda introbabla, las comandas validas son :"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Revisatz lo fichièr e resolvètz los elements « FIXME »"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+#, fuzzy
+msgid "Old API version"
+msgstr "Novèla version d'API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Novèla version d'API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Paramètres insufisents, indicatz ancian.xml novel.xml version"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr ""
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Paramètres insufisents, file.xml es esperat"
+
+#. TRANSLATORS: %s is a file type,
+#. * e.g. 'appdata'
+#: client/as-util.c:595
+#, c-format
+msgid "File format '%s' cannot be upgraded"
+msgstr ""
+
+#. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
+msgid "Format not recognised"
+msgstr ""
+
+#. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
+msgid "No desktop applications found"
+msgstr ""
+
+#. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
+msgid "OK"
+msgstr "D'ACÒRDI"
+
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FRACÀS"
+
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "La validacion a fracassat"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "La validacion dels fichièrs a fracassat"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "La validacion a fracassat"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "La validacion dels fichièrs a fracassat"
+
+#. TRANSLATORS: application was removed
+#: client/as-util.c:4076
+msgid "Removed"
+msgstr "Suprimit"
+
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Apondut"
+
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
+
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Utilizatz pas l'accès ret"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Afichar la version"
 
-#. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Desinstalla las metadonadas AppStream"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr ""
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Convertís las metadonadas AppStream d'una version a una autra"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Met a jorn las metadonadas AppData a la darrièra version"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+#, fuzzy
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Crèa un fichièr Appdata exemple a partir d'un fichièr .desktop"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Expòrta las aplicacions dins las metadonadas AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Verificar las donadas d'aplicacions installadas"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Installa las metadonadas AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Installa las metadonadas AppStream d'una novèla origina"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Desinstalla las metadonadas AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Crear una pagina de sintèsi HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Crear un document de sintèsi CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+#, fuzzy
+msgid "Create an HTML matrix page"
+msgstr "Crear una pagina de sintèsi HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Lista de las aplicacions non basadas sus de paquets"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Validar un fichièr AppData o AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Validar un fichièr AppData o AppStream (laxista)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Validar un fichièr AppData o AppStream (estricte)"
 
-msgid "Validation failed"
-msgstr "La validacion a fracassat"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Validar un fichièr AppData o AppStream (laxista)"
 
-msgid "Validation of files failed"
-msgstr "La validacion dels fichièrs a fracassat"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr ""
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Verificar las donadas d'aplicacions installadas"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Verificar las donadas d'aplicacions installadas"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+msgid "Watch AppStream locations for changes"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitari AppStream"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version :"

--- a/po/oc.po
+++ b/po/oc.po
@@ -553,3 +553,550 @@ msgstr "Utilitari AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version :"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "General"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "TOTES"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Adultes unicament"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Matur"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Adolescents"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "10 ans e mai"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Tot lo monde"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Bas atge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Pas cap de violéncia de dessenhs animats"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personatges de dessenh animat en situacion de dangièr"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personatges de dessenh animat en conflicte agressiu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr ""
+"Illustracion de violéncias implicant los personatges del dessenh animat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Pas de violéncias fantasticas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Personatges en situacions dangierosas francament irrealas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Personatges en situacion de conflicte agressiu francament irreal"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Illustracion violenta francament irreala"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Pas cap de violéncia realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personatges mejanament realistas en situacion dangierosa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Illustracions de personatges realistas en conflicte agressiu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Illustracions de violéncias implicant de personatges realistas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Pas cap de massacre"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Chaple irrealista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Chaple realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Illustracions d'un chaple e de mutilacions corporalas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Pas cap de violéncia sexuala"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Viòl e autre compòrtament sexual violent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Pas cap d'allusion a de bevendas alcoolizadas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Allusions a de bevendas alcoolizadas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Usatge de bevendas alcoolicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Pas cap d'allusion a de drògas illicitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Allusions a de drògas illicitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Usatge de drògas illicitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+#, fuzzy
+msgid "No references to tobacco products"
+msgstr "Allusions a de produits derivats del tabat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Allusions a de produits derivats del tabat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Referéncia al tabat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Pas cap de nud, de cap de mena"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Nud artistic de corta durada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Nuditat perlongada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Pas cap d'allusion o d'imatge amb caractèr sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Allusions e imatges provocators"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Recercar d'aplicacions"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Illustracions de compòrtaments sexuals"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Pas cap de profanacion, de cap de mena"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Utilizacion moderada e ocasionnala d'injúrias"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Utilizacion moderada d'injúrias"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Utilizacion fòrta e frequenta d'injúrias"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Pas cap d'umor desplaçat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Umor burlèsc"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Umor vulgar e de regòla"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Umor per adultes e sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Pas cap d'allusion discriminatòria, de cap de mena"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Actituds negativas de cap a de gropes especifics de gents"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminacions destinadas a nafrar emocionalament"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Discriminacions explicitas basadas sul genre, lo sèxe, la raça e la religion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Pas cap de publicitat, de cap de mena"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Gestion de projècte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Allusions explicitas a de produits de marca especifica e depausada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr ""
+"Los utilizaires son encoratjats a crompar d'elements especifics del monde "
+"real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Pas cap de pariatge, de cap de mena"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Pariatges sus d'eveniments aleatòris amb l'ajuda de getons e a crèdit"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Pariatges amb de moneda « fictiva »"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Pariatges amb d'argent vertadièr"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Pas cap de possibilitat de despensar d'argent"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Los utilizaires son encoratjats a donar d’argent real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Possibilitat de despensar d'argent vertadièr dins l’aplicacion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Pas cap de possibilitat de discutir amb los autres utilizaires"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interaccions entre utilizaires sens possibilitat de discussion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Possibilitat moderada de discutir entre utilizaires"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Possibilitat de discutir sens contròtle entre utilizaires"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Pas cap de mejan de parlar amb los autres utilizaires"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Possibilitat de discutir o se veire sens contròtle entre utilizaires"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Pas cap de partiment dels noms d'utilizaire de rets socialas o d'adreças "
+"electronicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Partiment dels noms d'utilizaire de rets socialas e de las adreças corrièr "
+"electronic"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr ""
+"Pas cap de partiment dels identificants d’utilizaire amb de tèrças partidas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Verificacion se s’agís de la darrièra version de l’aplicacion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Partiment de las donadas de diagnostic que permet pas l’identification de "
+"l’utilizaire"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Partiment d’informacions que permet l’identificacion de l’utilizaire"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Pas cap de partiment de geolocalizacion amb los autres utilizaires"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Partiment de geolocalizacion amb los autres utilizaires"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Pas cap d'allusion a l’omosexualitat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Allusions indirèctas a l’omosexualitat"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Estrentas entre personas d’un meteis sèxe"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Imatges de comportaments sexuals entre personas d’un meteis sèxe"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Pas cap d'allusion a la prostitucion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Allusions indirèctas a la prostitucion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Allusions dirèctas a la prostitucion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Imatges d’actes de prostitucion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Pas cap d'allusion a l’adultèri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Allusions indirèctas a l’adultèri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Allusions dirèctas a l’adultèri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Imatges d’actes d’adultèri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Representacions umanas amb caractèr non sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Representacions umanas leugièrament vestidas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Representacions umanas amb caractèr dobèrtament sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Pas cap d'allusion a de profanacion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Allusions o imatges de profanacions istoricas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Representacions d’actes de profanacion contemporanèus sus umans"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Imatges d’actes de profanacion contemporanèus sus umans"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Pas cap d'imatge de rèstas umanas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Imatges de rèstas umanas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Rèstas umanas expausadas als elements"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Imatges de profanacions sus de còsses umans"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Pas cap d'allusion a l’esclavagisme"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Representacions o allusions a l’esclavagisme istoric"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Representacions d’esclavagisme contemporanèu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Imatges d’esclavagisme contemporanèu"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,415 +12,537 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-09-28 10:53+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
-"Language-Team: Polish (http://www.transifex.com/freedesktop/appstream-glib/language/pl/)\n"
+"Language-Team: Polish (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/pl/)\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Wyświetla dodatkowe informacje debugowania"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Dodaje identyfikator pamięci podręcznej do każdego składnika"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Dołącza niepowodzenia w wyjściu"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Dodaje ikony HiDPI do archiwum tar"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Dodaje identyfikator pamięci podręcznej do każdego składnika"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Dodaje język do pliku źródłowego"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Dodaje element dostarczany do pliku źródłowego"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Dodaje zakodowane ikony do pliku XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Dodano"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias dla %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Narzędzie AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Anulowano"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Sprawdza dane zainstalowanego programu"
-
-msgid "Command not found, valid commands are:"
-msgstr "Nie odnaleziono polecenia. Prawidłowe polecenia:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Porównuje zawartość dwóch plików AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Porównuje numery wersji"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Konwersja %s na %s nie jest zaimplementowana"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Konwertuje plik AppData do formatu NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Konwertuje plik NEWS do formatu AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Konwertuje metadane AppStream z jednej wersji na inną"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Tworzy dokument stanu CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Tworzy stronę macierzy HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Tworzy stronę stanu HTML"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Tworzy przykładowy plik AppData z pliku .desktop"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Wyświetla tokeny wyszukiwania programów"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Bez kompresji ikon do archiwum tar"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Bez używania dostępu do sieci"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Gotowe."
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Zrzuca aplikacje w metadanych AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Ustawia katalog dziennika"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Włącza profilowanie"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Ustawia katalog pakietów"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Błąd podczas tworzenia katalogu wyjściowego"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Ustawia katalog tymczasowy"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Błąd podczas wczytywania pliku AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Ustawia katalog wyjściowy"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Błąd podczas wczytywania pliku .desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Ustawia katalog ikon"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Błąd podczas przetwarzania punktów"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Ustawia katalog pamięci podręcznej"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Błąd podczas przetwarzania elementów dostarczanych"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Ustawia podstawowe nazwy plików wyjściowych"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Błąd podczas przetwarzania tłumaczeń"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Ustawia pierwotną nazwę"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Błąd podczas zapisywania pliku AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Ustawia liczbę wątków"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Eksportuje umowę jako tekst"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Ustawia minimalne wymiary ikony w pikselach"
 
-#. list failures
-msgid "FAILED"
-msgstr "NIEPOWODZENIE"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Ustawia położenie poprzednich metadanych"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignoruje podane typy weta"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Dodanie pakietu się nie powiodło"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Utworzenie metadanych się nie powiodło"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Otwarcie pakietów się nie powiodło"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Przetworzenie parametrów się nie powiodło"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Utworzenie budowania się nie powiodło"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Otwarcie pakietów się nie powiodło"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Skanowanie pakietów…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Dodanie pakietu się nie powiodło"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Przetworzono pliki: %u/%u…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Utworzenie metadanych się nie powiodło"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Gotowe."
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Zapisywanie ikony"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Ustawia przedrostek"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Przetwarzanie programu"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Błąd podczas wczytywania pliku AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Błąd podczas przetwarzania tłumaczeń"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Błąd podczas przetwarzania punktów"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Błąd podczas przetwarzania elementów dostarczanych"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Nieprawidłowa nazwa pliku .desktop"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Błąd podczas wczytywania pliku .desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Błąd podczas tworzenia katalogu wyjściowego"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Zapisywanie pliku AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Błąd podczas zapisywania pliku AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias dla %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Nie odnaleziono polecenia. Prawidłowe polecenia:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Proszę przejrzeć plik i naprawić elementy oznaczone jako „FIXME”"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Poprzednia wersja API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nowa wersja API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Za mało parametrów, oczekiwano wersji poprzedniej.xml nowej.xml"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Konwersja %s na %s nie jest zaimplementowana"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Za mało parametrów, oczekiwano pliku.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Nie można zaktualizować formatu pliku „%s”"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Nie rozpoznano formatu"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Tworzy GUID z ciągu wejściowego"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignoruje podane typy weta"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importuje plik do języka znaczników AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Dołącza niepowodzenia w wyjściu"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Dołącza dodatkowe metadane z zewnętrznego pliku"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Instaluje metadane AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Instaluje metadane AppStream z nowym pochodzeniem"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Nieprawidłowa nazwa pliku .desktop"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Wyświetla listę aplikacji niezawartych w pakietach"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Łączy kilka plików w jeden plik AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Używa zrzutów ekranu nadrzędnego projektu"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modyfikuje plik AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nowa wersja API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nie odnaleziono żadnych programów"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Za mało parametrów, oczekiwano pliku.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Za mało parametrów, oczekiwano wersji poprzedniej.xml nowej.xml"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Poprzednia wersja API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "NIEPOWODZENIE"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Sprawdzenie się nie powiodło"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Sprawdzenie plików się nie powiodło"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Przetworzono pliki: %u/%u…"
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Proszę przejrzeć plik i naprawić elementy oznaczone jako „FIXME”"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Sprawdzenie się nie powiodło"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Przetwarzanie programu"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Sprawdzenie plików się nie powiodło"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Usunięto"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Zastępuje zrzuty ekranu w pliku źródłowym"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Dodano"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Zapisywanie pliku AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Anulowano"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Zapisywanie ikony"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Skanowanie pakietów…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Wyszukuje programy AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Wyszukuje programy AppStream według nazw kategorii"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Wyszukuje programy AppStream według nazw pakietów"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Bez używania dostępu do sieci"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Ustawia podstawowe nazwy plików wyjściowych"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Ustawia katalog pamięci podręcznej"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Ustawia katalog ikon"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Ustawia katalog dziennika"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Ustawia minimalne wymiary ikony w pikselach"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Ustawia liczbę wątków"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Ustawia położenie poprzednich metadanych"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Ustawia pierwotną nazwę"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Ustawia katalog wyjściowy"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Ustawia katalog pakietów"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Ustawia przedrostek"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Ustawia katalog tymczasowy"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Wyświetla wszystkie zainstalowane programy AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Wyświetla dodatkowe informacje debugowania"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Wyświetla wersję"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Dzieli plik AppStream na pliki AppData i Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Włącza profilowanie"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Testuje wyrażenie regularne"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Konwertuje metadane AppStream z jednej wersji na inną"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Odinstalowuje metadane AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Aktualizuje metadane AppData do najnowszej wersji"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Tworzy przykładowy plik AppData z pliku .desktop"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Zrzuca aplikacje w metadanych AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Wyszukuje programy AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Wyszukuje programy AppStream według nazw pakietów"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Wyświetla wszystkie zainstalowane programy AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Wyszukuje programy AppStream według nazw kategorii"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Wyświetla tokeny wyszukiwania programów"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Instaluje metadane AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Instaluje metadane AppStream z nowym pochodzeniem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Odinstalowuje metadane AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Tworzy stronę stanu HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Tworzy dokument stanu CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Tworzy stronę macierzy HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Wyświetla listę aplikacji niezawartych w pakietach"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Sprawdza poprawność pliku AppData lub AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Sprawdza poprawność pliku AppData lub AppStream (rozluźnione)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Eksportuje umowę jako tekst"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Sprawdza poprawność pliku AppData lub AppStream (ścisłe)"
 
-msgid "Validation failed"
-msgstr "Sprawdzenie się nie powiodło"
-
-msgid "Validation of files failed"
-msgstr "Sprawdzenie plików się nie powiodło"
-
-msgid "Version:"
-msgstr "Wersja:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Sprawdza poprawność pliku AppData lub AppStream (rozluźnione)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Konwertuje plik AppData do formatu NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Konwertuje plik NEWS do formatu AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Sprawdza dane zainstalowanego programu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "sprawdza zainstalowany program"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Zastępuje zrzuty ekranu w pliku źródłowym"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Dodaje element dostarczany do pliku źródłowego"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Dodaje język do pliku źródłowego"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Używa zrzutów ekranu nadrzędnego projektu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Dołącza dodatkowe metadane z zewnętrznego pliku"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Porównuje zawartość dwóch plików AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Tworzy GUID z ciągu wejściowego"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modyfikuje plik AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Dzieli plik AppStream na pliki AppData i Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Łączy kilka plików w jeden plik AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importuje plik do języka znaczników AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Obserwuje zmiany w położeniach AppStream"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "sprawdza zainstalowany program"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Porównuje numery wersji"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Testuje wyrażenie regularne"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Narzędzie AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Wersja:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -546,3 +546,547 @@ msgstr "Narzędzie AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Wersja:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Dla wszystkich"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "Dla wszystkich"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Tylko dla dorosłych"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Dla dorosłych"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Dla nastolatków"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Dla wszystkich 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Dla wszystkich"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Dla małych dzieci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Brak rysunkowej przemocy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Rysunkowe postacie w niebezpiecznych sytuacjach"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Rysunkowe postacie w agresywnym konflikcie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Obrazowa przemoc dotycząca rysunkowych postaci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Brak nierzeczywistej przemocy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Postacie w niebezpiecznych sytuacjach, łatwo odróżnialnych od rzeczywistości"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Postacie w agresywnym konflikcie, łatwo odróżnialnym od rzeczywistości"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Obrazowa przemoc, łatwo odróżnialna od rzeczywistości"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Brak realistycznej przemocy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Średnio realistyczne postacie w niebezpiecznych sytuacjach"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Przedstawienia realistycznych postaci w agresywnym konflikcie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Obrazowa przemoc dotycząca realistycznych postaci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Brak rozlewu krwi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Nierealistyczny rozlew krwi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistyczny rozlew krwi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Przedstawienia rozlewu krwi i okaleczeń części ciała"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Brak przemocy seksualnej"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Gwałt lub inne brutalne zachowanie seksualne"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Brak odniesień do alkoholu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Odniesienia do napojów alkoholowych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Spożycie napojów alkoholowych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Brak odniesień do narkotyków"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Odniesienia do narkotyków"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Spożycie narkotyków"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Brak odniesień do wyrobów tytoniowych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Odniesienia do wyrobów tytoniowych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Spożycie wyrobów tytoniowych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Brak wszelkiego rodzaju nagości"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Krótkotrwała nagość artystyczna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Długotrwała nagość"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Brak odniesień lub przedstawień o naturze seksualnej"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Wyzywające odniesienia lub przedstawienia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Seksualne odniesienia lub przedstawienia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Obrazowe zachowania seksualne"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Brak wszelkiego rodzaju przekleństw"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Lekkie lub nieczęste użycie przekleństw"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Umiarkowane użycie przekleństw"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Silne lub częste użycie przekleństw"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Brak nieodpowiedniego humoru"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Komedia slapstikowa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Komedia wulgarna lub toaletowa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Komedia dla dorosłych lub seksualna"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Brak wszelkiego rodzaju języka dyskryminacyjnego"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Niechęć wobec konkretnej grupy ludzi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Dyskryminacja mająca na celu krzywdę emocjonalną"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Jawna dyskryminacja ze względu na płeć, orientację seksualną, rasę lub "
+"religię"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Brak wszelkiego rodzaju reklam"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Lokowanie produktu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Jawne odniesienia do konkretnych marek lub zastrzeżonych produktów"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Użytkownicy są zachęcani do zakupu fizycznych przedmiotów"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Brak wszelkiego rodzaju hazardu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Zakłady o losowe wydarzenia używające żetonów lub punktów"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Zakłady używające zabawkowych pieniędzy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Zakłady używające prawdziwych pieniędzy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Brak możliwości wydawania pieniędzy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Użytkownicy są zachęcani do przekazywania datków pieniężnych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Możliwość wydawania prawdziwych pieniędzy w programie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Brak możliwości rozmów tekstowych z innymi użytkownikami"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interakcje między użytkownikami bez funkcji rozmów tekstowych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Moderowana funkcja rozmów tekstowych między użytkownikami"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Niekontrolowana funkcja rozmów tekstowych między użytkownikami"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Brak możliwości rozmów głosowych z innymi użytkownikami"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr ""
+"Niekontrolowana funkcja rozmów głosowych lub wideo między użytkownikami"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Brak udostępniania nazw użytkowników serwisów społecznościowych lub adresów "
+"e-mail"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Udostępnianie nazw użytkowników serwisów społecznościowych lub adresów e-mail"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Brak udostępniania informacji o użytkownikach stronom trzecim"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Wyszukiwanie najnowszej wersji programu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Udostępnianie danych diagnostycznych nieumożliwiających identyfikację "
+"użytkownika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Udostępnianie informacji umożliwiających identyfikację użytkownika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Brak udostępniania rzeczywistego adresu innym użytkownikom"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Udostępnianie rzeczywistego adresu innym użytkownikom"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Brak odniesień do homoseksualizmu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Niebezpośrednie odniesienia do homoseksualizmu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Całowanie między osobami tej samej płci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Obrazowe zachowania seksualne między osobami tej samej płci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Brak odniesień do prostytucji"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Niebezpośrednie odniesienia do prostytucji"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Bezpośrednie odniesienia do prostytucji"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Obrazowe przedstawienia czynności związanych z prostytucją"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Brak odniesień do cudzołóstwa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Niebezpośrednie odniesienia do cudzołóstwa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Bezpośrednie odniesienia do cudzołóstwa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Obrazowe przedstawienia czynności związanych z cudzołóstwem"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Brak seksualizowanych postaci"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Skąpo odziane postacie ludzkie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Jawnie seksualizowane postacie ludzkie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Brak odniesień do profanacji"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Przedstawienia lub odniesienia do historycznej profanacji"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Przedstawienia współczesnej profanacji ludzi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Obrazowe przedstawienia współczesnej profanacji"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Brak widocznych zwłok ludzkich"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Widoczne zwłoki ludzkie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Zwłoki ludzkie wystawione na działanie warunków atmosferycznych"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Obrazowe przedstawienia profanacji ludzkich ciał"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Brak odniesień do niewolnictwa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Przedstawienia lub odniesienia do historycznego niewolnictwa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Przedstawienia współczesnego niewolnictwa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Obrazowe przedstawienia współczesnego niewolnictwa"

--- a/po/pt.po
+++ b/po/pt.po
@@ -552,3 +552,572 @@ msgstr "Utilitário AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versão:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+#, fuzzy
+msgid "Mature"
+msgstr "Destaques"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personagem de desenhos animados em situações inseguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personagem de desenhos animados em conflito agressivo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Violência gráfica envolvendo personagem de desenhos animados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Personagens em situações inseguras facilmente distinguíveis da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Personagem em conflito agressivo facilmente distinguíveis da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Violência gráfica facilmente distinguível da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+#, fuzzy
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personagens moderadamente realistas em situações inseguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Personagens moderadamente realistas em conflito agressivo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Violência gráfica envolvendo personagens realistas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+#, fuzzy
+msgid "No bloodshed"
+msgstr "Derrame de sangue realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Derrame de sangue não realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Derrame de sangue realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Representações de derrame de sangue e mutilações de partes do corpo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Violação ou outro comportamento sexual violento"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+#, fuzzy
+msgid "No references to alcohol"
+msgstr "Referência a bebidas alcoólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referência a bebidas alcoólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Uso de bebidas alcoólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+#, fuzzy
+msgid "No references to illicit drugs"
+msgstr "Referência a drogas ilícitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referência a drogas ilícitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Uso de drogas ilícitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+#, fuzzy
+msgid "No references to tobacco products"
+msgstr "Referências a produtos com tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referências a produtos com tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Uso de produtos com tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Nudez artística breve"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Nudez prolongada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+#, fuzzy
+msgid "No references to or depictions of sexual nature"
+msgstr "Referências ou representações sexuais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Referências ou representações provocatórias"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Referências ou representações sexuais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Comportamento sexual gráfico"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Uso ligeiro ou infrequente de profanidades"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Uso moderado de profanidades "
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Uso constante ou frequente de profanidades"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Humor brejeiro"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Humor vulgar ou visceral"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humor maduro ou sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatividade em relação a um grupo específico de pessoas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+#, fuzzy
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Descriminação destinada a causar dano emocional"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Descriminação explícita baseada em género, sexualidade, raça ou religião"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Colocação de produtos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Referências explícitas a determinadas marcas ou produtos registados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+#, fuzzy
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Os jogadores são encorajados a comprar itens específicos do mundo real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Jogo de apostas com eventos aleatórios utilizando tokens ou créditos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+#, fuzzy
+msgid "Gambling using “play” money"
+msgstr "Jogo de apostas utilizando \"dinheiro de jogo\""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Jogo de apostas com dinheiro real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+#, fuzzy
+msgid "No ability to spend money"
+msgstr "Possibilidade de gastar dinheiro real dentro do jogo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+#, fuzzy
+msgid "Users are encouraged to donate real money"
+msgstr "Os jogadores são encorajados a comprar itens específicos do mundo real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+#, fuzzy
+msgid "Ability to spend real money in-app"
+msgstr "Possibilidade de gastar dinheiro real dentro do jogo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+#, fuzzy
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interações de jogo entre jogadores sem funcionalidade de conversação."
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+#, fuzzy
+msgid "Moderated chat functionality between users"
+msgstr "Conversa entre jogadores não controlada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+#, fuzzy
+msgid "Uncontrolled chat functionality between users"
+msgstr "Conversa entre jogadores não controlada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+#, fuzzy
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Conversa em áudio e vídeo entre jogadores não controlada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+#, fuzzy
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Partilha de nomes de utilizadores de redes sociais e endereços de email"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Partilha de nomes de utilizadores de redes sociais e endereços de email"
+
+# Profiling já foi traduzido como perfilamento, porém a tradução também pode ser a de criação de perfil --Enrico
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+#, fuzzy
+msgid "No sharing of user information with third parties"
+msgstr "Partilha informação do utilizador com terceiros"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+#, fuzzy
+msgid "Checking for the latest application version"
+msgstr "Verificar dados da aplicação instalada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+
+# Profiling já foi traduzido como perfilamento, porém a tradução também pode ser a de criação de perfil --Enrico
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+#, fuzzy
+msgid "Sharing information that lets others identify the user"
+msgstr "Partilha informação do utilizador com terceiros"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+#, fuzzy
+msgid "No sharing of physical location with other users"
+msgstr "Partilha de localizações físicas de outros utilizadores"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+#, fuzzy
+msgid "Sharing physical location with other users"
+msgstr "Partilha de localizações físicas de outros utilizadores"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+#, fuzzy
+msgid "No references to prostitution"
+msgstr "Referências ou representações sexuais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+#, fuzzy
+msgid "Indirect references to prostitution"
+msgstr "Referências ou representações provocatórias"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+#, fuzzy
+msgid "Direct references to prostitution"
+msgstr "Referências ou representações provocatórias"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+#, fuzzy
+msgid "No references to adultery"
+msgstr "Referências a produtos com tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+#, fuzzy
+msgid "No references to desecration"
+msgstr "Referências ou representações sexuais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -9,10 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 03:00+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: Portuguese (http://www.transifex.com/freedesktop/appstream-glib/language/pt/)\n"
+"Language-Team: Portuguese (http://www.transifex.com/freedesktop/appstream-"
+"glib/language/pt/)\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,246 +22,533 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "Adicionar ícones HiDPI ao tarball"
-
-#. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Adicionar uma ID de cache a cada componente"
-
-#. TRANSLATORS: command line option
-msgid "Add encoded icons to the XML"
-msgstr "Adicionar ícones codificados ao XML"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Aliás de %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitário AppStream"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Verificar dados da aplicação instalada"
-
-msgid "Command not found, valid commands are:"
-msgstr "Comando não encontrado, comandos válidos são:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Comparar o conteúdo de dois ficheiros AppStream"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Converter um ficheiro AppData em formato NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Converter um ficheiro NEWS em formato AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Converte metadados do AppStream de uma versão para outra"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Cria um documento CSV de estado"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Cria uma página HTML de matriz"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Cria uma página HTML de estado"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Mostrar símbolos de procura de aplicações"
-
-#. TRANSLATORS: command line option
-msgid "Do not compress the icons into a tarball"
-msgstr "Não comprimir os ícones num tarball"
-
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Não usar acesso à rede"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Terminado!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Despeja as aplicações nos metadados do AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Ativar análise de perfil"
-
-#. list failures
-msgid "FAILED"
-msgstr "FALHA"
-
-#. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Falha ao adicionar pacote"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Falha ao gerar metadados"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Falha ao abrir os pacotes"
-
-#. TRANSLATORS: error message
-msgid "Failed to parse arguments"
-msgstr "Falha ao processar argumentos"
-
-#. TRANSLATORS: error message
-msgid "Failed to set up builder"
-msgstr "Falha ao configurar o construtor"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignorar certos tipos de veto"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Incluir resultados falhados na saída"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorporar metadados extra a partir de ficheiro externo"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Instala metadados do AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Instala metadados do AppStream com nova origem"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Listar aplicações não suportadas por pacotes"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Espelhar capturas de ecrã"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nova versão do API"
-
-msgid "Not enough arguments, expected file.xml"
-msgstr "Sem argumentos suficientes, esperada file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Sem argumentos suficientes, esperadas versões old.xml e new.xml"
-
-#. TRANSLATORS: the file is valid
-msgid "OK"
-msgstr "CORRETO"
-
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Por favor, reveja o ficheiro e repare quaisquer itens \"FIXME\""
-
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Substituir capturas de ecrã no ficheiro origem"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "A analisar os pacotes..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Procurar aplicações AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Definir os nomes base dos ficheiros de saída"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Definir a pasta de cache"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Definir a pasta de ícones"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Definir a pasta de diário"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Definir o tamanho mínimo do ícone, em pixels"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Definir o número de linhas"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Definir a localização de metadados antigos"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Definir o nome de origem"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Definir a pasta de saída"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Definir a pasta de pacotes"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Definir a pasta temporária"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
 msgid "Show extra debugging information"
 msgstr "Mostrar informação extra de depuração"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Adicionar uma ID de cache a cada componente"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Incluir resultados falhados na saída"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "Adicionar ícones HiDPI ao tarball"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
+msgid "Add encoded icons to the XML"
+msgstr "Adicionar ícones codificados ao XML"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:91
+msgid "Do not compress the icons into a tarball"
+msgstr "Não comprimir os ícones num tarball"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Definir a pasta de diário"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Definir a pasta de pacotes"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Definir a pasta temporária"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Definir a pasta de saída"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Definir a pasta de ícones"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Definir a pasta de cache"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Definir os nomes base dos ficheiros de saída"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Definir o nome de origem"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Definir o número de linhas"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Definir o tamanho mínimo do ícone, em pixels"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Definir a localização de metadados antigos"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignorar certos tipos de veto"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
+msgid "Failed to parse arguments"
+msgstr "Falha ao processar argumentos"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:246
+msgid "Failed to set up builder"
+msgstr "Falha ao configurar o construtor"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Falha ao abrir os pacotes"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "A analisar os pacotes..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Falha ao adicionar pacote"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Falha ao gerar metadados"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Terminado!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+#, fuzzy
+msgid "Set the prefix"
+msgstr "Definir o nome de origem"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr ""
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr ""
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr ""
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr ""
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr ""
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+#, fuzzy
+msgid "Error creating output directory"
+msgstr "Definir a pasta de saída"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr ""
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr ""
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Aliás de %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Comando não encontrado, comandos válidos são:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Por favor, reveja o ficheiro e repare quaisquer itens \"FIXME\""
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+#, fuzzy
+msgid "Old API version"
+msgstr "Nova versão do API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nova versão do API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Sem argumentos suficientes, esperadas versões old.xml e new.xml"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr ""
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Sem argumentos suficientes, esperada file.xml"
+
+#. TRANSLATORS: %s is a file type,
+#. * e.g. 'appdata'
+#: client/as-util.c:595
+#, c-format
+msgid "File format '%s' cannot be upgraded"
+msgstr ""
+
+#. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
+msgid "Format not recognised"
+msgstr ""
+
+#. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
+msgid "No desktop applications found"
+msgstr ""
+
+#. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
+msgid "OK"
+msgstr "CORRETO"
+
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FALHA"
+
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validação falhada"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "A validação dos ficheiros falhou"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validação falhada"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "A validação dos ficheiros falhou"
+
+#. TRANSLATORS: application was removed
+#: client/as-util.c:4076
+msgid "Removed"
+msgstr ""
+
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr ""
+
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
+
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Não usar acesso à rede"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Mostrar versão"
 
-#. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Desinstala metadados do AppStream"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Ativar análise de perfil"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Converte metadados do AppStream de uma versão para outra"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Atualizar metadados AppStream para a última versão"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Despeja as aplicações nos metadados do AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Procurar aplicações AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+#, fuzzy
+msgid "Search for AppStream applications by package name"
+msgstr "Procurar aplicações AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Procurar aplicações AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "Procurar aplicações AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Mostrar símbolos de procura de aplicações"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Instala metadados do AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Instala metadados do AppStream com nova origem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Desinstala metadados do AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Cria uma página HTML de estado"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Cria um documento CSV de estado"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Cria uma página HTML de matriz"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Listar aplicações não suportadas por pacotes"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Validar um ficheiro AppData ou AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Validar um ficheiro AppData ou AppStream (relaxado)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Validar um ficheiro AppData ou AppStream (estrito)"
 
-msgid "Validation failed"
-msgstr "Validação falhada"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Validar um ficheiro AppData ou AppStream (relaxado)"
 
-msgid "Validation of files failed"
-msgstr "A validação dos ficheiros falhou"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Converter um ficheiro AppData em formato NEWS"
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Converter um ficheiro NEWS em formato AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Verificar dados da aplicação instalada"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Verificar dados da aplicação instalada"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Substituir capturas de ecrã no ficheiro origem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Espelhar capturas de ecrã"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Incorporar metadados extra a partir de ficheiro externo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Comparar o conteúdo de dois ficheiros AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+#, fuzzy
+msgid "Merge several files to an AppStream file"
+msgstr "Comparar o conteúdo de dois ficheiros AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+#, fuzzy
+msgid "Import a file to AppStream markup"
+msgstr "Converter um ficheiro NEWS em formato AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "Procurar aplicações AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitário AppStream"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versão:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -545,3 +545,551 @@ msgstr "Utilitário AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Versão:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Geral"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "TODAS"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Adultos apenas"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Maduro"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Adolescente"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Todo mundo 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Todo mundo"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Primeira infância"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Sem violência de desenho animado"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Personagens de desenho animado em situações inseguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Personagens de desenho animado em conflito agressivo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Cenas fortes com violência envolvendo personagens de desenho animado"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Sem violência de fantasia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Personagens em situações inseguras facilmente distinguíveis da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Personagens em conflito agressivo facilmente distinguíveis da realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr ""
+"Cenas fortes com violência envolvendo situações facilmente distinguíveis da "
+"realidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Sem violência realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Personagens levemente realísticos em situações inseguras"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Representações de personagens realísticos em conflito agressivo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Cenas fortes de violência envolvendo personagens realísticos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Sem derramamento de sangue"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Derramamento de sangue não realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Derramamento de sangue realista"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr ""
+"Representações de derramamento de sangue e mutilação de partes do corpo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Sem violência sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Estupro ou outro comportamento sexual violento"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Sem referência a bebidas alcoólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referências a bebidas alcoólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Uso de bebidas alcoólicas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Sem referência a drogas ilícitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referências a drogas ilícitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Use de drogas ilícitas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Sem referência a produtos de tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referências a produtos de tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Uso de produtos de tabaco"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Sem nudez de qualquer tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Nudez artística breve"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Nudez prolongada"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Sem referência a ou representação de natureza sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Referências ou representações provocativas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Referências ou representações sexuais"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Cenas fortes de comportamento sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Sem profanação de qualquer tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Uso leve ou infrequente de profanação"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Uso moderado de profanação"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Uso forte e frequente de profanação"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Sem humor impróprio"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Comédia pastelão"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Comédia vulgar ou de banheiro"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Comédia para adultos ou sexual"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Sem linguagem discriminatória de qualquer tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negatividade direcionada a um grupo específico de pessoas"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Discriminação projetada a causa ofensa emocional"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Discriminação explícita baseada em gênero, sexualidade, raça ou religião"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Sem publicidade de qualquer tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Colocação de produtos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Referências explícitas a marcas ou produtos comerciais específicos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Usuários são encorajados a comprar itens específicos do mundo real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Sem jogo de azar de qualquer tipo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Aposta em eventos aleatórios usando tokens ou créditos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Aposta usando dinheiro do jogo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Aposta usando dinheiro de verdade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Sem habilidade de gastar dinheiro"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Usuários são encorajados a doar dinheiro real"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Habilidade de gastar dinheiro real no aplicativo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Impossível conversar com outros usuários"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interações usuário com usuário sem funcionalidade de bate-papo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Funcionalidade de bate-papo moderado entre usuários"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Funcionalidade de bate-papo sem controle entre usuários"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Impossível falar com outros usuários"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr ""
+"Funcionalidade de chamada de vídeo ou de áudio sem controle entre usuários"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Sem compartilhamento de nomes de usuários ou endereços de e-mail de rede "
+"social"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Compartilhamento de nomes de usuários ou endereços de e-mail de rede social"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Sem compartilhamento de informações de usuário com terceiros"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Verificação pela versão mais recente do aplicativo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Compartilhamento de dados de diagnóstico que não permitem que identifiquem o "
+"usuário"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Compartilhamento de informações que permitem que identifiquem o usuário"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Sem compartilhamento de localização física com outros usuários"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Compartilhamento de localização física com outros usuários"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Sem referência a homossexualidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Referências indiretas a homossexualidade"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Beijo entre pessoas do mesmo gênero"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Comportamento sexual gráfico entre pessoas do mesmo gênero"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Sem referência a prostituição"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Referências indiretas a prostituição"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Referências diretas a prostituição"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Representações gráficas do ato de prostituição"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Sem referência a adultério"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Referências indiretas a adultério"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Referências diretas a adultério"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Representações gráficas do ato de adultério"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Sem caracteres sexualizados"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Personagens humanos semi-nus"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Personagens humanos notoriamente sexualizado"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Sem referência a profanação"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Representações de ou referências a profanação histórica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Representações de profanação humana em dias modernos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Representações gráficas de profanação em dias modernos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Sem restos de humanos mortos visíveis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Restos de humanos mortos visíveis"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Restos de humanos mortos que são expostos aos elementos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Representações gráficas de profanação de corpos humanos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Sem referência a escravidão"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Representações de ou referências a escravidão histórica"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Representações de escravidão em dias modernos"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Representações gráficas de escravidão em dias modernos"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -12,10 +12,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-30 18:56+0100\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-03-31 06:53+0000\n"
 "Last-Translator: Vinícius Pereira Aiala <vinicius_aiala@outlook.com>\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/freedesktop/appstream-glib/language/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/freedesktop/"
+"appstream-glib/language/pt_BR/)\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,403 +25,523 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Mostrar informações extra de  depuração"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Adiciona um ID de cache para cada componente"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Inclui resultados falhos na saída"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Adiciona ícones HiDPI para o tarball"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Adiciona um ID de cache para cada componente"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Adicione um idioma a um arquivo de origem"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Adicione um fornecedor a um arquivo de origem"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Adiciona ícones codificados ao XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Adicionado"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias para %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Utilitário AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Cancelado"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Verifica dados de aplicativo instalado"
-
-msgid "Command not found, valid commands are:"
-msgstr "Comando não encontrado, comandos válidos para:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Compara os conteúdos de dois arquivos AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Compare os números da versão"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "A conversão de %s para %s não está implementada"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Converte um arquivo AppData para formato NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Converte um arquivo NEWS para formato AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Converte metadados AppStream de uma versão para outra"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Cria um documento de status em CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Cria uma página de matriz em HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Cria uma página de status em HTML"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Cria um arquivo AppData de exemplo de um arquivo .desktop"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Exibe tokens de pesquisa por aplicativos"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Não comprime os ícones em um tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Não usar acesso por rede"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Pronto!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Despeja os aplicativos nos metadados do AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Define o diretório de log"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Habilita perfilamento"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Define o diretório de pacotes"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Erro ao criar diretório de saída"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Define o diretório temporário"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Erro ao carregar o arquivo AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Define o diretório de saída"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Erro ao carregar o arquivo desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Define o diretório de ícones"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Erro ao analisar kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Define o diretório do cache"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Erro ao analisar o provides"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Define os nomes base dos arquivos de saída"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Erro ao analisar traduções"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Define o nome de origem"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Erro ao salvar o arquivo de AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Define o número de fluxos"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Exporta o contrato na forma de texto"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Define o tamanho mínimo do ícone em pixels"
 
-#. list failures
-msgid "FAILED"
-msgstr "FALHOU"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Define a localização de metadados antigos"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignora certos tipos de veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Falha ao adicionar pacote"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Falha ao gerar metadados"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Falha ao abrir pacotes"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Falha ao analisar argumentos"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Falha ao definir um compilador"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Falha ao abrir pacotes"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Verificando pacotes..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Falha ao adicionar pacote"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Arquivos %u/%u analizados..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Falha ao gerar metadados"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Pronto!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Salvando o ícone"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Define o prefixo"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Processando o aplicativo"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Erro ao carregar o arquivo AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Erro ao analisar traduções"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Erro ao analisar kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Erro ao analisar o provides"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Nome do arquivo da área de trabalho inválido"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Erro ao carregar o arquivo desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Erro ao criar diretório de saída"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Salvando o AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Erro ao salvar o arquivo de AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias para %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Comando não encontrado, comandos válidos para:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Por favor, reveja o arquivo e corrija quaisquer itens \"FIXME\""
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Versão antiga da API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nova versão da API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Argumentos insuficientes, esperava versão antiga.xml nova.xml"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "A conversão de %s para %s não está implementada"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Argumentos insuficientes, esperava arquivo.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "O formato de arquivo \"%s\" não pôde ser atualizado"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Formato não reconhecido"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Gera um GUID a partir de um texto de entrada"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignora certos tipos de veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importar um arquivo de marcação AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Inclui resultados falhos na saída"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Incorpora metadados extra de um arquivo externo"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Instala metadados de AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Instala metadados do AppStream com nova origem"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Nome do arquivo da área de trabalho inválido"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Lista aplicativos não fornecidos por pacotes"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Mesclar diversos arquivos em um arquivo AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Espelha capturas de tela do upstream"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modifica um arquivo AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nova versão da API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nenhum aplicativo desktop encontrado"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Argumentos insuficientes, esperava arquivo.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Argumentos insuficientes, esperava versão antiga.xml nova.xml"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Versão antiga da API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "FALHOU"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validação falhou"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Validação de arquivos falhou"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Arquivos %u/%u analizados..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Por favor, reveja o arquivo e corrija quaisquer itens \"FIXME\""
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validação falhou"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Processando o aplicativo"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validação de arquivos falhou"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Removido"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Substitui capturas de tela no arquivo fonte"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Adicionado"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Salvando o AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Cancelado"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Salvando o ícone"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Verificando pacotes..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Pesquisa por aplicativos do AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Procure aplicativos AppStream pelo nome da categoria"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Procurar aplicativos AppStream pelo nome do pacote"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Não usar acesso por rede"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Define os nomes base dos arquivos de saída"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Define o diretório do cache"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Define o diretório de ícones"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Define o diretório de log"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Define o tamanho mínimo do ícone em pixels"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Define o número de fluxos"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Define a localização de metadados antigos"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Define o nome de origem"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Define o diretório de saída"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Define o diretório de pacotes"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Define o prefixo"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Define o diretório temporário"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Mostrar todos os aplicativos AppStream instalados"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Mostrar informações extra de  depuração"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Mostra versão"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Dividir um arquivo AppStream em arquivos AppData e Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Habilita perfilamento"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Teste uma expressão regular"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Converte metadados AppStream de uma versão para outra"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Desinstala metadados do AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Atualiza metadados do AppData para a última versão"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Cria um arquivo AppData de exemplo de um arquivo .desktop"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Despeja os aplicativos nos metadados do AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Pesquisa por aplicativos do AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Procurar aplicativos AppStream pelo nome do pacote"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Mostrar todos os aplicativos AppStream instalados"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Procure aplicativos AppStream pelo nome da categoria"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Exibe tokens de pesquisa por aplicativos"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Instala metadados de AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Instala metadados do AppStream com nova origem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Desinstala metadados do AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Cria uma página de status em HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Cria um documento de status em CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Cria uma página de matriz em HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Lista aplicativos não fornecidos por pacotes"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Valida um arquivo AppData ou AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Valida um arquivo de AppData ou AppStream (relaxado)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Exporta o contrato na forma de texto"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Valida um arquivo de AppData ou AppStream (estrito)"
 
-msgid "Validation failed"
-msgstr "Validação falhou"
-
-msgid "Validation of files failed"
-msgstr "Validação de arquivos falhou"
-
-msgid "Version:"
-msgstr "Versão:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Valida um arquivo de AppData ou AppStream (relaxado)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Converte um arquivo AppData para formato NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Converte um arquivo NEWS para formato AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Verifica dados de aplicativo instalado"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "Verifique um aplicativo instalado"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Substitui capturas de tela no arquivo fonte"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Adicione um fornecedor a um arquivo de origem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Adicione um idioma a um arquivo de origem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Espelha capturas de tela do upstream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Incorpora metadados extra de um arquivo externo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Compara os conteúdos de dois arquivos AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Gera um GUID a partir de um texto de entrada"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modifica um arquivo AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Dividir um arquivo AppStream em arquivos AppData e Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Mesclar diversos arquivos em um arquivo AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importar um arquivo de marcação AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Locais para mudanças do AppStream"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "Verifique um aplicativo instalado"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Compare os números da versão"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Teste uma expressão regular"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Utilitário AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Versão:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -551,3 +551,547 @@ msgstr "Устилита AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Версия:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+#, fuzzy
+msgid "Mature"
+msgstr "Рекомендуемые"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Отсутствуют сцены мультипликационного насилия"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Мультипликационные персонажи в опасных ситуациях"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Мультипликационные персонажи в агрессивных конфликтах"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Насилие в отношении мультипликационных персонажей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Отсутствуют сцены фэнтезийного насилия"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Персонажи в опасных ситуациях легко отличимых от реальности"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Персонажи в агрессивных конфликтах легко отличимых от реальности"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Насилие легко отличимое от реальности"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Нереалистичное насилие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Умеренно-реалистичные персонажи в опасных ситуациях"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Изображения реалистичных персонажей в агрессивных конфликтах"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Насилие в отношении реалистичных персонажей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Отсутствует кровопролитие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Нереалистичное кровопролитие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Реалистичное кровопролитие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Изображения крови и увечий"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Отсутствует сексуальное насилие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Изнасилование или другое сексуальное насилие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Отсутствие упоминания алкоголя"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Упоминание алкогольных напитков"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Употребление алкогольных напитков"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Отсутствуют упоминания запрещенных наркотиков"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Упоминание запрещенных наркотиков"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Употребление запрещенных наркотиков"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+#, fuzzy
+msgid "No references to tobacco products"
+msgstr "Упоминание табачных изделий"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Упоминание табачных изделий"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Использование табачных изделий"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Отсутствует обнажение в любом виде"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Короткие или неоткровенные сцены обнажения в художественных целях"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Продолжительные сцены обнажения"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Отсутствуют отсылки или описания сексуального характера"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Содержание или упоминание провокационного характера"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Содержание или упоминание сексуального характера"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Изображения сексуального поведения"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Отсутствует ненормативная лексика в любом виде"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Незначительное или нечастое сквернословие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Умеренное сквернословие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Очень грубое и частое сквернословие"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Отсутствует неприемлемый юмор"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Грубый юмор"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Вульгарный или непристойный юмор"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Юмор для взрослых или сексуального характера"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Отсутствуют фразы с дискриминацией любого типа"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Негативное отношение к определенной группе людей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Дискриминация с целью причинить моральный вред"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Явная дискриминация по признаку пола, сексуальной ориентации, расы или "
+"религии"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Отсутствует реклама в любом виде"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Неявная реклама"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Явные упоминания конкретных брендов или торговых марок"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr ""
+"Пользователям предлагается приобрести определенные предметы реального мира"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Отсутствуют азартные игры в любом виде"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr ""
+"Азартные игры с использованием жетонов, основанные на случайных событиях"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Азартные игры с использованием «игровой» валюты"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Азартные игры с использованием реальных денег"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Отсутствует возможность тратить деньги"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Пользователям предлагается платить реальные деньги"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Присутствует возможность тратить реальные деньги в приложении"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Отсутствует возможность общаться с другими игроками"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Взаимодействие между игроками без использования чата"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Модерируемые функции чата между пользователями"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Неконтролируемые функции чата между пользователями"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Отсутствует возможность общаться с другими игроками"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Неконтролируемые функции аудио или видеочата между пользователями"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Не распространяет имена пользователей или адреса электронной почты"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Распространяет имена пользователей или адреса электронной почты"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Не передает информацию о пользователе третьим лицам"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Проверка последней версии приложения"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Совместное использование диагностических данных, которые не позволяют другим "
+"идентифицировать пользователя"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Обмен информацией, позволяющей другим идентифицировать пользователя"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Нет общего физического местоположения с другими пользователями"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr ""
+"Совместное использование физического местоположения с другими пользователями"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Нет ссылок на гомосексуализм"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Косвенные ссылки на гомосексуализм"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Поцелуи между людьми одного пола"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Графическое сексуальное поведение между людьми одного пола"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Нет ссылок на проституцию"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Косвенные ссылки на проституцию"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Прямые ссылки на проституцию"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Графические изображения акта проституции"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Нет ссылок на прелюбодеяние"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Косвенные ссылки на прелюбодеяние"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Прямые ссылки на прелюбодеяние"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Графические изображения акта прелюбодеяния"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Нет сексуализированных персонажей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Необычно одетые человеческие персонажи"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Чрезмерно сексуализированные человеческие персонажи"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Нет упоминания осквернения"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Изображения или ссылки на историческое осквернение"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Изображения современного человеческого осквернения"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Графические изображения современного осквернения"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Нет видимых мертвых человеческих останков"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Видимые мертвые человеческие останки"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Мертвые человеческие останки, которые имеют неприкрытые части"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Графические изображения осквернения человеческих тел"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Отсутствие упоминания рабства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Изображения или упоминания исторического рабства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Изображения современного рабства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Графические изображения современного рабства"

--- a/po/ru.po
+++ b/po/ru.po
@@ -10,362 +10,544 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 03:00+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: Russian (http://www.transifex.com/freedesktop/appstream-glib/language/ru/)\n"
+"Language-Team: Russian (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/ru/)\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "Добавить пиктограммы высокого разрешения в архивный файл"
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Показывать дополнительную отладочную информацию"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
 msgid "Add a cache ID to each component"
 msgstr "Добавить идентификатор кэша в каждый компонент"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Включить неудачные результаты в вывод"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "Добавить пиктограммы высокого разрешения в архивный файл"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Добавить закодированные пиктограммы в XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Добавлено"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Псевдоним к %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Устилита AppStream"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Проверить данные установленного приложения"
-
-msgid "Command not found, valid commands are:"
-msgstr "Команда не найдена, корректные команды:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Сравнить содержимое двух файлов AppStream"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Преобразование из %s в %s не реализовано"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Преобразовать файл AppData в формат NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Преобразовать файл NEWS в формат AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Конвертирует AppStream метаданные из одной версии в другую"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Создать документ состояния в формате CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Создать страницу матрицы в формате HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Создать страницу состояния в формате HTML"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Показать токены поиска приложений"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Не сжимать пиктограммы в архивный файл"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Не использовать доступ к сети"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Выполнено!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Создаёт дамп приложений в метаданные AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Задать каталог журналов"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Включить профилирование"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Задать каталог пакетов"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Ошибка при создании каталога результатов"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Задать временный каталог"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Ошибка при загрузке файла AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Задать каталог вывода данных"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Ошибка при загрузе файла desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Задать каталог пиктограмм"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Ошибка при обработке благодарностей"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Задать каталог кэша"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Ошибка при обработке обеспечений"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Задать базовые названия выходных файлов"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Ошибка при обработке переводов"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Задать название происхождения"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Ошибка при сохранении файла AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Задать количество потоков"
 
-#. list failures
-msgid "FAILED"
-msgstr "ОШИБКА"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Задать минимальный размер пиктограмм в пикселях"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Задать нахождение старых метаданных"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Игнорировать определенные типы вето"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Не удалось добавить пакет"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Не удалось создать метаданные"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Не удалось открыть пакеты"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Ошибка при распознавании аргументов"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Не удалось настроить средство сборки"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Не удалось открыть пакеты"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Сканируем пакеты…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Не удалось добавить пакет"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Не удалось создать метаданные"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Выполнено!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Сохраняем пиктограмму"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Установить префикс"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Выполняем приложение"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Ошибка при загрузке файла AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Ошибка при обработке переводов"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Ошибка при обработке благодарностей"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Ошибка при обработке обеспечений"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Ошибка при загрузе файла desktop"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Ошибка при загрузе файла desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Ошибка при создании каталога результатов"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Сохраняем AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Ошибка при сохранении файла AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Псевдоним к %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Команда не найдена, корректные команды:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr ""
+"Пожалуйста, просмотрите файл и исправьте пункты, к которым добавлено «FIXME»"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Старая версия API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Новая версия API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Недостаточно аргументов, ожидалось old.xml new.xml version"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Преобразование из %s в %s не реализовано"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Недостаточно аргументов, ожидался file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Файл формата '%s' не может быть обновлён"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Нераспознанный формат"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Создать GUID из строки входных данных"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Игнорировать определенные типы вето"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Импортировать файл в AppStream-разметку"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Включить неудачные результаты в вывод"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Включить дополнительные метаданные из внешнего файла"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Устанавливает метаданные AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Устанавливает метаданные AppStream с новым происхождением"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Список приложений не из пакетов"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Объединить несколько файлов в файл AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Отзеркалить снимки экрана из основной ветки разработки"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Изменить файл AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Новая версия API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Приложения не найдены"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Недостаточно аргументов, ожидался file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Недостаточно аргументов, ожидалось old.xml new.xml version"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "ОК"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Старая версия API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "ОШИБКА"
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Пожалуйста, просмотрите файл и исправьте пункты, к которым добавлено «FIXME»"
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Проверка прошла неудачно"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Выполняем приложение"
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Проверка файлов прошла неудачно"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Проверка прошла неудачно"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Проверка файлов прошла неудачно"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Удалено"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Заменить снимки экрана в исходном файле"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Добавлено"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Сохраняем AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Сохраняем пиктограмму"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Сканируем пакеты…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Поиск приложений AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Поиск приложений AppStream по названию пакета"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Не использовать доступ к сети"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Задать базовые названия выходных файлов"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Задать каталог кэша"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Задать каталог пиктограмм"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Задать каталог журналов"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Задать минимальный размер пиктограмм в пикселях"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Задать количество потоков"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Задать нахождение старых метаданных"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Задать название происхождения"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Задать каталог вывода данных"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Задать каталог пакетов"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Установить префикс"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Задать временный каталог"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Показывать дополнительную отладочную информацию"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Показать версию"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Разделить файл AppStream на AppData и MetaInfo файлы"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Включить профилирование"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Удаляет метаданные AppStream"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Конвертирует AppStream метаданные из одной версии в другую"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Обновить метаданные AppData до последней версии"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Создаёт дамп приложений в метаданные AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Поиск приложений AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Поиск приложений AppStream по названию пакета"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Поиск приложений AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "Поиск приложений AppStream по названию пакета"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Показать токены поиска приложений"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Устанавливает метаданные AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Устанавливает метаданные AppStream с новым происхождением"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Удаляет метаданные AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Создать страницу состояния в формате HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Создать документ состояния в формате CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Создать страницу матрицы в формате HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Список приложений не из пакетов"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Проверить корректность AppData или AppStream файла"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Проверить корректность AppData или AppStream файла (мягко)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Проверить корректность AppData или AppStream файла (строго)"
 
-msgid "Validation failed"
-msgstr "Проверка прошла неудачно"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Проверить корректность AppData или AppStream файла (мягко)"
 
-msgid "Validation of files failed"
-msgstr "Проверка файлов прошла неудачно"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Преобразовать файл AppData в формат NEWS"
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Преобразовать файл NEWS в формат AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Проверить данные установленного приложения"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Проверить данные установленного приложения"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Заменить снимки экрана в исходном файле"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Отзеркалить снимки экрана из основной ветки разработки"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Включить дополнительные метаданные из внешнего файла"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Сравнить содержимое двух файлов AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Создать GUID из строки входных данных"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Изменить файл AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Разделить файл AppStream на AppData и MetaInfo файлы"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Объединить несколько файлов в файл AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Импортировать файл в AppStream-разметку"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "Поиск приложений AppStream по названию пакета"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Устилита AppStream"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Версия:"

--- a/po/sk.po
+++ b/po/sk.po
@@ -550,3 +550,559 @@ msgstr "Nástroj AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Verzia:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Všeobecné"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "VŠETCI"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Iba dospelí"
+
+# GtkLabel
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Dospievajúci"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Mladiství"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Každý s vekom nad 10 rokov"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Každý"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Skoré detstvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Žiadne kreslené násilie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Kreslené postavy v nebezpečných situáciách"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Kreslené postavy v agresívnom konflikte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Vyobrazené násilie zahŕňajúce kreslené postavy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Žiadne fiktívne násilie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Postavy v nebezpečných situáciach ľahko odlíšiteľných od reality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Postavy v agresívnom konflikte ľahko odlíšiteľnom od reality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Vyobrazené násilie ľahko odlíšiteľné od reality"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Žiadne realistické násilie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Mierne skutočné postavy v nebezpečných situáciách"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Vyobrazenia skutočných postáv v agresívnom konflikte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Vyobrazené násilie zahŕňajúce skutočné postavy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Žiadne krviprelievanie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Neskutočné krviprelievanie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Skutočné krviprelievanie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Vyobrazenia krviprelievania a zohavených častí tiel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Žiadne sexuálne násilie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Znásilnenie alebo iné násilné sexuálne správanie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Žiadne odkazy na alkohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Odkazy na alkoholické nápoje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Požívanie alkoholických nápojov"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Žiadne odkazy na zakázané drogy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Odkazy na zakázané drogy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Požívanie zakázaných drog"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Bez odkazov na tabakové výrobky"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Odkazy na tabakové výrobky"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Požívanie tabakových výrobkov"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Žiadna nahota akéhokoľvek druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Občasná umelecká nahota"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Dlhotrvajúca nahota"
+
+# cmdline description
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Bez sexuálnych odkazov alebo vyobrazení"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokačné odkazy alebo vyobrazenia"
+
+# cmdline description
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Sexuálne odkazy alebo vyobrazenia"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Vyobrazené sexuálne správanie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Žiadne zneuctenie akéhokoľvek druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Mierne alebo časte zneuctenie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Stredne silné zneuctenie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Silné alebo časté zneuctenie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Žiadny nevhodný humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Drsný humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgárny alebo kúpeľňový humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Sexuálny humor alebo humor pre dospelých"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Žiadny diskriminačný jazyk akéhokoľvek druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Odpor voči špecifickej skupine ľudí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminácia s následkami emočnej ujmy"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Jednoznačná diskriminácia založená na pohlaví, sexuálnej orientácii, rase "
+"alebo náboženstve"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Žiadne reklamy akéhokoľvek druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Umiestnenie výrobku"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Jednoznačné odkazy na produkty špecifických značiek alebo označené obchodnou "
+"známkou"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr ""
+"Používatelia sú vyzývaní na nákup špecifických položiek v skutočnom svete"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Žiadne hazardovanie akéhokoľvek druhu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Hazardovanie na náhodných podujatiach použitím žetónov alebo kreditov"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Hazardovanie s fiktívnymi peniazmi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Hazardovanie so skutočnými peniazmi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Žiadne možnosti míňania peňazí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Používatelia sú vyzývaní na darovanie skutočných peňazí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Možnosť míňania skutočných peňazí v aplikácii"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Žiadne možnosti textovej komunikácie s ostatnými používateľmi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+#, fuzzy
+msgid "User-to-user interactions without chat functionality"
+msgstr "Herné interakcie medzi hráčmi bez možnosti rozhovoru"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Moderované rozhovory medzi používateľmi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Nekontrolovateľné rozhovory medzi používateľmi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Žiadne možnosti hovoriť s ostatnými používateľmi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Nekontrolovateľné zvukové alebo video rozhovory medzi používateľmi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Žiadne zdieľanie používateľských mien alebo emailových adries zo sociálnych "
+"sietí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Zdieľanie používateľských mien alebo emailových adries zo sociálnych sietí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Žiadne zdieľanie informácií o používateľoch s tretími stranami"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Kontroluje sa najnovšia verzia aplikácie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+#, fuzzy
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Zdieľanie informácií, ktoré umožňujú ostatným identifikovať používateľa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Zdieľanie informácií, ktoré umožňujú ostatným identifikovať používateľa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Žiadne zdieľanie fyzickej lokality ostatným používateľom"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Zdieľanie fyzickej lokality ostatným používateľom"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Žiadne odkazy na homosexualitu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Nepriame odkazy na homosexualitu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Žiadne odkazy na prostitúciu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Nepriame odkazy na prostitúciu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Priame odkazy na prostitúciu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Grafické vyobrazenia aktu prostitúcie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Žiadne odkazy na cudzoložstvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Nepriame odkazy na cudzoložstvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Priame odkazy na cudzoložstvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Grafické vyobrazenia aktu cudzoložstva"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+#, fuzzy
+msgid "No sexualized characters"
+msgstr "Žiadne sexuálne násilie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+#, fuzzy
+msgid "Overtly sexualized human characters"
+msgstr "Žiadne sexuálne násilie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Žiadne odkazy na znesvätenie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Vyobrazenia alebo odkazy na historické znesvätenie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+#, fuzzy
+msgid "Depictions of modern-day human desecration"
+msgstr "Vyobrazenia alebo odkazy na historické znesvätenie"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+#, fuzzy
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Grafické vyobrazenia znesvätenia ľudských tiel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Bez viditeľných pozostatkov mŕtvych ľudí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Viditeľné pozostatky mŕtvych ľudí"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Grafické vyobrazenia znesvätenia ľudských tiel"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Žiadne odkazy na otroctvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Vyobrazenia alebo odkazy na historické otroctvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+#, fuzzy
+msgid "Depictions of modern-day slavery"
+msgstr "Vyobrazenia alebo odkazy na historické otroctvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+#, fuzzy
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Grafické vyobrazenia aktu cudzoložstva"

--- a/po/sk.po
+++ b/po/sk.po
@@ -10,10 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 03:00+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: Slovak (http://www.transifex.com/freedesktop/appstream-glib/language/sk/)\n"
+"Language-Team: Slovak (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/sk/)\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,342 +23,530 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "Pridá ikony HiDPI do archívu tarball"
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Zobrazovať ďalšie ladiace informácie"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
 msgid "Add a cache ID to each component"
 msgstr "Pridať ID vyrovnávacej pamäte každému komponentu"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Zahrnie výsledky zlyhaní do výstupu"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "Pridá ikony HiDPI do archívu tarball"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Pridá dekodované ikony do XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Pridaná"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias pre %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Nástroj AppStream"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Skontrolovať nainštalované dáta aplikácie"
-
-msgid "Command not found, valid commands are:"
-msgstr "Príkaz nebol nájdený, platné príkazy sú:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Porovná obsahy dvoch súborov AppStream"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Konverzia %s na %s nie je implementovaná"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Skonvertuje súbor AppData do formátu NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Skonvertuje súbor NEWS do formátu AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Konvertuje metadáta AppStream z jednej verzie na inú"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Vytvoriť dokument CSV so stavom"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Vytvorí stránku HTML s maticou"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Vytvoriť stránku HTML so stavom"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Zobrazí tokeny vyhľadávania aplikácií"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Nebude komprimovať ikony do archívu tarball"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Nepoužívať prístup k sieti"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Hotovo!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Pridá aplikácie do metadát AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Nastaviť adresár pre protokol"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Povolí profilovanie"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Nastaviť adresár pre balíky"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Chyba pri vytváraní výstupného adresára"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Nastaviť dočasný adresár"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Chyba pri načítavaní súboru AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Nastaviť výstupný adresár"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Chyba pri načítavaní süboru desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Nastaví adresár s ikonami"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Chyba pri analýze systému kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Nastaviť adresár vyrovnávacej pamäte"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Chyba pri analýze systému provides"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Nastaví základné názvy výstupných súborov"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Chyba pri analyzovaní prekladov"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Nastaviť pôvodné meno"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Chyba pri ukladaní súboru AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Nastaviť počet vlákien"
 
-#. list failures
-msgid "FAILED"
-msgstr "ZLYHALO"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Nastaví minimálnu veľkosť ikony v pixeloch"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Nastaviť umiestnenie starých metadát"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Bude ignorovať určité typy veta"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Nepodarilo sa pridať balík"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Nepodarilo sa vytvoriť metadáta"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Nepodarilo sa otvoriť balíky"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Nepodarilo sa spracovať argumenty"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Nepodarilo sa nastaviť zostavovanie"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Nepodarilo sa otvoriť balíky"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Prehľadávajú sa balíky..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Nepodarilo sa pridať balík"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Nepodarilo sa vytvoriť metadáta"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Hotovo!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Ukladá sa ikona"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Nastaviť predponu"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Spracováva sa aplikácia"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Chyba pri načítavaní súboru AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Chyba pri analyzovaní prekladov"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Chyba pri analýze systému kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Chyba pri analýze systému provides"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Chyba pri načítavaní süboru desktop"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Chyba pri načítavaní süboru desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Chyba pri vytváraní výstupného adresára"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Ukladá sa AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Chyba pri ukladaní súboru AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias pre %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Príkaz nebol nájdený, platné príkazy sú:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Prosím, skontrolujte súbor a opravte prípadné položky „FIXME“"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Stará verzia API"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Nová verzia API"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Nedostatočný počet argumentov. Očakávali sa: starý.xml nový.xml verzia"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Konverzia %s na %s nie je implementovaná"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Nedostatočný počet argumentov. Očakávali sa: súbor.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Formát súboru \"%s\" nemôže byť aktualizovaný"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Formát nebol rozpoznaný"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Vygenerovať identifikátor GUID zo vstupného reťazca"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Bude ignorovať určité typy veta"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Zahrnie výsledky zlyhaní do výstupu"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Zahrnie metaúdaje navyše z externého súboru"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Nainštaluje metadáta AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Nainštaluje metadáta AppStream s novým pôvodom"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Zoznam aplikácií, ktoré nepochádzajú z balíkov"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Zlúči niekoľko súborov do súboru AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Bude zrkadliť najnovšie snímky obrazoviek"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Upraviť súbor AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Nová verzia API"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Nenašli sa žiadne aplikácie pracovného prostredia"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Nedostatočný počet argumentov. Očakávali sa: súbor.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Nedostatočný počet argumentov. Očakávali sa: starý.xml nový.xml verzia"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Stará verzia API"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "ZLYHALO"
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Prosím, skontrolujte súbor a opravte prípadné položky „FIXME“"
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Overenie zlyhalo"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Spracováva sa aplikácia"
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Overenie súborov zlyhalo"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Overenie zlyhalo"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Overenie súborov zlyhalo"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Odstránená"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Nahradí snímký obrazoviek v zdrojovom súbore"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Pridaná"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Ukladá sa AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Ukladá sa ikona"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Prehľadávajú sa balíky..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Vyhľadá aplikácie AppStream"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Nepoužívať prístup k sieti"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Nastaví základné názvy výstupných súborov"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Nastaviť adresár vyrovnávacej pamäte"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Nastaví adresár s ikonami"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Nastaviť adresár pre protokol"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Nastaví minimálnu veľkosť ikony v pixeloch"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Nastaviť počet vlákien"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Nastaviť umiestnenie starých metadát"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Nastaviť pôvodné meno"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Nastaviť výstupný adresár"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Nastaviť adresár pre balíky"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Nastaviť predponu"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Nastaviť dočasný adresár"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Zobrazovať ďalšie ladiace informácie"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Zobraziť verziu"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Rozdelí súbor AppStream na súbory AppData a Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Povolí profilovanie"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Odinštaluje metadáta AppStream"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Konvertuje metadáta AppStream z jednej verzie na inú"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Aktualizovať metadáta AppStream na najnovšiu verziu"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Pridá aplikácie do metadát AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Vyhľadá aplikácie AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+#, fuzzy
+msgid "Search for AppStream applications by package name"
+msgstr "Vyhľadá aplikácie AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Vyhľadá aplikácie AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "Vyhľadá aplikácie AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Zobrazí tokeny vyhľadávania aplikácií"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Nainštaluje metadáta AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Nainštaluje metadáta AppStream s novým pôvodom"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Odinštaluje metadáta AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Vytvoriť stránku HTML so stavom"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Vytvoriť dokument CSV so stavom"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Vytvorí stránku HTML s maticou"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Zoznam aplikácií, ktoré nepochádzajú z balíkov"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Overiť súbor AppData alebo AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Overiť (voľnejšie) súbor AppData alebo AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Overiť (prísne) súbor AppData alebo AppStream"
 
-msgid "Validation failed"
-msgstr "Overenie zlyhalo"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Overiť (voľnejšie) súbor AppData alebo AppStream"
 
-msgid "Validation of files failed"
-msgstr "Overenie súborov zlyhalo"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Skonvertuje súbor AppData do formátu NEWS"
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Skonvertuje súbor NEWS do formátu AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Skontrolovať nainštalované dáta aplikácie"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Skontrolovať nainštalované dáta aplikácie"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Nahradí snímký obrazoviek v zdrojovom súbore"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Bude zrkadliť najnovšie snímky obrazoviek"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Zahrnie metaúdaje navyše z externého súboru"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Porovná obsahy dvoch súborov AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Vygenerovať identifikátor GUID zo vstupného reťazca"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Upraviť súbor AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Rozdelí súbor AppStream na súbory AppData a Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Zlúči niekoľko súborov do súboru AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+#, fuzzy
+msgid "Import a file to AppStream markup"
+msgstr "Skonvertuje súbor NEWS do formátu AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "Vyhľadá aplikácie AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Nástroj AppStream"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Verzia:"

--- a/po/sl.po
+++ b/po/sl.po
@@ -551,3 +551,545 @@ msgstr "Pripomoček AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Različica:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Splošno"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "Vse"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Le za odrasle"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+#, fuzzy
+msgid "Mature"
+msgstr "Novosti v ospredju"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Najstniki"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Kdorkoli nad 10"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Vsi"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Zgodnje otroštvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Brez nasilja v risani seriji"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Risani liki v nevarnih situacijah"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Risani liki v nasilnih konfliktih"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Nazorno nasilje med risanimi liki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Brez fantazijskega nasilja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Liki v nevarnih situacijah, ki jih je mogoče zlahka razlikovati od realnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Liki v nasilnem konfliktu, ki ga je mogoče zlahka razlikovati od realnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Nazorno nasilje, ki ga je mogoče zlahka razlikovati od realnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Brez realističnega nasilja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Napol realistični liki v nevarnih situacijah"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Prikazovanje realističnih likov v nasilnih konfliktih"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Nazorno nasilje, ki vključuje realistične like"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Brez prelivanja krvi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Nerealistično prelivanje krvi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistično prelivanje krvi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Prikazi prelivanja krvi in pohabljanje delov telesa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Brez spolnega nasilja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Posilstvo ali drugo nasilno vedenje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Brez omenjanja alkoholnih pijač"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Omenjanje alkoholnih pijač"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Uporaba alkoholnih pijač"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Ni omenjanja prepovedanih drog"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Omenjanje prepovedanih drog"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Uporaba prepovedanih drog"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Ni sklicevanja na tobačne izdelke"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Sklici na tobačne izdelke"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Uporaba tobačnih izdelkov"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Brez vsakršne golote"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Krajše umetniško ponazorjena spolnost"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Daljši prikazi golote"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Ni omenjanja in prikazov spolne narave"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Izzivalno obnašanje ali upodobljanje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Prikrit spolni akt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Nazorno seksualno vedenje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Brez kakršnegakoli preklinjanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Nežno ali redko preklinjanje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Zmerno preklinjanje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Izrazito ali pogosto preklinjanje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Brez neustreznega humorja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Situacijski humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgaren humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Humor za odrasle"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Brez vsakršnega diskriminatornega namigovanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negativen odnos do specifične skupine ljudi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminatorno delovanje, ki lahko sproži močan čustven odziv"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Izrecna diskriminacija na podlagi spola, spolnosti, rase ali vere"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Brez kakršnegakoli oglaševanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Opredelitev izdelka"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Izrecna sklicevanja na določene blagovne znamke ali izdelke"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Uporabnike spodbuja k nakupu določenih fizičnih predmetov"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Brez kakršnegakoli igranja na srečo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr ""
+"Igranje na srečo na naključnih dogodkih z uporabo žetonov ali kreditnih točk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Igranje na srečo s namišljenim denarjem"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Igranje na srečo s pravim denarjem"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Možnost uporabe pravega denarja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Uporabnike spodbuja k donaciji uradnih denarnih valut"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Možnost uporabe pravega denarja v programu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Ni možnosti klepeta z drugimi uporabniki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interakcije med uporabniki brez funkcije za klepet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Nadzorovana možnost klepeta med uporabniki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Nenadzorovana možnost klepeta med uporabniki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Ni možnosti klepeta ali pogovora z drugimi uporabniki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Nenadzorovana možnost zvočnega ali video klepeta med uporabniki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Ni objavljanja uporabniških imen ali elektronskih naslovov"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Objavljanje uporabniškega imena ali elektronskega naslova socialnega omrežja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Podrobnosti o uporabniku se ne objavljajo tretjim osebam"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Poteka preverjanje najnovejše različice programa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Objavljanje podatkov diagnostike, ki ne vključuje podatkov o istovetnosti "
+"uporabnika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Objavljanje podrobnosti o uporabniku"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Trenutno mesto se ne objavlja drugim uporabnikom"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Omogočeno je objavljanje trenutnega mesta drugim uporabnikom"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Brez sklicevanja na homoseksualnost"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Posredno namigovanje na homoseksualnost"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Poljubljanje med osebami istega spola"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Nazorno spolno obnašanje med osebami istega spola"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Brez sklicevanja na prostitucijo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Posredno namigovanje na prostitucijo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Neposredno omenjanje prostitucije"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Nazoren prikaz prostitucije"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Brez sklicevanja na nezvestobo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Posredno namigovanje na nezvestobo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Neposredno omenjanje nezvestobe"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Nazoren prikaz prešuštva"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Brez izrazitega spolnega izražanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Pomanjkljivo oblečeni človeški liki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Prekomerno spolno izraženi človeški liki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Brez sklicevanja na skrunjenje človeškega telesa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Prikazovanje ali sklicevanja na zgodovinsko skrunitev"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Prikazovanje sodobnega skrunjenja človeškega telesa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Nazorno prikazovanje sodobnega skrunjenja človeškega telesa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Brez vidnih ostankov mrtvih ljudi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Vidni deli mrtvih ljudi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Izpostavljanje ostankov človeških teles"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Nazorno prikazovanje oskrunjenja človeškega telesa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Brez sklicevanja na suženjstvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Prikazovanje suženjstva v preteklosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Prikazovanje sodobnega suženjstva"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Nazorno prikazovanje sodobnega suženjstva"

--- a/po/sl.po
+++ b/po/sl.po
@@ -9,186 +9,545 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 03:00+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: Slovenian (http://www.transifex.com/freedesktop/appstream-glib/language/sl/)\n"
+"Language-Team: Slovenian (http://www.transifex.com/freedesktop/appstream-"
+"glib/language/sl/)\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Dodaj ID predpomnilnika vsaki komponenti"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Vzdevek za %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Pripomoček AppStream"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Preveri podatke nameščenega programa"
-
-msgid "Command not found, valid commands are:"
-msgstr "Ukaza ni mogoče najti, veljavni ukazi so:"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Pretvori metapodatke AppStream iz ene različice v drugo"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Ustvari dokument stanja CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Ustvari stran HTML s stanjem"
-
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Ne uporabi omrežnega dostopa"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Opravljeno!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Izmeče programe v metapodatkih AppStream"
-
-#. list failures
-msgid "FAILED"
-msgstr "SPODLETELO"
-
-#. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Dodajanje paketa je spodletelo"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Izdelava metapodatkov je spodletela"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Odpiranje paketov je spodletelo"
-
-#. TRANSLATORS: error message
-msgid "Failed to parse arguments"
-msgstr "Razčlenjevanje argumentov je spodletelo"
-
-#. TRANSLATORS: error message
-msgid "Failed to set up builder"
-msgstr "Vzpostavitev graditelja je spodletela"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Namesti metapodatke AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Namesti metapodatke AppStream z novim izvorom"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Izpiši programe, ki jih paketi ne podpirajo"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Različica novega API-ja"
-
-msgid "Not enough arguments, expected file.xml"
-msgstr "Premalo parametrov, pričakovana datoteka.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Premalo parametrov, pričakovano stari.xml novi.xml različica"
-
-#. TRANSLATORS: the file is valid
-msgid "OK"
-msgstr "V REDU"
-
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Preglejte datoteko in popravite vse elemene \"POPRAVIME\" (\"FIXME\")"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Pregledovanje paketov ..."
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Določite mapo predpomnilnika"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Določite mapo beleženja"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Določite število niti"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Določite staro mesto metapodatkov"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Določite ime izvora"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Določite izhodno mapo"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Določite mapo paketov"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Določite začasno mapo"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
 msgid "Show extra debugging information"
 msgstr "Pokaži dodatne podatke razhroščevanja"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Dodaj ID predpomnilnika vsaki komponenti"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
+msgid "Add encoded icons to the XML"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:91
+msgid "Do not compress the icons into a tarball"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Določite mapo beleženja"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Določite mapo paketov"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Določite začasno mapo"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Določite izhodno mapo"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+#, fuzzy
+msgid "Set the icons directory"
+msgstr "Določite mapo beleženja"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Določite mapo predpomnilnika"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+#, fuzzy
+msgid "Set the basenames of the output files"
+msgstr "Določite število niti"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Določite ime izvora"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Določite število niti"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Določite staro mesto metapodatkov"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
+msgid "Failed to parse arguments"
+msgstr "Razčlenjevanje argumentov je spodletelo"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:246
+msgid "Failed to set up builder"
+msgstr "Vzpostavitev graditelja je spodletela"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Odpiranje paketov je spodletelo"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Pregledovanje paketov ..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Dodajanje paketa je spodletelo"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Izdelava metapodatkov je spodletela"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Opravljeno!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+#, fuzzy
+msgid "Set the prefix"
+msgstr "Določite ime izvora"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr ""
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr ""
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr ""
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr ""
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr ""
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+#, fuzzy
+msgid "Error creating output directory"
+msgstr "Določite izhodno mapo"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr ""
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr ""
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Vzdevek za %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Ukaza ni mogoče najti, veljavni ukazi so:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Preglejte datoteko in popravite vse elemene \"POPRAVIME\" (\"FIXME\")"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+#, fuzzy
+msgid "Old API version"
+msgstr "Različica novega API-ja"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Različica novega API-ja"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Premalo parametrov, pričakovano stari.xml novi.xml različica"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr ""
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Premalo parametrov, pričakovana datoteka.xml"
+
+#. TRANSLATORS: %s is a file type,
+#. * e.g. 'appdata'
+#: client/as-util.c:595
+#, c-format
+msgid "File format '%s' cannot be upgraded"
+msgstr ""
+
+#. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
+msgid "Format not recognised"
+msgstr ""
+
+#. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
+msgid "No desktop applications found"
+msgstr ""
+
+#. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
+msgid "OK"
+msgstr "V REDU"
+
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "SPODLETELO"
+
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Potrjevanje je spodletelo"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Potrjevanje datotek je spodletelo"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Potrjevanje je spodletelo"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Potrjevanje datotek je spodletelo"
+
+#. TRANSLATORS: application was removed
+#: client/as-util.c:4076
+msgid "Removed"
+msgstr ""
+
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr ""
+
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
+
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Ne uporabi omrežnega dostopa"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Pokaži različico"
 
-#. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Odstrani metapodatke AppStream"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr ""
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Pretvori metapodatke AppStream iz ene različice v drugo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Posodobi metapodatke AppData na najnovejšo različico"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Izmeče programe v metapodatkih AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Preveri podatke nameščenega programa"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Namesti metapodatke AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Namesti metapodatke AppStream z novim izvorom"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Odstrani metapodatke AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Ustvari stran HTML s stanjem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Ustvari dokument stanja CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+#, fuzzy
+msgid "Create an HTML matrix page"
+msgstr "Ustvari stran HTML s stanjem"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Izpiši programe, ki jih paketi ne podpirajo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Preveri datoteko AppData ali AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Preveri datoteko AppData ali AppStream (površno)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Preveri datoteko AppData ali AppStream (strogo)"
 
-msgid "Validation failed"
-msgstr "Potrjevanje je spodletelo"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Preveri datoteko AppData ali AppStream (površno)"
 
-msgid "Validation of files failed"
-msgstr "Potrjevanje datotek je spodletelo"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr ""
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Preveri podatke nameščenega programa"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Preveri podatke nameščenega programa"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+msgid "Watch AppStream locations for changes"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Pripomoček AppStream"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Različica:"

--- a/po/sr.po
+++ b/po/sr.po
@@ -11,354 +11,546 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 03:00+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: Serbian (http://www.transifex.com/freedesktop/appstream-glib/language/sr/)\n"
+"Language-Team: Serbian (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/sr/)\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "Додај „HiDPi“ иконице у архиву"
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Приказује додатне податке за исправљање грешака у програму"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
 msgid "Add a cache ID to each component"
 msgstr "Додаје ИБ оставе сваком састојку"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Укључи неуспешне резултате у излаз"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "Додај „HiDPi“ иконице у архиву"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Додај кодиране иконицу у „XML“"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Додат"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Други назив за „%s“"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Алатка Програмског тока"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Проверава инсталиране податке програма"
-
-msgid "Command not found, valid commands are:"
-msgstr "Нисам нашао наредбу, исправне наредбе су:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Упореди садржај две датотеке Програмског тока"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Претварање „%s“ у „%s“ није примењено"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Претвори „AppData“ датотеку у „NEWS“ формат"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Претвори „NEWS“ датотеку у „AppData“ формат"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Претвара метаподатке Програмског тока из једног издања у друго"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Прави CSV документ стања"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Направи матричну ХТМЛ страницу"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Прави ХТМЛ страницу стања"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Прикажи жетоне претраге програма"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Не пакуј иконице унутар архиве"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Не користи приступ мрежи"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Готово!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Исписује програме у метаподацима Програмског тока"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Подешава директоријум дневника"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Укључи профилисање"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Подешава директоријум пакета"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Грешка прављења излазног директоријума"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Подешава привремени директоријум"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Грешка учитавања датотеке програмских података"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Подешава директоријум излаза"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Грешка учитавања датотеке радне површи"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Постави фасциклу са иконицама"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Грешка обраде кудос-а"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Подешава директоријум оставе"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Грешка обраде достављања"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Постави основно име за излазне датотеке"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Грешка обраде превода"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Подешава назив порекла"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Грешка чувања датотеке Програмског тока"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Подешава број нити"
 
-#. list failures
-msgid "FAILED"
-msgstr "НЕУСПЕХ"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Постави најмању величину иконице у пикселима"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Подешава старо место метаподатака"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Занемари одређене врсте вета"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Не могу да додам пакет"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Не могу да направим метаподатке"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Не могу да отворим пакет"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Не могу да обрадим аргументе"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Не могу да подесим програм за изградњу"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Не могу да отворим пакет"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Прегледам пакете..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Не могу да додам пакет"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Не могу да направим метаподатке"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Готово!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Чувам иконицу"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Подеси префикс"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Обрађујем програм"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Грешка учитавања датотеке програмских података"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Грешка обраде превода"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Грешка обраде кудос-а"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Грешка обраде достављања"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "Грешка учитавања датотеке радне површи"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Грешка учитавања датотеке радне површи"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Грешка прављења излазног директоријума"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Чувам Програмски ток"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Грешка чувања датотеке Програмског тока"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Други назив за „%s“"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Нисам нашао наредбу, исправне наредбе су:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Прегледајте датотеку и поправите сваку ставку „FIXME“"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Старо издање АПИ-ја"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Ново издање АПИ-ја"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Нема довољно аргумената, очекивах „стари.xml нови.xml“ издање"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Претварање „%s“ у „%s“ није примењено"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Нема довољно аргумената, очекивах „датотека.xml“"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Запис датотеке „%s“ се не може надоградити"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Запис није препознат"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Ствара ГУИБ из улазне ниске"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Занемари одређене врсте вета"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Увози датотеку у означавање Програмског тока"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Укључи неуспешне резултате у излаз"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Уврсти додатне метаподатке из спољне датотеке"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Инсталира метаподатке Програмског тока"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Инсталира метаподатке Програмског тока са новим пореклом"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Исписује програме за које пакети нису направили резерву"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Дуплирај узводне снимке екрана"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Мења датотеку програмских података"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Ново издање АПИ-ја"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Нисам пронашао програме радне површи"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Нема довољно аргумената, очекивах „датотека.xml“"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Нема довољно аргумената, очекивах „стари.xml нови.xml“ издање"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "У реду"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Старо издање АПИ-ја"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "НЕУСПЕХ"
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Прегледајте датотеку и поправите сваку ставку „FIXME“"
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Потврђивање није успело"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Обрађујем програм"
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Потврђивање датотека није успело"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Потврђивање није успело"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Потврђивање датотека није успело"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Уклоњен"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Замени снимке екрана у изворној датотеци"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Додат"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Чувам Програмски ток"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Чувам иконицу"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Прегледам пакете..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Потражи програме Програмског тока"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Не користи приступ мрежи"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Постави основно име за излазне датотеке"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Подешава директоријум оставе"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Постави фасциклу са иконицама"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Подешава директоријум дневника"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Постави најмању величину иконице у пикселима"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Подешава број нити"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Подешава старо место метаподатака"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Подешава назив порекла"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Подешава директоријум излаза"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Подешава директоријум пакета"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Подеси префикс"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Подешава привремени директоријум"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Приказује додатне податке за исправљање грешака у програму"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Приказује издање"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Дели датотеку Програмског тока на програмске податке и на датотеке метаподатака"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Укључи профилисање"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Уклања метаподатке Програмског тока"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Претвара метаподатке Програмског тока из једног издања у друго"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Надограђује метаподатке Програмског тока на најновије издање"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Исписује програме у метаподацима Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Потражи програме Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+#, fuzzy
+msgid "Search for AppStream applications by package name"
+msgstr "Потражи програме Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Потражи програме Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "Потражи програме Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Прикажи жетоне претраге програма"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Инсталира метаподатке Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Инсталира метаподатке Програмског тока са новим пореклом"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Уклања метаподатке Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Прави ХТМЛ страницу стања"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Прави CSV документ стања"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Направи матричну ХТМЛ страницу"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Исписује програме за које пакети нису направили резерву"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Потврђује Програмске податке или датотеку Програмског тока"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Потврђује Програмске податке или датотеку Програмског тока(опуштено)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Потврђује Програмске податке или датотеку Програмског тока(изричито)"
 
-msgid "Validation failed"
-msgstr "Потврђивање није успело"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Потврђује Програмске податке или датотеку Програмског тока(опуштено)"
 
-msgid "Validation of files failed"
-msgstr "Потврђивање датотека није успело"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Претвори „AppData“ датотеку у „NEWS“ формат"
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Претвори „NEWS“ датотеку у „AppData“ формат"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Проверава инсталиране податке програма"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Проверава инсталиране податке програма"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Замени снимке екрана у изворној датотеци"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Дуплирај узводне снимке екрана"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Уврсти додатне метаподатке из спољне датотеке"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Упореди садржај две датотеке Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Ствара ГУИБ из улазне ниске"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Мења датотеку програмских података"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr ""
+"Дели датотеку Програмског тока на програмске податке и на датотеке "
+"метаподатака"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+#, fuzzy
+msgid "Merge several files to an AppStream file"
+msgstr "Грешка чувања датотеке Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Увози датотеку у означавање Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "Потражи програме Програмског тока"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Алатка Програмског тока"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Издање:"

--- a/po/sr.po
+++ b/po/sr.po
@@ -554,3 +554,545 @@ msgstr "Алатка Програмског тока"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Издање:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Опште"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "СВЕ"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Само за одрасле"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "За одрасле"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Тинејџери"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Сви 10+ година"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Сви"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Рано детињство"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Нема цртаног насиља"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Ликови из цртаћа у непожељним ситуацијама"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Ликови из цртаћа у агресивном сукобу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Графичко насиље које укључује ликове из цртаћа"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Нема фантазијског насиља"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Ликови у несигурним ситуацијама које се лако разликују од стварности"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Ликови у агресивном сукобу који се лако разликује од стварности"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Графичко насиље које се лако разликује од стварности"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Нема реалистичног насиља"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Благо стварни ликови у несигурним ситуацијама"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Приказ стварних ликова у агресивном сукобу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Графичко насиље које укључује стварне ликове"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Нема крвопролића"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Нереално крвопролиће"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Реално крвопролиће"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Приказ крвопролића и сакаћење делова тела"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Нема сексуалног насиља"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Силовање или друго насилно сексуално понашање"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Нема упућивања на алкохол"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Упућивање на алкохолна пића"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Употреба алкохолних пића"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Нема упућивања на забрањене дроге"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Упућивање на забрањене дроге"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Употреба забрањених дрога"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Нема упућивањ на дуванске производе"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Упућивање на дуванске производе"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Употреба дуванских производа"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Нема било какве нагости"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Кратка уметничка голотиња"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Продужена голотиња"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Нема сексуалних приказа или упућивања"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Провокативне упуте или прикази"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Сексуалне упуте или прикази"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Графичко сексуално понашање"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Нема било какве вулгарности"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Блага или ретка употреба псовки"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Умерена употреба псовки"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Јака или честа употреба псовки"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Нема неумесног хумора"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Урнебесна комедија"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Вулгаран или неумесни хумор"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Еротски и хумор за одрасле"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Нема било каквог дискриминационог говора"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Негативност према одређеној групи људи"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Дискриминација осмишљена да изазове емотивну повреду"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Експлицитна дискриминација на основу пола, сексуалности, расе или "
+"вероисповести"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Нема било каквог оглашавања"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Пласман производа"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Експлицитно упућивање на нарочите робне марке или заштићене производе"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Корисници се охрабрују да купују одређене ставке у стварном свету"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Нема било каквог коцкања"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Коцкање на насумичним догађајима који користе жетоне или кредите"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Коцкање које користи „играчки“ новац (play)"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Коцкање које користи стварни новац"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Не може се трошити стваран новац"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Корисници се охрабрују да донирају стварни новац"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Способност потрошње стварног новца у програму"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Нема начина за ћаскање са другим корисницима"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Међудејство између корисника без могућности ћаскања"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Умерена могућност ћаскања између корисника"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Неконтролисана могућност ћаскања између корисника"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Нема начина за разговор са другим корисницима"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Неконтролисана могућност звучног и видео ћаскања између корисника"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Нема дељења корисничких имена на друштвеним мрежама или адреса електронске "
+"поште"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Дељење корисничких имена на друштвеним мрежама или адреса електронске поште"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Нема дељења корисничких података са трећим странама"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Проверава последње издање програма"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Деле се дијагностички подаци преко којих други не могу препознати корисника"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Деле се дијагностички подаци преко којих други могу препознати корисника"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Нема дељења стварне локације са другим корисницима"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Дељење стварне локације са другим корисницима"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Нема упућивања на хомосексуалност"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Посредна упућивања на хомосексуалност"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Љубљење између особа истог пола"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Графичко сексуално понашање између особа истог пола"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Нема упућивања на проституцију"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Посредна упућивања на проституцију"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Непосредна упућивања на проституцију"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Графички прикази чина проституције"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Нема упућивања на прељубу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Посредна упућивања на прељубу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Непосредна упућивања на прељубу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Графички прикази чина прељубе"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Нема сексуализованих карактера"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Оскудно обучени људски карактери"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Претерано сексуализовани људски карактери"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Нема упућивања на скрнављење"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Прикази или упућивања ка историјским скрнављењима"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Прикази савременог људског скрнављења"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Графички прикази савременог скрнављења"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Без видљивих људских посмртних остатака"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Са видљивим људским посмртним остацима"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Посмртни остаци људи који су изложени временским приликама"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Графички прикази скрнављења људских тела"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Нема упућивања на робовласништво"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Прикази или упућивања ка историјском робовласништву"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Прикази савременог робовласништва"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Графички прикази савременог робовласништва"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -555,3 +555,556 @@ msgstr "Alatka Programskog toka"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Izdanje:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+#, fuzzy
+msgid "Mature"
+msgstr "Izdvojeno"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr ""
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr ""
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Nema crtanog nasilja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Likovi iz crtaća u nepoželjnim situacijama"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Likovi iz crtaća u agresivnom sukobu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Grafičko nasilje koje uključuje likove iz crtaća"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Nema fantazijskog nasilja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Likovi u nesigurnim situacijama koje se lako razlikuju od stvarnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Likovi u agresivnom sukobu koji se lako razlikuje od stvarnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Grafičko nasilje koje se lako razlikuje od stvarnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Nema realističnog nasilja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Blago stvarni likovi u nesigurnim situacijama"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Prikaz stvarnih likova u agresivnom sukobu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Grafičko nasilje koje uključuje stvarne likove"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Nema krvoprolića"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Nerealno krvoproliće"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realno krvoproliće"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Prikaz krvoprolića i sakaćenje delova tela"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Nema seksualnog nasilja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Silovanje ili drugo nasilno seksualno ponašanje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Nema upućivanja na alkohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Upućivanje na alkoholna pića"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Upotreba alkoholnih pića"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Nema upućivanja na zabranjene droge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Upućivanje na zabranjene droge"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Upotreba zabranjenih droga"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+#, fuzzy
+msgid "No references to tobacco products"
+msgstr "Upućivanje na duvanske proizvode"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Upućivanje na duvanske proizvode"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Upotreba duvanskih proizvoda"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Nema bilo kakve nagosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Kratka umetnička golotinja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Produžena golotinja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+#, fuzzy
+msgid "No references to or depictions of sexual nature"
+msgstr "Nema seksualnih prikaza ili upućivanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokativne upute ili prikazi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Seksualne upute ili prikazi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Grafičko seksualno ponašanje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Nema bilo kakve vulgarnosti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Blaga ili retka upotreba psovki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Umerena upotreba psovki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Jaka ili česta upotreba psovki"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Nema neumesnog humora"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Urnebesna komedija"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgaran ili neumesni humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Erotski i humor za odrasle"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Nema bilo kakvog diskriminacionog govora"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negativnost prema određenoj grupi ljudi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminacija osmišljena da izazove emotivnu povredu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Eksplicitna diskriminacija na osnovu pola, seksualnosti, rase ili "
+"veroispovesti"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Nema bilo kakvog oglašavanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Plasman proizvoda"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Eksplicitno upućivanje na naročite robne marke ili zaštićene proizvode"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Korisnici se ohrabruju da kupuju određene stavke u stvarnom svetu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Nema bilo kakvog kockanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Kockanje na nasumičnim događajima koji koriste žetone ili kredite"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Kockanje koje koristi „igrački“ novac (play)"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Kockanje koje koristi stvarni novac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Ne može se trošiti stvaran novac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Korisnici se ohrabruju da doniraju stvarni novac"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+#, fuzzy
+msgid "Ability to spend real money in-app"
+msgstr "Sposobnost potrošnje stvarnog novca u igri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Nema načina za ćaskanje sa drugim korisnicima"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+#, fuzzy
+msgid "User-to-user interactions without chat functionality"
+msgstr "Međudejstvo između korisnika bez mogućnosti ćaskanja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Umerena mogućnost ćaskanja između korisnika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Nekontrolisana mogućnost ćaskanja između korisnika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Nema načina za razgovor sa drugim korisnicima"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Nekontrolisana mogućnost zvučnog i video ćaskanja između korisnika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr ""
+"Nema razmene korisničkih imena društvenih mreža ili adresa elektronske pošte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr ""
+"Razmena korisničkih imena društvenih mreža ili adresa elektronske pošte"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+#, fuzzy
+msgid "No sharing of user information with third parties"
+msgstr "Nema razmene korisničkih podataka sa trećim stranama"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Proverava poslednje izdanje programa"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Dele se dijagnostički podaci preko kojih drugi ne mogu prepoznati korisnika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr ""
+"Dele se dijagnostički podaci preko kojih drugi mogu prepoznati korisnika"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+#, fuzzy
+msgid "No sharing of physical location with other users"
+msgstr "Nema razmene fizičke lokacije sa drugim korisnicima"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+#, fuzzy
+msgid "Sharing physical location with other users"
+msgstr "Razmena stvarnih lokacija sa drugim korisnicima"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Nema upućivanja na homoseksualnost"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Posredna upućivanja na homoseksualnost"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Ljubljenje između osoba istog pola"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Grafičko seksualno ponašanje između osoba istog pola"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Nema upućivanja na prostituciju"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Posredna upućivanja na prostituciju"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+#, fuzzy
+msgid "Direct references to prostitution"
+msgstr "Neposredna upućivanja na prostituciju"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Grafički prikazi čina prostitucije"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Nema upućivanja na preljubu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Posredna upućivanja na preljubu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+#, fuzzy
+msgid "Direct references to adultery"
+msgstr "Neposredna upućivanja na preljubu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Grafički prikazi čina preljube"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Nema seksualizovanih karaktera"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Oskudno obučeni ljudski karakteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Preterano seksualizovani ljudski karakteri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Nema upućivanja na skrnavljenje"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+#, fuzzy
+msgid "Depictions of or references to historical desecration"
+msgstr "Prikazi ili upućivanja ka istorijskim skrnavljenjima"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Prikazi savremenog ljudskog skrnavljenja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Grafički prikazi savremenog skrnavljenja"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Bez vidljivih ljudskih posmrtnih ostataka"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Sa vidljivim ljudskim posmrtnim ostacima"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Posmrtni ostaci ljudi koji su izloženi vremenskim prilikama"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Grafički prikazi skrnavljenja ljudskih tela"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Nema upućivanja na robovlasništvo"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+#, fuzzy
+msgid "Depictions of or references to historical slavery"
+msgstr "Prikazi ili upućivanja ka istorijskom robovlasništvu"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Prikazi savremenog robovlasništva"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Grafički prikazi savremenog robovlasništva"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -11,258 +11,547 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2016-08-06 03:00+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
-"Language-Team: Serbian (Latin) (http://www.transifex.com/freedesktop/appstream-glib/language/sr@latin/)\n"
+"Language-Team: Serbian (Latin) (http://www.transifex.com/freedesktop/"
+"appstream-glib/language/sr@latin/)\n"
 "Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
-msgid "Add HiDPI icons to the tarball"
-msgstr "Dodaj „HiDPi“ ikonice u arhivu"
-
-#. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Dodaje IB ostave svakom sastojku"
-
-#. TRANSLATORS: command line option
-msgid "Add encoded icons to the XML"
-msgstr "Dodaj kodirane ikonicu u „XML“"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Drugi naziv za „%s“"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Alatka Programskog toka"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Proverava instalirane podatke programa"
-
-msgid "Command not found, valid commands are:"
-msgstr "Nisam našao naredbu, ispravne naredbe su:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Uporedi sadržaj dve datoteke Programskog toka"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Pretvori „AppData“ datoteku u „NEWS“ format"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Pretvori „NEWS“ datoteku u „AppData“ format"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Pretvara metapodatke Programskog toka iz jednog izdanja u drugo"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Pravi CSV dokument stanja"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Napravi matričnu HTML stranicu"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Pravi HTML stranicu stanja"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Prikaži žetone pretrage programa"
-
-#. TRANSLATORS: command line option
-msgid "Do not compress the icons into a tarball"
-msgstr "Ne pakuj ikonice unutar arhive"
-
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Ne koristi pristup mreži"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Gotovo!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Ispisuje programe u metapodacima Programskog toka"
-
-#. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Uključi profilisanje"
-
-#. list failures
-msgid "FAILED"
-msgstr "NEUSPEH"
-
-#. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Ne mogu da dodam paket"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Ne mogu da napravim metapodatke"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Ne mogu da otvorim paket"
-
-#. TRANSLATORS: error message
-msgid "Failed to parse arguments"
-msgstr "Ne mogu da obradim argumente"
-
-#. TRANSLATORS: error message
-msgid "Failed to set up builder"
-msgstr "Ne mogu da podesim program za izgradnju"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Zanemari određene vrste veta"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Uključi neuspešne rezultate u izlaz"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Uvrsti dodatne metapodatke iz spoljne datoteke"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Instalira metapodatke Programskog toka"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Instalira metapodatke Programskog toka sa novim poreklom"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Ispisuje programe za koje paketi nisu napravili rezervu"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Dupliraj uzvodne snimke ekrana"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Novo izdanje API-ja"
-
-msgid "Not enough arguments, expected file.xml"
-msgstr "Nema dovoljno argumenata, očekivah „datoteka.xml“"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Nema dovoljno argumenata, očekivah „stari.xml novi.xml“ izdanje"
-
-#. TRANSLATORS: the file is valid
-msgid "OK"
-msgstr "U redu"
-
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Pregledajte datoteku i popravite svaku stavku „FIXME“"
-
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Zameni snimke ekrana u izvornoj datoteci"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Pregledam pakete..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Potraži programe Programskog toka"
-
-#. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Postavi osnovno ime za izlazne datoteke"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Podešava direktorijum ostave"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Postavi fasciklu sa ikonicama"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Podešava direktorijum dnevnika"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Postavi najmanju veličinu ikonice u pikselima"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Podešava broj niti"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Podešava staro mesto metapodataka"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Podešava naziv porekla"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Podešava direktorijum izlaza"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Podešava direktorijum paketa"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Podešava privremeni direktorijum"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
 msgid "Show extra debugging information"
 msgstr "Prikazuje dodatne podatke za ispravljanje grešaka u programu"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Dodaje IB ostave svakom sastojku"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Uključi neuspešne rezultate u izlaz"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
+msgid "Add HiDPI icons to the tarball"
+msgstr "Dodaj „HiDPi“ ikonice u arhivu"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:88
+msgid "Add encoded icons to the XML"
+msgstr "Dodaj kodirane ikonicu u „XML“"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:91
+msgid "Do not compress the icons into a tarball"
+msgstr "Ne pakuj ikonice unutar arhive"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Podešava direktorijum dnevnika"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Podešava direktorijum paketa"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Podešava privremeni direktorijum"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Podešava direktorijum izlaza"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Postavi fasciklu sa ikonicama"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Podešava direktorijum ostave"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Postavi osnovno ime za izlazne datoteke"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Podešava naziv porekla"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Podešava broj niti"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Postavi najmanju veličinu ikonice u pikselima"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Podešava staro mesto metapodataka"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Zanemari određene vrste veta"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
+msgid "Failed to parse arguments"
+msgstr "Ne mogu da obradim argumente"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:246
+msgid "Failed to set up builder"
+msgstr "Ne mogu da podesim program za izgradnju"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Ne mogu da otvorim paket"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Pregledam pakete..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Ne mogu da dodam paket"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Ne mogu da napravim metapodatke"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Gotovo!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr ""
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+#, fuzzy
+msgid "Set the prefix"
+msgstr "Podešava naziv porekla"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr ""
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr ""
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr ""
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr ""
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr ""
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr ""
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+#, fuzzy
+msgid "Error creating output directory"
+msgstr "Podešava direktorijum izlaza"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr ""
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr ""
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Drugi naziv za „%s“"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Nisam našao naredbu, ispravne naredbe su:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Pregledajte datoteku i popravite svaku stavku „FIXME“"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+#, fuzzy
+msgid "Old API version"
+msgstr "Novo izdanje API-ja"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Novo izdanje API-ja"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Nema dovoljno argumenata, očekivah „stari.xml novi.xml“ izdanje"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr ""
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Nema dovoljno argumenata, očekivah „datoteka.xml“"
+
+#. TRANSLATORS: %s is a file type,
+#. * e.g. 'appdata'
+#: client/as-util.c:595
+#, c-format
+msgid "File format '%s' cannot be upgraded"
+msgstr ""
+
+#. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
+msgid "Format not recognised"
+msgstr ""
+
+#. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
+msgid "No desktop applications found"
+msgstr ""
+
+#. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
+msgid "OK"
+msgstr "U redu"
+
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "NEUSPEH"
+
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Potvrđivanje nije uspelo"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Potvrđivanje datoteka nije uspelo"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Potvrđivanje nije uspelo"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Potvrđivanje datoteka nije uspelo"
+
+#. TRANSLATORS: application was removed
+#: client/as-util.c:4076
+msgid "Removed"
+msgstr ""
+
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr ""
+
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr ""
+
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Ne koristi pristup mreži"
+
+#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Prikazuje izdanje"
 
-#. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Uklanja metapodatke Programskog toka"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Uključi profilisanje"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Pretvara metapodatke Programskog toka iz jednog izdanja u drugo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Nadograđuje metapodatke Programskog toka na najnovije izdanje"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Ispisuje programe u metapodacima Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Potraži programe Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+#, fuzzy
+msgid "Search for AppStream applications by package name"
+msgstr "Potraži programe Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+#, fuzzy
+msgid "Show all installed AppStream applications"
+msgstr "Potraži programe Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+#, fuzzy
+msgid "Search for AppStream applications by category name"
+msgstr "Potraži programe Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Prikaži žetone pretrage programa"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Instalira metapodatke Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Instalira metapodatke Programskog toka sa novim poreklom"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Uklanja metapodatke Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Pravi HTML stranicu stanja"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Pravi CSV dokument stanja"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Napravi matričnu HTML stranicu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Ispisuje programe za koje paketi nisu napravili rezervu"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Potvrđuje Programske podatke ili datoteku Programskog toka"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Potvrđuje Programske podatke ili datoteku Programskog toka(opušteno)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Potvrđuje Programske podatke ili datoteku Programskog toka(izričito)"
 
-msgid "Validation failed"
-msgstr "Potvrđivanje nije uspelo"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Potvrđuje Programske podatke ili datoteku Programskog toka(opušteno)"
 
-msgid "Validation of files failed"
-msgstr "Potvrđivanje datoteka nije uspelo"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Pretvori „AppData“ datoteku u „NEWS“ format"
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Pretvori „NEWS“ datoteku u „AppData“ format"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Proverava instalirane podatke programa"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "Proverava instalirane podatke programa"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Zameni snimke ekrana u izvornoj datoteci"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Dupliraj uzvodne snimke ekrana"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Uvrsti dodatne metapodatke iz spoljne datoteke"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Uporedi sadržaj dve datoteke Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+#, fuzzy
+msgid "Merge several files to an AppStream file"
+msgstr "Uporedi sadržaj dve datoteke Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+#, fuzzy
+msgid "Import a file to AppStream markup"
+msgstr "Pretvori „NEWS“ datoteku u „AppData“ format"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "Potraži programe Programskog toka"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Alatka Programskog toka"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "Izdanje:"

--- a/po/sv.po
+++ b/po/sv.po
@@ -14,10 +14,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-01-14 02:00+0000\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
-"Language-Team: Swedish (http://www.transifex.com/freedesktop/appstream-glib/language/sv/)\n"
+"Language-Team: Swedish (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/sv/)\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,403 +27,523 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Visa extra felsökningsinformation"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Lägg till ett cache-ID till varje komponent"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Inkludera misslyckade resultat i utmatningen"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Lägg till HiDPI-ikoner till tar-arkivet"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Lägg till ett cache-ID till varje komponent"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Lägg till ett språk till en källfil"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Lägg till ett tillhandahållande till en källfil"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Lägg till kodade ikoner till XML:en"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Tillagt"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Alias för %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream Utility"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Avbrutet"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Kontrollera installerad programdata"
-
-msgid "Command not found, valid commands are:"
-msgstr "Hittade inte kommando, giltiga kommandon är:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Jämför innehåll från två AppStream-filer"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Jämför versionsnummer"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Konvertering från %s to %s är inte implementerad"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Konvertera en AppData-fil till NEWS-format"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Konvertera en NEWS-fil till AppData-format"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Konverterar AppStream-metadata från en version till en annan"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Skapa ett CSV-statusdokument"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Skapa en HTML-matrissida"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Skapa en HTML-statussida"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Skapar en exempel-AppData-fil från en .desktop-fil"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Visa sökelement för program"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Komprimera inte ikonerna till ett tar-arkiv"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Använd inte nätverksåtkomst"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Klar!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Dumpar programmen i AppStream-metadatat"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Sätt loggningskatalogen"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Aktivera profilering"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Sätt paketkatalogen"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Fel vid skapande av utdatakatalog"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Sätt den temporära katalogen"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Fel vid inläsning av AppData-fil"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Sätt utdatakatalogen"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Fel vid inläsning av skrivbordsfil"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Ställ in ikonkatalogen"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Fel vid tolkning av kudos"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Sätt cachekatalogen"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Fel vid tolkning av tillhandahåller"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Ställ in grundnamnet för de utmatade filerna"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Fel vid tolkning av översättningar"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Sätt ursprungsnamnet"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Fel vid sparning av AppStream-fil"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Sätt antalet trådar"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Exporterar överenskommelsen till text"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Ställ in den minimala storleken för ikoner i pixlar"
 
-#. list failures
-msgid "FAILED"
-msgstr "MISSLYCKADES"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Sätt platsen för det gamla metadatat"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ignorera vissa typer av veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Misslyckades med att lägga till paket"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Misslyckades med att generera metadata"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Misslyckades med att öppna paket"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Misslyckades med att tolka argument"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Misslyckades med att ställa in builder"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Misslyckades med att öppna paket"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Söker av paket…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Misslyckades med att lägga till paket"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Tolkade %u/%u filer …"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Misslyckades med att generera metadata"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Klar!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Sparningsikon"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Ställ in prefixet"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Behandlar program"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Fel vid inläsning av AppData-fil"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Fel vid tolkning av översättningar"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Fel vid tolkning av kudos"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Fel vid tolkning av tillhandahåller"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Ogiltigt desktop-filnamn"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Fel vid inläsning av skrivbordsfil"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Fel vid skapande av utdatakatalog"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Sparar AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Fel vid sparning av AppStream-fil"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Alias för %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Hittade inte kommando, giltiga kommandon är:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Vänligen granska filen och fixa ”FIXME”-objekt"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Gammal API-version"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Ny API-version"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Inte nog med argument, förväntade old.xml new.xml version"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Konvertering från %s to %s är inte implementerad"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Inte nog med argument, förväntade file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Filformat ”%s” kan inte uppgraderas"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Format kan inte identifieras"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Generera ett GUID från en inmatad sträng"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ignorera vissa typer av veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Importera en fil till AppStream-uppmärkning"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Inkludera misslyckade resultat i utmatningen"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Bädda in extra metadata från en extern fil"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Installerar AppStream-metadata"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Installerar AppStream-metadata med nytt ursprung"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Ogiltigt desktop-filnamn"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Lista program utan motsvarande paket"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Sammanfoga flera filer till en AppStream-fil"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Spegla skärmdumparna från uppström"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Modifiera en AppData-fil"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Ny API-version"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Inga skrivbordsprogram hittades"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Inte nog med argument, förväntade file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Inte nog med argument, förväntade old.xml new.xml version"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "OK"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Gammal API-version"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "MISSLYCKADES"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Validering misslyckades"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Validering av filer misslyckades"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Tolkade %u/%u filer …"
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Vänligen granska filen och fixa ”FIXME”-objekt"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Validering misslyckades"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Behandlar program"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Validering av filer misslyckades"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Borttaget"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Ersätt skärmdumpar i källfil"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Tillagt"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Sparar AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Avbrutet"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Sparningsikon"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Söker av paket…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Sök efter AppStream-program"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Sök efter AppStream-program efter kategorinamn"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Sök efter AppStream-program efter paketnamn"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Använd inte nätverksåtkomst"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Ställ in grundnamnet för de utmatade filerna"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Sätt cachekatalogen"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Ställ in ikonkatalogen"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Sätt loggningskatalogen"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Ställ in den minimala storleken för ikoner i pixlar"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Sätt antalet trådar"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Sätt platsen för det gamla metadatat"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Sätt ursprungsnamnet"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Sätt utdatakatalogen"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Sätt paketkatalogen"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Ställ in prefixet"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Sätt den temporära katalogen"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Visa alla installerade AppStream-program"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Visa extra felsökningsinformation"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Visa version"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Dela upp en AppStream-fil i AppData- och Metainfo-filer"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Aktivera profilering"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Testa ett reguljärt uttryck"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Konverterar AppStream-metadata från en version till en annan"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Avinstallerar AppStream-metadata"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Uppgradera AppStream-metadata till den senaste versionen"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Skapar en exempel-AppData-fil från en .desktop-fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Dumpar programmen i AppStream-metadatat"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Sök efter AppStream-program"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Sök efter AppStream-program efter paketnamn"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Visa alla installerade AppStream-program"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Sök efter AppStream-program efter kategorinamn"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Visa sökelement för program"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Installerar AppStream-metadata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Installerar AppStream-metadata med nytt ursprung"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Avinstallerar AppStream-metadata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Skapa en HTML-statussida"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Skapa ett CSV-statusdokument"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Skapa en HTML-matrissida"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Lista program utan motsvarande paket"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Validera en AppData- eller AppStream-fil"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Validera en AppData- eller AppStream-fil (löst)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Exporterar överenskommelsen till text"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Validera en AppData- eller AppStream-fil (strikt)"
 
-msgid "Validation failed"
-msgstr "Validering misslyckades"
-
-msgid "Validation of files failed"
-msgstr "Validering av filer misslyckades"
-
-msgid "Version:"
-msgstr "Version:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Validera en AppData- eller AppStream-fil (löst)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Konvertera en AppData-fil till NEWS-format"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Konvertera en NEWS-fil till AppData-format"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Kontrollera installerad programdata"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "kontrollera ett installerat program"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Ersätt skärmdumpar i källfil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Lägg till ett tillhandahållande till en källfil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Lägg till ett språk till en källfil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Spegla skärmdumparna från uppström"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Bädda in extra metadata från en extern fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Jämför innehåll från två AppStream-filer"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Generera ett GUID från en inmatad sträng"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Modifiera en AppData-fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Dela upp en AppStream-fil i AppData- och Metainfo-filer"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Sammanfoga flera filer till en AppStream-fil"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Importera en fil till AppStream-uppmärkning"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Övervaka AppStream-platser för ändringar"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "kontrollera ett installerat program"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Jämför versionsnummer"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Testa ett reguljärt uttryck"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream Utility"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Version:"

--- a/po/sv.po
+++ b/po/sv.po
@@ -547,3 +547,542 @@ msgstr "AppStream Utility"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Version:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Allmänt"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "ALLA"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Endast för vuxna"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Mogen"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Tonåring"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Alla över 10 år"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Alla"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Tidig barndom"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Inget tecknat våld"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Tecknade figurer i farliga situationer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Tecknade figurer i aggressiv konflikt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Våldsskildring som involverar tecknade figurer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Inget orealistiskt våld"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Figurer i farliga situationer lätt åtskiljbara från verkligheten"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Figurer i aggressiv konflikt lätt åtskiljbar från verkligheten"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Våldsskildring lätt åtskiljbar från verkligheten"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Inget realistiskt våld"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Någorlunda realistiska figurer i farliga situationer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Skildringar av realistiska figurer i aggressiv konflikt"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Våldsskildring som involverar realistiska figurer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Ingen blodsutgjutelse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Orealistisk blodsutgjutelse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Realistisk blodsutgjutelse"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Skildringar av blodsutgjutelse och lemlästning"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Inget sexuellt våld"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Våldtäkt eller annat våldsamt sexuellt beteende"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Inga referenser till alkohol"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Referenser till alkoholhaltiga drycker"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Användning av alkoholhaltiga drycker"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Inga referenser till illegala droger"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Referenser till illegala droger"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Användning av illegala droger"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Inga referenser till tobaksprodukter"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Referenser till tobaksprodukter"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Användning av tobaksprodukter"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Inga sorters nakenhet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Kortvarig konstnärlig nakenhet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Långvarig nakenhet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Inga sexuella referenser eller skildringar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Provokativa referenser eller skildringar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Sexuella referenser eller skildringar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Skildring av sexuellt beteende"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Inga sorters svordomar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Milda eller tillfälligt förekommande svordomar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Måttlig användning av svordomar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Grova eller ofta förekommande svordomar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Ingen olämplig humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Slapstickhumor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Vulgär humor eller badrumshumor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Mogen eller sexuell humor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Inget diskriminerande språkbruk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Negativ inställning mot en specifik folkgrupp"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Diskriminering avsedd att orsaka emotionell smärta"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Explicit diskriminering baserad på kön, sexuell läggning, ras eller religion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Inga sorters annonser"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Produktplacering"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr ""
+"Explicita referenser till specifika varumärken eller varumärkesskyddade "
+"produkter"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Användare uppmanas att köpa specifika föremål i verkliga världen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Inget spelande"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Spel på slumpbaserade händelser med marker eller poäng"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Spel med låtsaspengar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Spel med riktiga pengar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Ingen möjlighet att spendera pengar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Användare uppmanas att skänka riktiga pengar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Möjlighet att spendera riktiga pengar i programmet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Inget sätt att chatta med andra användare"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Interaktion mellan användare utan chattfunktion"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Modererad chattfunktion mellan användare"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Okontrollerad chattfunktion mellan användare"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Inget sätt att prata med andra användare"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "Okontrollerad ljud- eller videochattfunktion mellan användare"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Ingen delning av e-postadresser eller användarnamn på sociala nätverk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Delning av e-postadresser eller användarnamn på sociala nätverk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Ingen delning av användarinformation med tredje part"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Söker efter den senaste programversionen"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Delning av diagnostiska data som inte låter andra identifiera användaren"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Delning av information som låter andra identifiera användaren"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Ingen delning av fysisk plats med andra användare"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Delning av fysisk plats med andra användare"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Inga referenser till homosexualitet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Indirekta referenser till homosexualitet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Kyssande mellan personer av samma kön"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Skildring av sexuellt beteende mellan personer av samma kön"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Inga referenser till prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Indirekta referenser till prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Direkta referenser till prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Skildringar av prostitution"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Inga referenser till otrohet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Indirekta referenser till otrohet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Direkta referenser till otrohet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Skildringar av otrohet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Inga sexualiserade figurer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Lättklädda mänskliga figurer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Öppet sexualiserade mänskliga figurer"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Inga referenser till skändning"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Skildringar av eller referenser till historisk skändning"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Skildringar av nutida skändning av människor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Realistiska skildringar av nutida skändning"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Inga synliga kvarlevor av människor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Synliga kvarlevor av människor"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Kvarlevor av döda människor som utsatts för väder och vind"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Realistiska skildringar av skändning av mänskliga kroppar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Inga referenser till slaveri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Skildringar av eller referenser till historiskt slaveri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Skildringar av nutida slaveri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Grafiska skildringar av nutida slaveri"

--- a/po/tr.po
+++ b/po/tr.po
@@ -546,3 +546,544 @@ msgstr "AppStream Uygulaması"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Sürüm:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Genel"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "TÜMÜ"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Yalnızca Yetişkinler"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Yetişkin"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Genç"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "10 Yaş Üstü Herkes"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Herkes"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Erken Çocukluk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Çizgi dizisi şiddeti yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Çizgi karakterler güvensiz durumlarda"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Çizgi karakterler saldırgan çatışma halinde"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Çizgi karakterlerin dahil olduğu görsel şiddet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Fantezi şiddeti yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr ""
+"Güvensiz durumlardaki karakterler gerçeklikten kolayca ayırt edilebilir"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr ""
+"Agresif çatışma içindeki karakterler gerçeklikten kolayca ayırt edilebilir"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Gerçeklikten kolayca ayırt edilebilen canlı şiddet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Gerçekçi şiddet yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Hafif gerçekçi karakterler güvenli olmayan durumlarda"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Agresif çatışma içindeki gerçekçi karakterlerin betimlemesi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Gerçekçi karakterleri ilgilendiren canlı şiddet"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Kan dökme yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Gerçekçi olmayan kan dökme"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Gerçekçi kan dökme"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Kan dökme betimlemeleri ve vücut parçalarının sakatlanması"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Cinsel şiddet yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Tecavüz veya diğer şiddetli cinsel davranış"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Alkole atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Alkollü içeceklere atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Alkollü içeceklerin kullanımı"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Yasadışı ilaçlara atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Yasadışı ilaçlara atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Yasadışı ilaçların kullanımı"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Tütün ürünlerine atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Tütün ürünlerine atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Tütün ürünlerinin kullanımı"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Herhangi biçimde çıplaklık yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Kısa sanatsal çıplaklık"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Uzun çıplaklık"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Cinsel doğaya atıf veya betimleme yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Kışkırtıcı atıflar veya betimlemeler"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Cinsel atıflar veya betimlemeler"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Canlı cinsel davranış"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Herhangi biçimde küfür yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Hafif veya sık olmayan küfür kullanımı"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Orta kullanımlı küfür"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Şiddetli veya sık küfür kullanımı"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Uygunsuz mizah yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Kaba mizah"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Kaba veya banyo mizahı"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Olgun veya cinsel mizah"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Herhangi biçimde ayrımcı dil yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Belirli bir insan kümesine karşı olumsuzluk"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Duygusal zarara neden olmaya tasarlanmış ayrımcılık"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "Cinsiyet, cinsellik, ırk veya din tabanlı açık ayrımcılık"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Herhangi biçimde reklam yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Ürün yerleştirme"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Belirli markalara veya ticari markalı ürünlere açık atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Kullanıcılar belirli gerçek dünya ögelerini satın almaya özendirilir"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Herhangi biçimde kumar yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr ""
+"Belirteç veya kontör kullanarak rastlantısal etkinlikler üzerinde kumar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "“Oyun” parası kullanarak kumar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Gerçek para kullanarak kumar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Para harcama yeteneği yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Kullanıcılar gerçek para bağışlamaya özendirilir"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Uygulama içi gerçek para harcama yeteneği"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Diğer kullanıcılarla sohbet etme yolu yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Sohbet işlevi olmadan kullanıcıdan kullanıcıya etkileşimler"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Kullanıcılar arasında denetlenen konuşma işlevi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Kullanıcılar arasında denetlenmeyen konuşma işlevi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Diğer kullanıcılarla konuşma yolu yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr ""
+"Kullanıcılar arasında denetlenmeyen sesli veya görüntülü konuşma işlevi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Sosyal ağ kullanıcı adlarının veya e-posta adreslerinin paylaşımı yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Sosyal ağ kullanıcı adlarını veya e-posta adreslerini paylaşır"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Üçüncü şahıslarla kullanıcı bilgisi paylaşımı yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "En son uygulama sürümünün denetlenmesi"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Başkalarının kullanıcıyı tanımasını sağlamayacak tanılama verisinin "
+"paylaşılması"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Başkalarının kullanıcıyı tanımasını sağlayacak bilgilerin paylaşılması"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Diğer kullanıcılarla fiziksel konum paylaşımı yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Diğer kullanıcılarla fiziksel konum paylaşımı"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Eş cinselliğe atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Eş cinselliğe doğrudan olmayan atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Benzer cinsiyetteki insanlar arasında öpüşme"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Benzer cinsiyetteki insanların arasında görsel cinsî davranış"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Fuhşa atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Fuhşa doğrudan olmayan atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Fuhuşa doğrudan atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Fuhuş eyleminin görsel betimlemeleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Eş aldatmaya atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Eş aldatmaya doğrudan olmayan atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Eş aldatmaya doğrudan atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Eş aldatma eyleminin görsel betimlemeleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Cinselleştirilmiş karakterler yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Yetersizce giyinmiş insan karakterleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Açıkça cinselleştirilmiş insan karakterleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Kutsala saygısızlığa atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Tarihsel saygısızlığa ilişkin betimlemeler veya atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Çağdaş zaman insan saygısızlığının betimlemeleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Çağdaş zaman saygısızlığının görsel betimlemeleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Görününür ölü insan kalıntıları yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Görününür ölü insan kalıntıları"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Parçalarına ayrılmış ölü insan kalıntıları"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "İnsan bedenlerine saygısızlığın görsel betimlemeleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Köleliğe atıf yok"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Tarihsel köleliğe ait betimlemeler veya atıflar"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Çağdaş zaman köleliğinin betimlemeleri"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Çağdaş zaman köleliğinin görsel betimlemeleri"

--- a/po/tr.po
+++ b/po/tr.po
@@ -12,10 +12,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-08-25 07:59+0000\n"
 "Last-Translator: Emin Tufan Çetin <etcetin@gmail.com>\n"
-"Language-Team: Turkish (http://www.transifex.com/freedesktop/appstream-glib/language/tr/)\n"
+"Language-Team: Turkish (http://www.transifex.com/freedesktop/appstream-glib/"
+"language/tr/)\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,403 +25,524 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Ek hata ayıklama bilgisi göster"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Her bileşene önbellek kimliği ekle"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Başarısız sonuçları çıktıya dahil et"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "HiDPI simgeleri Tar dosyasına ekle"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Her bileşene önbellek kimliği ekle"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Kaynak dosyaya dil ekle"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Kaynak dosyaya sağlanan ekle"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Kodlanmış simgeleri XML'e ekle"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Eklendi"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "%s için takma ad"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream Uygulaması"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "İptal edildi"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Kurulu uygulama verisini kontrol et"
-
-msgid "Command not found, valid commands are:"
-msgstr "Komut bulunamadı, geçerli komutlar şunlar:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "İki AppStream dosyasının içeriklerini karşılaştır"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Sürüm numaralarını karşılaştır"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "%s türünden %s türüne dönüşüm hayata geçirilmedi"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "AppData dosyasını NEWS biçimine dönüştür"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "NEWS dosyasını AppData biçimine dönüştür"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "AppStream üst verisini bir sürümden diğerine dönüştürür"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Bir CSV durum belgesi oluştur"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Bir HTML matris sayfası oluştur"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Bir HTML durum sayfası oluşturur"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Bir .desktop dosyasından örnek bir AppData dosyası oluşturur"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Uygulama arama jetonlarını görüntüle"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Simgeleri Tar dosyasına sıkıştırma"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Ağ erişimini kullanma"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Tamamlandı!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "AppStream üst verisindeki uygulamaları döker"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Günlük kaydı dizinini ayarla"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Profillemeyi etkinleştir"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Paketler dizinini ayarla"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Çıktı dizini oluşturulurken hata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Geçici dizini ayarla"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "AppData dosyası yüklenirken hata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Çıktı dizinini ayarla"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Masaüstü dosyası yüklenirken hata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Simgeler dizinini belirle"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Kudo'lar ayıklanırken hata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Önbellek dizini ayarla"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Sağlananlar ayıklanırken hata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Çıktı dosyalarının temel adını belirle"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Çeviriler ayıklanırken hata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Köken adını ayarla"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "AppStream dosyasını kaydederken hata"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Süreç sayısını ayarla"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Sözleşmeyi metin olarak dışa aktarır"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "En küçük simge boyutunu piksel türünde belirle"
 
-#. list failures
-msgid "FAILED"
-msgstr "BAŞARISIZ"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Eski üst veri konumunu ayarla"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Bazı tür retleri görmezden gel"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Paket ekleme başarısız"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Üst veri üretilemedi"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Paketler açılamadı"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Argüman ayrıştırması başarısız"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "İnşa edici kurulumu başarısız oldu"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Paketler açılamadı"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Paketler taranıyor..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Paket ekleme başarısız"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "%u/%u dosya ayıklandı..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Üst veri üretilemedi"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Tamamlandı!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Simge kaydediliyor"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Öneki belirle"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Uygulama işleniyor"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "AppData dosyası yüklenirken hata"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Çeviriler ayıklanırken hata"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Kudo'lar ayıklanırken hata"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Sağlananlar ayıklanırken hata"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Geçersiz masaüstü dosya adı"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Masaüstü dosyası yüklenirken hata"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Çıktı dizini oluşturulurken hata"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "AppStream kaydediliyor"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "AppStream dosyasını kaydederken hata"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "%s için takma ad"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Komut bulunamadı, geçerli komutlar şunlar:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr ""
+"Lütfen dosyayı gözden geçirin ve 'FIXME' olarak işaretlenmiş ögeleri düzeltin"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Eski API sürümü"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Yeni API sürümü"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Yeterli argüman yok, old.xml new.xml sürümleri bekleniyor"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "%s türünden %s türüne dönüşüm hayata geçirilmedi"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Yeterli argüman yok, file.xml bekleniyor"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "'%s' dosya biçimi yükseltilemiyor"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Biçim tanınmadı"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Girdi dizgesinden GUID oluştur"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Bazı tür retleri görmezden gel"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "AppStream biçimlendirmesine dosya aktar"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Başarısız sonuçları çıktıya dahil et"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Dış dosyadan ek üst veri kat"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "AppStream üst verisini yükler"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "AppStream üst verisini yeni bir köken ile yükler"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Geçersiz masaüstü dosya adı"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Paketler tarafından desteklenmeyen uygulamaları listele"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Birkaç dosyayı AppStream dosyasında birleştir"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Üst akım ekran görüntülerini yansıla"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "AppData dosyasını düzenle"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Yeni API sürümü"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Hiçbir masaüstü uygulaması bulunamadı"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Yeterli argüman yok, file.xml bekleniyor"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Yeterli argüman yok, old.xml new.xml sürümleri bekleniyor"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "Tamam"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Eski API sürümü"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "BAŞARISIZ"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Doğrulama başarısız"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Dosyaların doğrulaması başarısız"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "%u/%u dosya ayıklandı..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Lütfen dosyayı gözden geçirin ve 'FIXME' olarak işaretlenmiş ögeleri düzeltin"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Doğrulama başarısız"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Uygulama işleniyor"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Dosyaların doğrulaması başarısız"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Kaldırıldı"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Kaynak dosyadaki ekran görüntülerini değiştir"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Eklendi"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "AppStream kaydediliyor"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "İptal edildi"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Simge kaydediliyor"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Paketler taranıyor..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "AppStream uygulamalarını ara"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "AppStream uygulamalarını kategori adına göre ara"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "AppStream uygulamalarını paket adına göre ara"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Ağ erişimini kullanma"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Çıktı dosyalarının temel adını belirle"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Önbellek dizini ayarla"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Simgeler dizinini belirle"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Günlük kaydı dizinini ayarla"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "En küçük simge boyutunu piksel türünde belirle"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Süreç sayısını ayarla"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Eski üst veri konumunu ayarla"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Köken adını ayarla"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Çıktı dizinini ayarla"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Paketler dizinini ayarla"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Öneki belirle"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Geçici dizini ayarla"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Tüm kurulu AppStream uygulamalarını göster"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Ek hata ayıklama bilgisi göster"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Sürümü göster"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "AppStream dosyasını AppData ve Metainfo dosyalarına ayır"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Profillemeyi etkinleştir"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Düzenli ifadeyi sına"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "AppStream üst verisini bir sürümden diğerine dönüştürür"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "AppStream üst verisini kaldırır"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "AppStream üst verisini son sürüme günceller"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Bir .desktop dosyasından örnek bir AppData dosyası oluşturur"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "AppStream üst verisindeki uygulamaları döker"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "AppStream uygulamalarını ara"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "AppStream uygulamalarını paket adına göre ara"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Tüm kurulu AppStream uygulamalarını göster"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "AppStream uygulamalarını kategori adına göre ara"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Uygulama arama jetonlarını görüntüle"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "AppStream üst verisini yükler"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "AppStream üst verisini yeni bir köken ile yükler"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "AppStream üst verisini kaldırır"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Bir HTML durum sayfası oluşturur"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Bir CSV durum belgesi oluştur"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Bir HTML matris sayfası oluştur"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Paketler tarafından desteklenmeyen uygulamaları listele"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Bir AppData veya AppStream dosyasını doğrula"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Bir AppData veya AppStream dosyasını doğrula (gevşek)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Sözleşmeyi metin olarak dışa aktarır"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Bir AppData veya AppStream dosyasını doğrula (sıkı)"
 
-msgid "Validation failed"
-msgstr "Doğrulama başarısız"
-
-msgid "Validation of files failed"
-msgstr "Dosyaların doğrulaması başarısız"
-
-msgid "Version:"
-msgstr "Sürüm:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Bir AppData veya AppStream dosyasını doğrula (gevşek)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "AppData dosyasını NEWS biçimine dönüştür"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "NEWS dosyasını AppData biçimine dönüştür"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Kurulu uygulama verisini kontrol et"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "kurulu uygulamayı denetle"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Kaynak dosyadaki ekran görüntülerini değiştir"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Kaynak dosyaya sağlanan ekle"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Kaynak dosyaya dil ekle"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Üst akım ekran görüntülerini yansıla"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Dış dosyadan ek üst veri kat"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "İki AppStream dosyasının içeriklerini karşılaştır"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Girdi dizgesinden GUID oluştur"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "AppData dosyasını düzenle"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "AppStream dosyasını AppData ve Metainfo dosyalarına ayır"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Birkaç dosyayı AppStream dosyasında birleştir"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "AppStream biçimlendirmesine dosya aktar"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "AppStream konumlarını değişiklikler için gözle"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "kurulu uygulamayı denetle"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Sürüm numaralarını karşılaştır"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Düzenli ifadeyi sına"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream Uygulaması"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Sürüm:"

--- a/po/uk.po
+++ b/po/uk.po
@@ -547,3 +547,543 @@ msgstr "Інструмент AppStream"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "Версія:"
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "Загальне"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "Усі"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "Лише для дорослих"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "Для дорослих"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "Для підлітків"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "Для усіх 10+"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "Для усіх"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "Для маленьких дітей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "Без казкової жорстокості"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "Казковий персонаж у небезпеці"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "Казковий персонаж у сутичці"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "Графічна жорстокість застосовується до казкового персонажа"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "Без фантастичної жорстокості"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "Персонаж у небезпеці легко розрізняється від дійсності"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "Персонаж у сутичці легко розрізняється від дійсності"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "Графічна жорстокість легко розрізняється від дійсності"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "Без правдоподібної жорстокості"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "Наполовину вигаданий персонаж у небезпеці"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "Картинки про дійсного персонажа в сутичці"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "Графічна жорстокість застосовується до дійсного персонажа"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "Без кровопролиття"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "Неправдоподібне кровопролиття"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "Правдоподібне кровопролиття"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "Картинки кровопролиття і орудування частинами тіла"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "Без сексуального насильства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "Ґвалтування або інші насильні сексуальні поведінки"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "Без згадування про алкогольні напої"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "Згадування про алкогольні напої"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "Вживання алкогольних напоїв"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "Без згадування про заборонені медикаменти"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "Згадування про заборонені медикаменти"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "Вживання заборонених медикаментів"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "Без згадування про тютюнові вироби"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "Згадування про тютюнові виробів"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "Вживання тютюнових виробів"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "Без всякої оголеності"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "Коротка художня оголеність"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "Тривала оголеність"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "Без згадування або картинки сексуального характеру"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "Згадування або картинки задирливого характеру"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "Згадування або картинки сексуального характеру"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "Графічна сексуальна поведінка"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "Без усілякого богохульства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "Часткове використання богохульства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "Помірне використання богохульства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "Надмірне використання богохульства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "Без недоречного гумору"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "Блазенський гумор"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "Вульгарний або туалетний гумор"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "Дорослий або сороміцький гумор"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "Без дискримінацій в будь-яких її проявах"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "Негативне ставлення до певних груп людей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "Образи на підґрунті дискримінації"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr ""
+"Чітка дискримінація, яка ґрунтується на статевій, сексуальний, расовій або "
+"релігійній ознаці"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "Без реклами в будь-яких її проявах"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "Розміщення виробів"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "Чітке згадування про певний бренд або торгову марку"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "Користувачам пропонують придбати певні матеріальні товари"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "Без азартних ігор у будь-яких її проявах"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "Азартні ігри на випадкових подіях з використанням жетонів або кредитів"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "Азартні ігри з використанням ігрових грошей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "Азартні ігри з використанням справжніх грошей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "Без можливості витрачати справжні гроші у грі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "Користувачам пропонують вкладати реальні гроші"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "Можливість витрачати справжні гроші у програмі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "Не можна спілкуватися із іншими користувачами"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "Безпосередня взаємодія між користувачами без можливостей спілкування"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "Можливості зі спілкування між користувачами із модерацією"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "Неконтрольовані можливості із спілкування між користувачами"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "Без можливості звукового спілкування із іншими користувачами"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr ""
+"Неконтрольовані можливості із звукового та відеоспілкування між користувачами"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "Без оприлюднення даних соціальної мережі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "Оприлюднення даних соціальної мережі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "Без оприлюднення інформації третій стороні"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "Пошук найсвіжішої версії програми"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr ""
+"Оприлюднення діагностичних даних, які не надають безпосередньої змоги "
+"ідентифікувати користувача"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "Оприлюднення даних, які уможливлюють ідентифікацію користувача"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "Без оприлюднення фізичного розміщення іншим користувачам"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "Оприлюднення фізичного розміщення іншим користувачам"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "Без згадування гомосексуальності"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "Опосередковане згадування гомосексуальності"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "Цілунки між людьми однієї статі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "Відверта сексуальна поведінка між людьми однієї статі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "Без згадування проституції"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "Опосередковане згадування проституції"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "Безпосереднє згадування проституції"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "Відверте зображення акту проституції"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "Без згадування перелюбу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "Опосередковані згадування перелюбу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "Безпосередні згадування перелюбу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "Відверті зображення актів перелюбу"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "Без сексуальних персонажів"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "Напівоголені людські персонажі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "Відверто сексуальні людські персонажі"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "Без згадування знущання над людьми"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "Зображення або згадування знущання над людьми у минулому"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "Відверті зображення сучасного знущання над людьми"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "Відверті зображення сучасного знущання над людьми"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "Без показу решток мертвих людей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "Показ решток мертвих людей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "Докладний показ решток мертвих людей"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "Відверте зображення осквернення людських тіл"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "Без згадування рабства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "Зображення або згадки рабства у минулому"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "Зображення сучасного рабства"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "Відверте зображення сучасного рабства"

--- a/po/uk.po
+++ b/po/uk.po
@@ -13,415 +13,537 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-30 18:56+0100\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2019-03-03 07:21+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
-"Language-Team: Ukrainian (http://www.transifex.com/freedesktop/appstream-glib/language/uk/)\n"
+"Language-Team: Ukrainian (http://www.transifex.com/freedesktop/appstream-"
+"glib/language/uk/)\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "Показати додаткові діагностичні дані"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "Додавати ідентифікатор кешу до кожного з компонентів"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "Включити до виведення результати з помилками"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "Додати до архіву піктограми HiDPI"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "Додавати ідентифікатор кешу до кожного з компонентів"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "Додати мову до файла початкового коду"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "Додати надання залежностей до файла початкового коду"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "Додати до XML закодовані піктограми"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "Додано"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "Псевдонім %s"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "Інструмент AppStream"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "Скасовано"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "Перевірити дані встановлених програм"
-
-msgid "Command not found, valid commands are:"
-msgstr "Такої команди не знайдено. Можливі команди:"
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "Порівняти вміст двох файлів AppStream"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "Порівняти номери версій"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "Перетворення з %s у %s не реалізовано"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "Перетворити файл AppData у формат NEWS"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "Перетворити файл NEWS у формат AppData"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "Перетворити метадані AppStream з однієї версії до іншої"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "Створити документ щодо стану у форматі CSV"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "Створити сторінку матриці у форматі HTML"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "Створити сторінку щодо стану у форматі HTML"
-
-#. TRANSLATORS: command description
-msgid "Creates an example AppData file from a .desktop file"
-msgstr "Створити приклад файла AppData на основі файла .desktop"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "Виводити ключі пошуку програм"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "Не стискати піктограми до архіву"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "Не використовувати доступ до мережі"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "Виконано!"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "Створити дамп програм у метаданих AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "Встановити каталог для журналу"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "Увімкнути профілювання"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "Встановити каталог для пакунків"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "Помилка під час спроби створення каталогу результатів"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "Встановити адресу тимчасового каталогу"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "Помилка під час спроби завантажити файл AppData"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "Встановити каталог для виведення даних"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "Помилка під час спроби завантажити файл desktop"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "Встановити каталог піктограм"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "Помилка під час спроби обробити запис подяк"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "Встановити каталог кешу"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "Помилка під час спроби обробити запис вмісту (provides)"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "Встановити базові назви для виведених файлів"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "Помилка під час спроби обробити переклади"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "Встановити назву походження"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "Помилка під час спроби зберегти файл AppStream"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "Встановити кількість потоків виконання"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "Експортує угоду у текстовому форматі"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "Встановити мінімальний розмір піктограми у пікселях"
 
-#. list failures
-msgid "FAILED"
-msgstr "ПОМИЛКА"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "Встановити розташування старих метаданих"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "Ігнорувати певні типи вето"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "Не вдалося додати пакунок"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "Не вдалося створити метадані"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "Не вдалося відкрити пакунки"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "Не вдалося обробити аргументи"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "Не вдалося налаштувати засіб збирання"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "Не вдалося відкрити пакунки"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "Скануємо пакунки…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "Не вдалося додати пакунок"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "Оброблено %u з %u файлів…"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "Не вдалося створити метадані"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "Виконано!"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "Зберігаємо піктограму"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "Встановити префікс"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "Обробляємо програму"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "Помилка під час спроби завантажити файл AppData"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "Помилка під час спроби обробити переклади"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "Помилка під час спроби обробити запис подяк"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "Помилка під час спроби обробити запис вмісту (provides)"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "Некоректна назва стільничного файла"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "Помилка під час спроби завантажити файл desktop"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "Помилка під час спроби створення каталогу результатів"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "Зберігаємо AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "Помилка під час спроби зберегти файл AppStream"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "Псевдонім %s"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "Такої команди не знайдено. Можливі команди:"
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "Будь ласка, перегляньте файл і виправте записи, до яких додано «FIXME»"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "Стара версія програмного інтерфейсу"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "Нова версія програмного інтерфейсу"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "Недостатньо аргументів: мало бути вказано старий.xml і новий.xml"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "Перетворення з %s у %s не реалізовано"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "Недостатньо аргументів: мало бути вказано файл.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "Дані у форматі файлів «%s» не може бути оновлено"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "Нерозпізнаний формат"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "Створити GUID на основі рядка вхідних даних"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "Ігнорувати певні типи вето"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "Імпортувати файл до розмітки AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "Включити до виведення результати з помилками"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "Включити додаткові метадані із зовнішнього файла"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "Встановити метадані AppStream"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "Встановити метадані AppStream з новим походженням"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "Некоректна назва стільничного файла"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "Показати список програм, які не супроводжуються пакунками"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "Об’єднати декілька файлів до файла AppStream"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "Віддзеркалити знімки вікон із основної гілки розробки"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "Внести зміни до файла AppData"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "Нова версія програмного інтерфейсу"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "Не знайдено стільничних програм"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "Недостатньо аргументів: мало бути вказано файл.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "Недостатньо аргументів: мало бути вказано старий.xml і новий.xml"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "Гаразд"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "Стара версія програмного інтерфейсу"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "ПОМИЛКА"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "Спроба перевірки зазнала невдачі"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "Файли не пройшли перевірку"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "Оброблено %u з %u файлів…"
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "Будь ласка, перегляньте файл і виправте записи, до яких додано «FIXME»"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "Спроба перевірки зазнала невдачі"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "Обробляємо програму"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "Файли не пройшли перевірку"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "Вилучено"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "Замінити знімки вікон у початковому файлі"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "Додано"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "Зберігаємо AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "Скасовано"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "Зберігаємо піктограму"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "Скануємо пакунки…"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "Шукати програми AppStream"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "Шукати програми AppStream за назвою категорії"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "Шукати програми AppStream за назвою пакунка"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "Не використовувати доступ до мережі"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "Встановити базові назви для виведених файлів"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "Встановити каталог кешу"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "Встановити каталог піктограм"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "Встановити каталог для журналу"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "Встановити мінімальний розмір піктограми у пікселях"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "Встановити кількість потоків виконання"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "Встановити розташування старих метаданих"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "Встановити назву походження"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "Встановити каталог для виведення даних"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "Встановити каталог для пакунків"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "Встановити префікс"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "Встановити адресу тимчасового каталогу"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "Показати усі встановлені програми AppStream"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Показати додаткові діагностичні дані"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "Показати дані щодо версії"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "Розділити файл AppStream на файли AppData і Metainfo"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "Увімкнути профілювання"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "Перевірити формальний вираз"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "Перетворити метадані AppStream з однієї версії до іншої"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "Вилучити метадані AppStream"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "Оновити метадані AppData до найсвіжішої версії"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr "Створити приклад файла AppData на основі файла .desktop"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "Створити дамп програм у метаданих AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "Шукати програми AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "Шукати програми AppStream за назвою пакунка"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "Показати усі встановлені програми AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "Шукати програми AppStream за назвою категорії"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "Виводити ключі пошуку програм"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "Встановити метадані AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "Встановити метадані AppStream з новим походженням"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "Вилучити метадані AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "Створити сторінку щодо стану у форматі HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "Створити документ щодо стану у форматі CSV"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "Створити сторінку матриці у форматі HTML"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "Показати список програм, які не супроводжуються пакунками"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "Перевірити файл AppData або AppStream"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "Перевірити файл AppData або AppStream (нестрого)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "Експортує угоду у текстовому форматі"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "Перевірити файл AppData або AppStream (строго)"
 
-msgid "Validation failed"
-msgstr "Спроба перевірки зазнала невдачі"
-
-msgid "Validation of files failed"
-msgstr "Файли не пройшли перевірку"
-
-msgid "Version:"
-msgstr "Версія:"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "Перевірити файл AppData або AppStream (нестрого)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "Перетворити файл AppData у формат NEWS"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "Перетворити файл NEWS у формат AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "Перевірити дані встановлених програм"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "перевірити встановлену програму"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "Замінити знімки вікон у початковому файлі"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "Додати надання залежностей до файла початкового коду"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "Додати мову до файла початкового коду"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "Віддзеркалити знімки вікон із основної гілки розробки"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "Включити додаткові метадані із зовнішнього файла"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "Порівняти вміст двох файлів AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "Створити GUID на основі рядка вхідних даних"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "Внести зміни до файла AppData"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "Розділити файл AppStream на файли AppData і Metainfo"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "Об’єднати декілька файлів до файла AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "Імпортувати файл до розмітки AppStream"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "Спостерігати за змінами у місцях AppStream"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "перевірити встановлену програму"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "Порівняти номери версій"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "Перевірити формальний вираз"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "Інструмент AppStream"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "Версія:"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -551,3 +551,539 @@ msgstr "AppStream 实用工具"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "版本："
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s（%s）"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "常规"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "全部"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "仅限成人"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "成人"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "青少年"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "十岁及以上"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "任何人"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "儿童"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "无动画角色暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "动画角色处于危险境地"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "动画角色处于激烈冲突"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "包含动画角色的写实暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "无幻想的暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "角色处于易于与现实区分的危险境地"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "角色参与易于与现实区分的激烈冲突"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "角色参与易于与现实区分的写实暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "无逼真的暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "较逼真角色处于危险境地"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "描写逼真角色参与激烈冲突"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "逼真角色参与的写实暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "无流血"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "不逼真的血"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "逼真的血"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "描写流血及肢体伤害"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "无性暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "强奸及其他暴力的性行为"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "无对酒精的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "对酒精饮料的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "饮用酒精饮料"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "无对非法药物的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "对非法药物的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "吸食非法药物"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+#, fuzzy
+msgid "No references to tobacco products"
+msgstr "对烟草产品的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "对烟草产品的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "吸食烟草产品"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "无任何形式的裸体"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "短暂且艺术性的裸体"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "长时间的裸体描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "无性相关的暗示和描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "挑衅性暗示或描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "性暗示或描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "生动的性行为"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "无任何种类的粗俗语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "少量粗俗语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "中等数量的粗俗语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "大量粗俗语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "无不适当的笑话"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "闹剧式笑话"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "粗俗或浴室笑话"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "荤笑话"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "无任何种类的歧视性语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "对特定人群负面的语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "伤害情感的歧视性语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "针对性别、性向、种族或宗教的歧视性语言"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "无任何种类的广告"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "植入式广告"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "对特定产品的品牌或商标的明显暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "鼓励用户购买特定的真实商品"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "无任何种类的赌博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "通过随机事件使用游戏票券赌博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "使用游戏货币赌博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "使用真实货币赌博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "无花钱的功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "鼓励用户捐赠真实货币"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "应用中可使用真实货币"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "没有与其他用户聊天的功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "在用户之间不带聊天功能的交互功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "在用户之间受监控的聊天功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "在用户之间不受控制的聊天功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "无与其他用户沟通的方式"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "在用户之间不受控制的音频或视频聊天功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "不共享社交网络的用户名或电子邮件地址"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "共享社交网络的用户名或电子邮件地址"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "不与第三方共享用户信息"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "正在检查最新应用程序版本"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "分享无法识别用户身份的诊断数据"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "分享可以识别用户身份的信息"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "不与其他用户共享物理位置"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "与其他用户共享物理位置"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "无对同性恋的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "对同性恋的间接暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "同性别人类之间的亲吻"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "含有同性别人类之间性行为的图像"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "无对卖淫的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "对卖淫的间接暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "对卖淫的直接暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "卖淫行为的图像描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "无对通奸的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "对通奸的间接暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "对通奸的直接暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "通奸的图像描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "无性暗示角色"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "穿着暴露的人类角色"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "具有明显性暗示的人类角色"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "无对亵渎行为的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "亵渎历史的描写或暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "对当代人类亵渎的描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "亵渎当代社会的图像描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "无可见死亡人类尸体"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "有可见死亡人类尸体"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "有死亡人类尸体并展示其内容物"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "对亵渎人体行为的图像描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "无对奴役的暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "对历史上奴役行为的描写或暗示"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "对当代奴役行为的描写"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "对当代奴役行为的图片描写"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -14,10 +14,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2017-07-23 03:30+0000\n"
 "Last-Translator: cheng ye <18969068329@163.com>\n"
-"Language-Team: Chinese (China) (http://www.transifex.com/freedesktop/appstream-glib/language/zh_CN/)\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/freedesktop/"
+"appstream-glib/language/zh_CN/)\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,375 +27,527 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "显示额外的调试信息"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "向每一个组件添加一个缓存 ID"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "在输出中列出失败的结果"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "将高分辨率（HiDPI）图标添加进 tarball"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "向每一个组件添加一个缓存 ID"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "向源文件添加语言"
-
-#. TRANSLATORS: command description
-#, fuzzy
-msgid "Add a provide to a source file"
-msgstr "向源文件添加其所提供"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "将已编码的图标加入 XML"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "已添加"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "%s 的别名"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream 实用工具"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "已取消"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "检查安装的应用程序数据"
-
-msgid "Command not found, valid commands are:"
-msgstr "命令未找到，有效的命令有："
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "比较两份 AppStream 文件的内容"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "比较版本号"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "将 %s 转换成 %s 还未执行"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "将 AppData 文件转换成 NEWS 格式"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "将 NEWS 文件转换成 AppData 格式"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "将 AppStream 元数据从一个版本转换成另一个版本"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "创建一个 CSV 状态文档"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "创建 HTML matrix 表格页面"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "创建一个 HTML 状态页面"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "显示应用程序搜索令牌"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "不要将图标压缩至 tarball 中"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "不要使用网络连接"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "完成！"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "将应用程序转储到 AppStream 元数据中"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "设置日志用目录"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "启用性能分析"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "设置软件包目录"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "创建输出目录出错"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "设置临时目录"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "载入 AppData 文件出错"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "设置输出目录"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "载入 desktop 文件出错"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "设置图标用目录"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "解析 kudos 值出错"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "设置缓存目录"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "解析 provides 值出错"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "设置输出文件的基础名称"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "解析翻译出错"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "设置来源名称"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "保存 AppStream 文件出错"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "设置线程的数目"
 
-#. list failures
-msgid "FAILED"
-msgstr "失败"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "设置图标的最小像素大小"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "设置旧的元数据位置"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "忽略特定类型的否认值"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "软件包添加失败"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "元数据生成失败"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "软件包打开失败"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "参数解析失败"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "设置构建程序失败"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "软件包打开失败"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "正在扫描软件包……"
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "软件包添加失败"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr ""
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "元数据生成失败"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "完成！"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "正在保存图标"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "设置前缀"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "正在处理应用程序"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "载入 AppData 文件出错"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "解析翻译出错"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "解析 kudos 值出错"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "解析 provides 值出错"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+#, fuzzy
+msgid "Invalid desktop filename"
+msgstr "载入 desktop 文件出错"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "载入 desktop 文件出错"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "创建输出目录出错"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "正在保存 AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "保存 AppStream 文件出错"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "%s 的别名"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "命令未找到，有效的命令有："
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "请检查文件并修复任何标有“FIXME”的项目"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "旧 API 版本"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "新 API 版本"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "参数不够，预期为 old.xml new.xml [版本]"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "将 %s 转换成 %s 还未执行"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "参数不足，预期 file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "文件格式 “%s” 无法被升级"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "格式未识别"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "从输入字符串创建 GUID"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "忽略特定类型的否认值"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "导入文件到 AppStream 标记"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "在输出中列出失败的结果"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "从外部文件集成额外元数据"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "安装 AppStream 元数据"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "从新的来源安装 AppStream 元数据"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "列出未受软件包支持的应用程序"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "合并多个文件到一 AppStream 文件上"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "镜像上游快照"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "编辑 AppData 文件"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "新 API 版本"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "未发现桌面应用程序"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "参数不足，预期 file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "参数不够，预期为 old.xml new.xml [版本]"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "成功"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "旧 API 版本"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "失败"
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "请检查文件并修复任何标有“FIXME”的项目"
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "验证失败"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "正在处理应用程序"
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "文件验证失败"
+
+#: client/as-util.c:2908
+#, c-format
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
+
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "验证失败"
+
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "文件验证失败"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "已移除"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "替换源文件内的画面快照"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "已添加"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "正在保存 AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "已取消"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "正在保存图标"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "正在扫描软件包……"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "搜索 AppStream 应用程序"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "以类别名搜索 for AppStream 应用"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "按包名搜索 AppStream 应用程序"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "不要使用网络连接"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "设置输出文件的基础名称"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "设置缓存目录"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "设置图标用目录"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "设置日志用目录"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "设置图标的最小像素大小"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "设置线程的数目"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "设置旧的元数据位置"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "设置来源名称"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "设置输出目录"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "设置软件包目录"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "设置前缀"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "设置临时目录"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "显示所有已安装的 Appstream 应用"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "显示额外的调试信息"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "显示版本"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "将 AppStream 文件分割为 AppData 和 Metainfo 文件"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "启用性能分析"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "卸载 AppStream 元数据"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "将 AppStream 元数据从一个版本转换成另一个版本"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "升级 AppData 元数据至最新版本"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "将应用程序转储到 AppStream 元数据中"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "搜索 AppStream 应用程序"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "按包名搜索 AppStream 应用程序"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "显示所有已安装的 Appstream 应用"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "以类别名搜索 for AppStream 应用"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "显示应用程序搜索令牌"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "安装 AppStream 元数据"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "从新的来源安装 AppStream 元数据"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "卸载 AppStream 元数据"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "创建一个 HTML 状态页面"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "创建一个 CSV 状态文档"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "创建 HTML matrix 表格页面"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "列出未受软件包支持的应用程序"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "验证 AppData 或 AppStream 文件"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "验证 AppData 或 AppStream 文件 (宽松检验)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "验证 AppData 或 AppStream 文件 (严格检验)"
 
-msgid "Validation failed"
-msgstr "验证失败"
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "验证 AppData 或 AppStream 文件 (宽松检验)"
 
-msgid "Validation of files failed"
-msgstr "文件验证失败"
+#. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "将 AppData 文件转换成 NEWS 格式"
 
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "将 NEWS 文件转换成 AppData 格式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "检查安装的应用程序数据"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+#, fuzzy
+msgid "check an installed application"
+msgstr "检查安装的应用程序数据"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "替换源文件内的画面快照"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+#, fuzzy
+msgid "Add a provide to a source file"
+msgstr "向源文件添加其所提供"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "向源文件添加语言"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "镜像上游快照"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "从外部文件集成额外元数据"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "比较两份 AppStream 文件的内容"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "从输入字符串创建 GUID"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "编辑 AppData 文件"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "将 AppStream 文件分割为 AppData 和 Metainfo 文件"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "合并多个文件到一 AppStream 文件上"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "导入文件到 AppStream 标记"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
+#, fuzzy
+msgid "Watch AppStream locations for changes"
+msgstr "按包名搜索 AppStream 应用程序"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "比较版本号"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr ""
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream 实用工具"
+
+#: client/as-util.c:4732
 msgid "Version:"
 msgstr "版本："

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -547,3 +547,538 @@ msgstr "AppStream 公用程式"
 #: client/as-util.c:4732
 msgid "Version:"
 msgstr "版本："
+
+#. TRANSLATORS: This is the formatting of English and localized name
+#. * of the rating e.g. "Adults Only (solo adultos)"
+#: libappstream-glib/as-content-rating.c:261
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: libappstream-glib/as-content-rating.c:407
+msgid "General"
+msgstr "一般"
+
+#: libappstream-glib/as-content-rating.c:416
+msgid "ALL"
+msgstr "所有"
+
+#: libappstream-glib/as-content-rating.c:420
+#: libappstream-glib/as-content-rating.c:496
+msgid "Adults Only"
+msgstr "僅限成人 (18+)"
+
+#: libappstream-glib/as-content-rating.c:422
+#: libappstream-glib/as-content-rating.c:495
+msgid "Mature"
+msgstr "成熟 (17+)"
+
+#: libappstream-glib/as-content-rating.c:424
+#: libappstream-glib/as-content-rating.c:494
+msgid "Teen"
+msgstr "青少年 (13-19)"
+
+#: libappstream-glib/as-content-rating.c:426
+#: libappstream-glib/as-content-rating.c:493
+msgid "Everyone 10+"
+msgstr "十歲以上 (10+)"
+
+#: libappstream-glib/as-content-rating.c:428
+#: libappstream-glib/as-content-rating.c:492
+msgid "Everyone"
+msgstr "任何人"
+
+#: libappstream-glib/as-content-rating.c:430
+#: libappstream-glib/as-content-rating.c:491
+msgid "Early Childhood"
+msgstr "幼兒 (3+)"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:775
+msgid "No cartoon violence"
+msgstr "沒有漫畫暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:777
+msgid "Cartoon characters in unsafe situations"
+msgstr "漫畫角色處在非安全的情況下"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:779
+msgid "Cartoon characters in aggressive conflict"
+msgstr "漫畫角色有強勢衝突"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:781
+msgid "Graphic violence involving cartoon characters"
+msgstr "涉及漫畫角色的圖像暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:786
+msgid "No fantasy violence"
+msgstr "沒有幻想暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:788
+msgid "Characters in unsafe situations easily distinguishable from reality"
+msgstr "人物處在非安全的情況下但容易與現實區隔"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:790
+msgid "Characters in aggressive conflict easily distinguishable from reality"
+msgstr "人物有強勢衝突但容易與現實區隔"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:792
+msgid "Graphic violence easily distinguishable from reality"
+msgstr "圖像暴力但容易與現實區隔"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:797
+msgid "No realistic violence"
+msgstr "沒有現實暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:799
+msgid "Mildly realistic characters in unsafe situations"
+msgstr "輕微真實人物處在非安全的情況下"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:801
+msgid "Depictions of realistic characters in aggressive conflict"
+msgstr "真實人物有強勢衝突的描繪"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:803
+msgid "Graphic violence involving realistic characters"
+msgstr "涉及真實人物的圖像暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:808
+msgid "No bloodshed"
+msgstr "沒有殺人"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:810
+msgid "Unrealistic bloodshed"
+msgstr "非寫實的殺人"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:812
+msgid "Realistic bloodshed"
+msgstr "寫實的殺人"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:814
+msgid "Depictions of bloodshed and the mutilation of body parts"
+msgstr "殺人及殘害身體的描繪"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:819
+msgid "No sexual violence"
+msgstr "沒有性暴力"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:821
+msgid "Rape or other violent sexual behavior"
+msgstr "強暴或其他暴力式性行為"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:828
+msgid "No references to alcohol"
+msgstr "沒有涉及酒精"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:830
+msgid "References to alcoholic beverages"
+msgstr "涉及酒精性飲料"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:832
+msgid "Use of alcoholic beverages"
+msgstr "使用到酒精性飲料"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:838
+msgid "No references to illicit drugs"
+msgstr "沒有涉及非法藥物"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:840
+msgid "References to illicit drugs"
+msgstr "涉及非法藥物"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:842
+msgid "Use of illicit drugs"
+msgstr "使用到非法藥物"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:848
+msgid "No references to tobacco products"
+msgstr "沒有涉及菸草產品"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:850
+msgid "References to tobacco products"
+msgstr "涉及菸草產品"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:852
+msgid "Use of tobacco products"
+msgstr "使用到菸草產品"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:858
+msgid "No nudity of any sort"
+msgstr "沒有任何形式之裸體"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:860
+msgid "Brief artistic nudity"
+msgstr "短暫藝術性裸體"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:862
+msgid "Prolonged nudity"
+msgstr "長時間裸體"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:868
+msgid "No references to or depictions of sexual nature"
+msgstr "沒有涉及性事或描繪性事"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:870
+msgid "Provocative references or depictions"
+msgstr "涉及刺激或描繪刺激"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:872
+msgid "Sexual references or depictions"
+msgstr "涉及性或描繪性"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:874
+msgid "Graphic sexual behavior"
+msgstr "圖像式性行為"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:879
+msgid "No profanity of any kind"
+msgstr "沒有任何形式之辱駡"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:881
+msgid "Mild or infrequent use of profanity"
+msgstr "輕微或少有使用辱駡"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:883
+msgid "Moderate use of profanity"
+msgstr "偶爾使用辱駡"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:885
+msgid "Strong or frequent use of profanity"
+msgstr "強烈或經常使用辱駡"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:890
+msgid "No inappropriate humor"
+msgstr "沒有不適切之幽默"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:892
+msgid "Slapstick humor"
+msgstr "低俗鬧劇式幽默"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:894
+msgid "Vulgar or bathroom humor"
+msgstr "粗俗或廁所式幽默"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:896
+msgid "Mature or sexual humor"
+msgstr "成人或性相關幽默"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:901
+msgid "No discriminatory language of any kind"
+msgstr "沒有任何形式之歧視用語"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:903
+msgid "Negativity towards a specific group of people"
+msgstr "排斥特定群體"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:905
+msgid "Discrimination designed to cause emotional harm"
+msgstr "刻意造成情緒傷害之歧視"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:907
+msgid "Explicit discrimination based on gender, sexuality, race or religion"
+msgstr "根據性別、性能力、種族、信仰所作的針對性歧視"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:912
+msgid "No advertising of any kind"
+msgstr "沒有任何形式之行銷"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:914
+msgid "Product placement"
+msgstr "置入性產品行銷"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:916
+msgid "Explicit references to specific brands or trademarked products"
+msgstr "明確指涉特定廠牌或註冊商標之產品"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:918
+msgid "Users are encouraged to purchase specific real-world items"
+msgstr "鼓吹使用者購買特定真實世界商品"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:923
+msgid "No gambling of any kind"
+msgstr "任何形式之賭博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:925
+msgid "Gambling on random events using tokens or credits"
+msgstr "使用代幣或儲值之隨機活動性賭博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:927
+msgid "Gambling using “play” money"
+msgstr "使用「遊戲」財物之賭博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:929
+msgid "Gambling using real money"
+msgstr "使用實體金錢的賭博"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:934
+msgid "No ability to spend money"
+msgstr "沒有金錢花費之功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:936
+msgid "Users are encouraged to donate real money"
+msgstr "鼓勵使用者捐贈實體金錢"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:939
+msgid "Ability to spend real money in-app"
+msgstr "可在程式中花費實體金錢"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:944
+msgid "No way to chat with other users"
+msgstr "無法和其他使用者聊天"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:946
+msgid "User-to-user interactions without chat functionality"
+msgstr "使用者與使用者間之互動不含聊天功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:948
+msgid "Moderated chat functionality between users"
+msgstr "受審查的使用者間聊天功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:950
+msgid "Uncontrolled chat functionality between users"
+msgstr "未受管制的使用者間聊天功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:955
+msgid "No way to talk with other users"
+msgstr "無法和其他使用者對談"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:957
+msgid "Uncontrolled audio or video chat functionality between users"
+msgstr "未受管制的使用者間音訊或視訊聊天功能"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:964
+msgid "No sharing of social network usernames or email addresses"
+msgstr "不會分享社交網路使用者名稱或電子郵件爲止"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:966
+msgid "Sharing social network usernames or email addresses"
+msgstr "分享社交網路使用者名稱或電子郵件位址"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:973
+msgid "No sharing of user information with third parties"
+msgstr "不會與第三方單位分享使用者資訊"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:975
+msgid "Checking for the latest application version"
+msgstr "檢查最新的應用程式版本"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:977
+msgid "Sharing diagnostic data that does not let others identify the user"
+msgstr "分享無法讓他人辨識出使用者的診斷性數據資料"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:979
+msgid "Sharing information that lets others identify the user"
+msgstr "分享可以讓其他人辨識出使用者的資訊"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:984
+msgid "No sharing of physical location with other users"
+msgstr "不會與其他使用者分享實際地理位置"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:986
+msgid "Sharing physical location with other users"
+msgstr "與其他使用者分享實際地理位置"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:995
+msgid "No references to homosexuality"
+msgstr "沒有涉及同性戀議題"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:997
+msgid "Indirect references to homosexuality"
+msgstr "間接涉及同性戀議題"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:999
+msgid "Kissing between people of the same gender"
+msgstr "人類同性別親吻"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1001
+msgid "Graphic sexual behavior between people of the same gender"
+msgstr "圖像式人類同性別性行為"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1006
+msgid "No references to prostitution"
+msgstr "沒有涉及賣淫"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1008
+msgid "Indirect references to prostitution"
+msgstr "間接涉及賣淫"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1010
+msgid "Direct references to prostitution"
+msgstr "直接涉及賣淫"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1012
+msgid "Graphic depictions of the act of prostitution"
+msgstr "圖像式賣淫動作描繪"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1017
+msgid "No references to adultery"
+msgstr "沒有涉及通姦"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1019
+msgid "Indirect references to adultery"
+msgstr "間接涉及通姦"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1021
+msgid "Direct references to adultery"
+msgstr "直接涉及通姦"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1023
+msgid "Graphic depictions of the act of adultery"
+msgstr "圖像式通姦行為描繪"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1028
+msgid "No sexualized characters"
+msgstr "沒有性化角色"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1031
+msgid "Scantily clad human characters"
+msgstr "衣著覆蓋極少的人類角色"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1033
+msgid "Overtly sexualized human characters"
+msgstr "刻意性化的人類角色"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1038
+msgid "No references to desecration"
+msgstr "沒有涉及褻瀆"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1040
+msgid "Depictions of or references to historical desecration"
+msgstr "描繪或涉及史實上的褻瀆"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1042
+msgid "Depictions of modern-day human desecration"
+msgstr "描繪當代人體褻瀆"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1044
+msgid "Graphic depictions of modern-day desecration"
+msgstr "圖像式當代褻瀆描繪"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1049
+msgid "No visible dead human remains"
+msgstr "不會看見亡者遺體"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1051
+msgid "Visible dead human remains"
+msgstr "會看見亡者遺體"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1053
+msgid "Dead human remains that are exposed to the elements"
+msgstr "亡者遺體暴露在相關元素中"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1055
+msgid "Graphic depictions of desecration of human bodies"
+msgstr "圖像式褻瀆人體的描繪"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1060
+msgid "No references to slavery"
+msgstr "沒有涉及奴隸行為"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1062
+msgid "Depictions of or references to historical slavery"
+msgstr "描繪或涉及史實上的奴隸行為"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1064
+msgid "Depictions of modern-day slavery"
+msgstr "描繪當代的奴隸行為"
+
+#. TRANSLATORS: content rating description
+#: libappstream-glib/as-content-rating.c:1066
+msgid "Graphic depictions of modern-day slavery"
+msgstr "圖像式當代奴隸行為描繪"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,10 +14,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: appstream-glib\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-28 10:43+0000\n"
+"POT-Creation-Date: 2020-05-26 12:37+0100\n"
 "PO-Revision-Date: 2018-10-08 02:19+0000\n"
 "Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/freedesktop/appstream-glib/language/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (http://www.transifex.com/freedesktop/"
+"appstream-glib/language/zh_TW/)\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,399 +27,523 @@ msgstr ""
 "X-Generator: Zanata 4.6.2\n"
 
 #. TRANSLATORS: command line option
+#: client/as-builder.c:76 client/as-compose.c:326 client/as-util.c:4429
+msgid "Show extra debugging information"
+msgstr "顯示額外的除錯用資訊"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:79
+msgid "Add a cache ID to each component"
+msgstr "加入快取 ID 至各個組件"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:82
+msgid "Include failed results in the output"
+msgstr "在輸出中列入失敗的結果"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:85
 msgid "Add HiDPI icons to the tarball"
 msgstr "將 HiDPI 圖示加入 Tarball 中"
 
 #. TRANSLATORS: command line option
-msgid "Add a cache ID to each component"
-msgstr "加入快取 ID 至各個組件"
-
-#. TRANSLATORS: command description
-msgid "Add a language to a source file"
-msgstr "加入語言到來源檔中"
-
-#. TRANSLATORS: command description
-msgid "Add a provide to a source file"
-msgstr "加入提供者到來源檔中"
-
-#. TRANSLATORS: command line option
+#: client/as-builder.c:88
 msgid "Add encoded icons to the XML"
 msgstr "將編碼的圖示加到 XML 中"
 
-#. TRANSLATORS: application was added
-msgid "Added"
-msgstr "已加入"
-
-#. TRANSLATORS: this is a command alias
-#, c-format
-msgid "Alias to %s"
-msgstr "%s 的別名"
-
-#. TRANSLATORS: program name
-msgid "AppStream Utility"
-msgstr "AppStream 公用程式"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-msgid "Cancelled"
-msgstr "已取消"
-
-#. TRANSLATORS: command description
-msgid "Check installed application data"
-msgstr "檢查安裝的應用程式資料"
-
-msgid "Command not found, valid commands are:"
-msgstr "找不到指令，有效的指令有："
-
-#. TRANSLATORS: command description
-msgid "Compare the contents of two AppStream files"
-msgstr "比較兩份 AppStream 檔案的內容"
-
-#. TRANSLATORS: command description
-msgid "Compare version numbers"
-msgstr "比較版本號"
-
-#. TRANSLATORS: the %s and %s are file types,
-#. * e.g. "appdata" to "appstream"
-#, c-format
-msgid "Conversion %s to %s is not implemented"
-msgstr "尚未實作從 %s 至 %s 的轉換"
-
-#. TRANSLATORS: command description
-msgid "Convert an AppData file to NEWS format"
-msgstr "將 AppData 檔轉換成 NEWS 格式"
-
-#. TRANSLATORS: command description
-msgid "Convert an NEWS file to AppData format"
-msgstr "將 NEWS 檔轉換成 AppData 格式"
-
-#. TRANSLATORS: command description
-msgid "Converts AppStream metadata from one version to another"
-msgstr "將 AppStream 中介資料從一個版本轉換成另一個版本"
-
-#. TRANSLATORS: command description
-msgid "Create an CSV status document"
-msgstr "建立 CSV 狀態文件"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML matrix page"
-msgstr "建立 HTML matrix 頁面"
-
-#. TRANSLATORS: command description
-msgid "Create an HTML status page"
-msgstr "建立 HTML 狀態網頁"
-
-#. TRANSLATORS: command description
-msgid "Display application search tokens"
-msgstr "顯示應用程式搜尋代符"
-
 #. TRANSLATORS: command line option
+#: client/as-builder.c:91
 msgid "Do not compress the icons into a tarball"
 msgstr "不要將圖示壓縮到 Tarball 中"
 
-#. TRANSLATORS: this is the --nonet argument
-msgid "Do not use network access"
-msgstr "不要使用網路存取"
-
-#. success
-#. TRANSLATORS: information message
-msgid "Done!"
-msgstr "完成！"
-
-#. TRANSLATORS: command description
-msgid "Dumps the applications in the AppStream metadata"
-msgstr "將應用程式傾印到 AppStream 中介資料中"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:94
+msgid "Set the logging directory"
+msgstr "設定紀錄用目錄"
 
 #. TRANSLATORS: command line option
-msgid "Enable profiling"
-msgstr "啟用評測"
+#: client/as-builder.c:97
+msgid "Set the packages directory"
+msgstr "設定軟體包目錄"
 
-#. TRANSLATORS: this is when the folder could
-#. * not be created
-msgid "Error creating output directory"
-msgstr "建立輸出目錄時發生錯誤"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:100
+msgid "Set the temporary directory"
+msgstr "設定暫存目錄"
 
-#. TRANSLATORS: the .appdata.xml file could not
-#. * be loaded
-msgid "Error loading AppData file"
-msgstr "載入 AppData 檔案時發生錯誤"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:103 client/as-compose.c:332
+msgid "Set the output directory"
+msgstr "設定輸出目錄"
 
-#. TRANSLATORS: the .desktop file could not
-#. * be loaded
-msgid "Error loading desktop file"
-msgstr "載入桌面檔時發生錯誤"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:106 client/as-compose.c:335
+msgid "Set the icons directory"
+msgstr "設定圖示目錄"
 
-#. TRANSLATORS: we could not auto-add the kudo
-msgid "Error parsing kudos"
-msgstr "解析嘉許時發生錯誤"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:109
+msgid "Set the cache directory"
+msgstr "設定快取目錄"
 
-#. TRANSLATORS: we could not auto-add the provides
-msgid "Error parsing provides"
-msgstr "解析提供項時發生錯誤"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:112 client/as-compose.c:344
+msgid "Set the basenames of the output files"
+msgstr "設定輸出檔案的基礎名稱"
 
-#. TRANSLATORS: the .mo files could not be parsed
-msgid "Error parsing translations"
-msgstr "解析翻譯時發生錯誤"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:115 client/as-compose.c:338
+msgid "Set the origin name"
+msgstr "設定來源名稱"
 
-#. TRANSLATORS: this is when the destination file
-#. * cannot be saved for some reason
-msgid "Error saving AppStream file"
-msgstr "儲存 AppStream 檔案時發生錯誤"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:118
+msgid "Set the number of threads"
+msgstr "設定執行緒的數目"
 
-#. TRANSLATORS: command description
-msgid "Exports the agreement to text"
-msgstr "將同意條款輸出至文字檔案"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:121 client/as-compose.c:341
+msgid "Set the minimum icon size in pixels"
+msgstr "設定圖示的最小像素大小"
 
-#. list failures
-msgid "FAILED"
-msgstr "失敗"
+#. TRANSLATORS: command line option
+#: client/as-builder.c:124
+msgid "Set the old metadata location"
+msgstr "設定舊的中介資料位置"
+
+#. TRANSLATORS: command line option
+#: client/as-builder.c:127
+msgid "Ignore certain types of veto"
+msgstr "忽略特定類型的 veto"
 
 #. TRANSLATORS: error message
-msgid "Failed to add package"
-msgstr "無法加入軟體包"
-
-#. TRANSLATORS: error message
-msgid "Failed to generate metadata"
-msgstr "無法生成中介資料"
-
-#. TRANSLATORS: error message
-msgid "Failed to open packages"
-msgstr "無法開啟軟體包"
-
-#. TRANSLATORS: error message
+#: client/as-builder.c:141 client/as-compose.c:358 client/as-util.c:4714
 msgid "Failed to parse arguments"
 msgstr "無法解析引數"
 
 #. TRANSLATORS: error message
+#: client/as-builder.c:246
 msgid "Failed to set up builder"
 msgstr "無法設置組建程式"
 
+#. TRANSLATORS: error message
+#: client/as-builder.c:265
+msgid "Failed to open packages"
+msgstr "無法開啟軟體包"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:275
+msgid "Scanning packages..."
+msgstr "正在掃描軟體包..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:285
+msgid "Failed to add package"
+msgstr "無法加入軟體包"
+
+#. TRANSLATORS: information message
+#: client/as-builder.c:291
+#, c-format
+msgid "Parsed %u/%u files..."
+msgstr "已解析 %u/%u 份檔案..."
+
+#. TRANSLATORS: error message
+#: client/as-builder.c:301
+msgid "Failed to generate metadata"
+msgstr "無法生成中介資料"
+
+#. success
+#. TRANSLATORS: information message
+#: client/as-builder.c:308 client/as-compose.c:537
+msgid "Done!"
+msgstr "完成！"
+
+#. TRANSLATORS: we've saving the icon file to disk
+#: client/as-compose.c:109 client/as-compose.c:163
+msgid "Saving icon"
+msgstr "正在儲存圖示"
+
+#. TRANSLATORS: command line option
+#: client/as-compose.c:329
+msgid "Set the prefix"
+msgstr "設定前綴"
+
+#. TRANSLATORS: we're generating the AppStream data
+#: client/as-compose.c:401
+msgid "Processing application"
+msgstr "正在處理應用程式"
+
+#. TRANSLATORS: the .appdata.xml file could not
+#. * be loaded
+#: client/as-compose.c:407
+msgid "Error loading AppData file"
+msgstr "載入 AppData 檔案時發生錯誤"
+
+#. TRANSLATORS: the .mo files could not be parsed
+#: client/as-compose.c:420
+msgid "Error parsing translations"
+msgstr "解析翻譯時發生錯誤"
+
+#. TRANSLATORS: we could not auto-add the kudo
+#: client/as-compose.c:431
+msgid "Error parsing kudos"
+msgstr "解析嘉許時發生錯誤"
+
+#. TRANSLATORS: we could not auto-add the provides
+#: client/as-compose.c:442
+msgid "Error parsing provides"
+msgstr "解析提供項時發生錯誤"
+
+#. TRANSLATORS: not a valid desktop filename
+#: client/as-compose.c:465
+msgid "Invalid desktop filename"
+msgstr "無效的桌面檔名稱"
+
+#. TRANSLATORS: the .desktop file could not
+#. * be loaded
+#: client/as-compose.c:484
+msgid "Error loading desktop file"
+msgstr "載入桌面檔時發生錯誤"
+
+#. TRANSLATORS: this is when the folder could
+#. * not be created
+#: client/as-compose.c:512
+msgid "Error creating output directory"
+msgstr "建立輸出目錄時發生錯誤"
+
+#. TRANSLATORS: we've saving the XML file to disk
+#: client/as-compose.c:521
+msgid "Saving AppStream"
+msgstr "正在儲存 AppStream"
+
+#. TRANSLATORS: this is when the destination file
+#. * cannot be saved for some reason
+#: client/as-compose.c:531
+msgid "Error saving AppStream file"
+msgstr "儲存 AppStream 檔案時發生錯誤"
+
+#. TRANSLATORS: this is a command alias
+#: client/as-util.c:93
+#, c-format
+msgid "Alias to %s"
+msgstr "%s 的別名"
+
+#: client/as-util.c:175
+msgid "Command not found, valid commands are:"
+msgstr "找不到指令，有效的指令有："
+
+#. TRANSLATORS: any manual changes required?
+#. * also note: FIXME is a hardcoded string
+#: client/as-util.c:467
+msgid "Please review the file and fix any 'FIXME' items"
+msgstr "請檢閱檔案並修正任何有「FIXME」的項目"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:485
+msgid "Old API version"
+msgstr "舊 API 版本"
+
+#. TRANSLATORS: information message
+#: client/as-util.c:497
+msgid "New API version"
+msgstr "新 API 版本"
+
+#: client/as-util.c:516
+msgid "Not enough arguments, expected old.xml new.xml version"
+msgstr "引數不夠，預期 old.xml new.xml 版本"
+
+#. TRANSLATORS: the %s and %s are file types,
+#. * e.g. "appdata" to "appstream"
+#: client/as-util.c:552
+#, c-format
+msgid "Conversion %s to %s is not implemented"
+msgstr "尚未實作從 %s 至 %s 的轉換"
+
+#: client/as-util.c:569
+msgid "Not enough arguments, expected file.xml"
+msgstr "引數不足，預期 file.xml"
+
 #. TRANSLATORS: %s is a file type,
 #. * e.g. 'appdata'
+#: client/as-util.c:595
 #, c-format
 msgid "File format '%s' cannot be upgraded"
 msgstr "無法升級「%s」格式"
 
 #. TRANSLATORS: not a recognised file type
+#: client/as-util.c:638 client/as-util.c:1038 client/as-util.c:1139
 msgid "Format not recognised"
 msgstr "無法辨別格式"
 
-#. TRANSLATORS: command description
-msgid "Generate a GUID from an input string"
-msgstr "從輸入字串生成 GUID"
-
-#. TRANSLATORS: command line option
-msgid "Ignore certain types of veto"
-msgstr "忽略特定類型的 veto"
-
-#. TRANSLATORS: command description
-msgid "Import a file to AppStream markup"
-msgstr "匯入檔案到 AppStream 標記"
-
-#. TRANSLATORS: command line option
-msgid "Include failed results in the output"
-msgstr "在輸出中列入失敗的結果"
-
-#. TRANSLATORS: command description
-msgid "Incorporate extra metadata from an external file"
-msgstr "從外部檔案整合額外中介資料"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata"
-msgstr "安裝 AppStream 中介資料"
-
-#. TRANSLATORS: command description
-msgid "Installs AppStream metadata with new origin"
-msgstr "以新來源安裝 AppStream 中介資料"
-
-#. TRANSLATORS: not a valid desktop filename
-msgid "Invalid desktop filename"
-msgstr "無效的桌面檔名稱"
-
-#. TRANSLATORS: command description
-msgid "List applications not backed by packages"
-msgstr "列出未受軟體包支持的應用程式"
-
-#. TRANSLATORS: command description
-msgid "Merge several files to an AppStream file"
-msgstr "將多個檔案合併成一份 AppStream 檔"
-
-#. TRANSLATORS: command description
-msgid "Mirror upstream screenshots"
-msgstr "同步使用上游畫面快照"
-
-#. TRANSLATORS: command description
-msgid "Modify an AppData file"
-msgstr "修改 AppData 檔"
-
-#. TRANSLATORS: information message
-msgid "New API version"
-msgstr "新 API 版本"
-
 #. TRANSLATORS: probably wrong XML
+#: client/as-util.c:1979
 msgid "No desktop applications found"
 msgstr "找不到桌面應用程式"
 
-msgid "Not enough arguments, expected file.xml"
-msgstr "引數不足，預期 file.xml"
-
-msgid "Not enough arguments, expected old.xml new.xml version"
-msgstr "引數不夠，預期 old.xml new.xml 版本"
-
 #. TRANSLATORS: the file is valid
+#: client/as-util.c:2711 client/as-util.c:2928
 msgid "OK"
 msgstr "確定"
 
-#. TRANSLATORS: information message
-msgid "Old API version"
-msgstr "舊 API 版本"
+#. list failures
+#: client/as-util.c:2716 client/as-util.c:2920
+msgid "FAILED"
+msgstr "失敗"
 
-#. TRANSLATORS: information message
+#: client/as-util.c:2812
+msgid "Validation failed"
+msgstr "驗證失敗"
+
+#: client/as-util.c:2856
+msgid "Validation of files failed"
+msgstr "檔案驗證失敗"
+
+#: client/as-util.c:2908
 #, c-format
-msgid "Parsed %u/%u files..."
-msgstr "已解析 %u/%u 份檔案..."
+msgid "Cannot validate version of file format '%s'"
+msgstr ""
 
-#. TRANSLATORS: any manual changes required?
-#. * also note: FIXME is a hardcoded string
-msgid "Please review the file and fix any 'FIXME' items"
-msgstr "請檢閱檔案並修正任何有「FIXME」的項目"
+#: client/as-util.c:2924
+#, fuzzy
+msgid "Version validation failed"
+msgstr "驗證失敗"
 
-#. TRANSLATORS: we're generating the AppStream data
-msgid "Processing application"
-msgstr "正在處理應用程式"
+#: client/as-util.c:2976
+#, fuzzy
+msgid "Version validation of files failed"
+msgstr "檔案驗證失敗"
 
 #. TRANSLATORS: application was removed
+#: client/as-util.c:4076
 msgid "Removed"
 msgstr "已移除"
 
-#. TRANSLATORS: command description
-msgid "Replace screenshots in source file"
-msgstr "替換源檔內的畫面快照"
+#. TRANSLATORS: application was added
+#: client/as-util.c:4089
+msgid "Added"
+msgstr "已加入"
 
-#. TRANSLATORS: we've saving the XML file to disk
-msgid "Saving AppStream"
-msgstr "正在儲存 AppStream"
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#: client/as-util.c:4372
+msgid "Cancelled"
+msgstr "已取消"
 
-#. TRANSLATORS: we've saving the icon file to disk
-msgid "Saving icon"
-msgstr "正在儲存圖示"
-
-#. TRANSLATORS: information message
-msgid "Scanning packages..."
-msgstr "正在掃描軟體包..."
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications"
-msgstr "搜尋 AppStream 應用程式"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by category name"
-msgstr "依據類別名稱搜尋 AppStream 應用程式"
-
-#. TRANSLATORS: command description
-msgid "Search for AppStream applications by package name"
-msgstr "依據軟體包名稱搜尋 AppStream 應用程式"
+#. TRANSLATORS: this is the --nonet argument
+#: client/as-util.c:4426
+msgid "Do not use network access"
+msgstr "不要使用網路存取"
 
 #. TRANSLATORS: command line option
-msgid "Set the basenames of the output files"
-msgstr "設定輸出檔案的基礎名稱"
-
-#. TRANSLATORS: command line option
-msgid "Set the cache directory"
-msgstr "設定快取目錄"
-
-#. TRANSLATORS: command line option
-msgid "Set the icons directory"
-msgstr "設定圖示目錄"
-
-#. TRANSLATORS: command line option
-msgid "Set the logging directory"
-msgstr "設定紀錄用目錄"
-
-#. TRANSLATORS: command line option
-msgid "Set the minimum icon size in pixels"
-msgstr "設定圖示的最小像素大小"
-
-#. TRANSLATORS: command line option
-msgid "Set the number of threads"
-msgstr "設定執行緒的數目"
-
-#. TRANSLATORS: command line option
-msgid "Set the old metadata location"
-msgstr "設定舊的中介資料位置"
-
-#. TRANSLATORS: command line option
-msgid "Set the origin name"
-msgstr "設定來源名稱"
-
-#. TRANSLATORS: command line option
-msgid "Set the output directory"
-msgstr "設定輸出目錄"
-
-#. TRANSLATORS: command line option
-msgid "Set the packages directory"
-msgstr "設定軟體包目錄"
-
-#. TRANSLATORS: command line option
-msgid "Set the prefix"
-msgstr "設定前綴"
-
-#. TRANSLATORS: command line option
-msgid "Set the temporary directory"
-msgstr "設定暫存目錄"
-
-#. TRANSLATORS: command description
-msgid "Show all installed AppStream applications"
-msgstr "顯示所有安裝的 AppStream 應用程式"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "顯示額外的除錯用資訊"
-
-#. TRANSLATORS: command line option
+#: client/as-util.c:4432
 msgid "Show version"
 msgstr "顯示版本"
 
-#. TRANSLATORS: command description
-msgid "Split an AppStream file to AppData and Metainfo files"
-msgstr "將 AppStream 檔案切分為 AppData 和 Metainfo 檔案"
+#. TRANSLATORS: command line option
+#: client/as-util.c:4435
+msgid "Enable profiling"
+msgstr "啟用評測"
 
 #. TRANSLATORS: command description
-msgid "Test a regular expression"
-msgstr "測試常規表述式"
+#: client/as-util.c:4467
+msgid "Converts AppStream metadata from one version to another"
+msgstr "將 AppStream 中介資料從一個版本轉換成另一個版本"
 
 #. TRANSLATORS: command description
-msgid "Uninstalls AppStream metadata"
-msgstr "解除 AppStream 中介資料的安裝"
-
-#. TRANSLATORS: command description
+#: client/as-util.c:4473
 msgid "Upgrade AppData metadata to the latest version"
 msgstr "將 AppData 中介資料升級至最新版"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4479
+msgid "Creates an example AppData file from a .desktop file"
+msgstr ""
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4485
+msgid "Dumps the applications in the AppStream metadata"
+msgstr "將應用程式傾印到 AppStream 中介資料中"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4491
+msgid "Search for AppStream applications"
+msgstr "搜尋 AppStream 應用程式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4497
+msgid "Search for AppStream applications by package name"
+msgstr "依據軟體包名稱搜尋 AppStream 應用程式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4503
+msgid "Show all installed AppStream applications"
+msgstr "顯示所有安裝的 AppStream 應用程式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4509
+msgid "Search for AppStream applications by category name"
+msgstr "依據類別名稱搜尋 AppStream 應用程式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4515
+msgid "Display application search tokens"
+msgstr "顯示應用程式搜尋代符"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4521
+msgid "Installs AppStream metadata"
+msgstr "安裝 AppStream 中介資料"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4527
+msgid "Installs AppStream metadata with new origin"
+msgstr "以新來源安裝 AppStream 中介資料"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4533
+msgid "Uninstalls AppStream metadata"
+msgstr "解除 AppStream 中介資料的安裝"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4539
+msgid "Create an HTML status page"
+msgstr "建立 HTML 狀態網頁"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4545
+msgid "Create an CSV status document"
+msgstr "建立 CSV 狀態文件"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4551
+msgid "Create an HTML matrix page"
+msgstr "建立 HTML matrix 頁面"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4557
+msgid "List applications not backed by packages"
+msgstr "列出未受軟體包支持的應用程式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4563
 msgid "Validate an AppData or AppStream file"
 msgstr "驗證 AppData 或 AppStream 檔案"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4569
 msgid "Validate an AppData or AppStream file (relaxed)"
 msgstr "驗證 AppData 或 AppStream 檔案 (寬鬆檢驗)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4575
+msgid "Exports the agreement to text"
+msgstr "將同意條款輸出至文字檔案"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4581
 msgid "Validate an AppData or AppStream file (strict)"
 msgstr "驗證 AppData 或 AppStream 檔案 (嚴格檢驗)"
 
-msgid "Validation failed"
-msgstr "驗證失敗"
-
-msgid "Validation of files failed"
-msgstr "檔案驗證失敗"
-
-msgid "Version:"
-msgstr "版本："
+#. TRANSLATORS: command description
+#: client/as-util.c:4587
+#, fuzzy
+msgid "Validate that AppData file includes the specified release"
+msgstr "驗證 AppData 或 AppStream 檔案 (寬鬆檢驗)"
 
 #. TRANSLATORS: command description
+#: client/as-util.c:4593
+msgid "Convert an AppData file to NEWS format"
+msgstr "將 AppData 檔轉換成 NEWS 格式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4599
+msgid "Convert an NEWS file to AppData format"
+msgstr "將 NEWS 檔轉換成 AppData 格式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4605
+msgid "Check installed application data"
+msgstr "檢查安裝的應用程式資料"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4611
+msgid "check an installed application"
+msgstr "檢查安裝的應用程式"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4617
+msgid "Replace screenshots in source file"
+msgstr "替換源檔內的畫面快照"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4623
+msgid "Add a provide to a source file"
+msgstr "加入提供者到來源檔中"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4629
+msgid "Add a language to a source file"
+msgstr "加入語言到來源檔中"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4635
+msgid "Mirror upstream screenshots"
+msgstr "同步使用上游畫面快照"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4641
+msgid "Incorporate extra metadata from an external file"
+msgstr "從外部檔案整合額外中介資料"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4647
+msgid "Compare the contents of two AppStream files"
+msgstr "比較兩份 AppStream 檔案的內容"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4653
+msgid "Generate a GUID from an input string"
+msgstr "從輸入字串生成 GUID"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4659
+msgid "Modify an AppData file"
+msgstr "修改 AppData 檔"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4665
+msgid "Split an AppStream file to AppData and Metainfo files"
+msgstr "將 AppStream 檔案切分為 AppData 和 Metainfo 檔案"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4671
+msgid "Merge several files to an AppStream file"
+msgstr "將多個檔案合併成一份 AppStream 檔"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4677
+msgid "Import a file to AppStream markup"
+msgstr "匯入檔案到 AppStream 標記"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4683
 msgid "Watch AppStream locations for changes"
 msgstr "監看 AppStream 位置是否有變動"
 
 #. TRANSLATORS: command description
-msgid "check an installed application"
-msgstr "檢查安裝的應用程式"
+#: client/as-util.c:4689
+msgid "Compare version numbers"
+msgstr "比較版本號"
+
+#. TRANSLATORS: command description
+#: client/as-util.c:4695
+msgid "Test a regular expression"
+msgstr "測試常規表述式"
+
+#. TRANSLATORS: program name
+#: client/as-util.c:4708
+msgid "AppStream Utility"
+msgstr "AppStream 公用程式"
+
+#: client/as-util.c:4732
+msgid "Version:"
+msgstr "版本："


### PR DESCRIPTION
These are moving to libappstream-glib as they are used by gnome-software
and libmalcontent-ui, and are potentially useful in other projects. In
particular, there are a number of translatable strings which need to be
centralised so that translation work isn’t repeated.

This code was originally written by:
 • Richard Hughes <richard@hughsie.com>
 • Piotr Drąg <piotrdrag@gmail.com>
 • Philip Withnall <withnall@endlessm.com>
 • Jordi Mas <jmas@softcatala.org>

It was previously in `src/gs-content-rating.[ch]` in gnome-software,
under the GPL-2.0+; and in `libmalcontent-ui/gs-content-rating.[ch]` in
malcontent, also under the GPL-2.0+. Relicensing from LGPL to GPL can
happen automatically.

In moving it from one project to the other, I have added documentation
comments and tweaked some of the APIs to make them more usable.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

Draft until:
 [ ] Relicensing is agreed to by all contributors (see below)
 [ ] Commit message has been updated to include relicensing details/agreements
 [ ] MR exists for moving translations over