### PR TITLE
Validate launchable tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ copy. To do the latter just do:
 
     dnf install docbook-utils gettext-devel glib-devel \
                 gobject-introspection-devel gperf gtk-doc gtk3-devel \
-                libarchive-devel libsoup-devel \
+                json-glib-devel libarchive-devel libsoup-devel \
                 libstemmer-devel libuuid-devel libyaml-devel \
                 meson rpm-devel
     mkdir build && cd build

--- a/data/tests/broken.appdata.xml
+++ b/data/tests/broken.appdata.xml
@@ -22,6 +22,9 @@
   <url type="bugtracker">www.dave.org</url>
   <updatecontact></updatecontact>
   <categories><category>Game</category></categories>
+  <launchable type="desktop-id">test.desktop</launchable>
+  <launchable type="desktop">test.desktop</launchable>
+  <launchable type="desktop-id"></launchable>
 
   <xxx>This is not a valid tag</xxx>
   <releases>

--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -1179,6 +1179,35 @@ as_app_validate_check_id (AsAppValidateHelper *helper, const gchar *id)
 	}
 }
 
+static void
+as_app_validate_launchables (AsApp *app, AsAppValidateHelper *helper)
+{
+	GPtrArray *launchables = as_app_get_launchables (app);
+
+	/* launchable isn't required */
+	if (launchables == NULL)
+		return;
+
+	/* check each launchable in the file */
+	for (guint j = 0; j < launchables->len; j++) {
+		AsLaunchable *tmp = g_ptr_array_index (launchables, j);
+
+		if (as_launchable_get_kind (tmp) == AS_LAUNCHABLE_KIND_UNKNOWN) {
+			ai_app_validate_add (helper,
+			     AS_PROBLEM_KIND_ATTRIBUTE_INVALID,
+			     "<launchable> has invalid type attribute");
+			continue;
+		}
+
+		if (as_launchable_get_value (tmp) == NULL) {
+			ai_app_validate_add (helper,
+			     AS_PROBLEM_KIND_VALUE_MISSING,
+			     "<launchable> missing value");
+			continue;
+		}
+	}
+}
+
 /**
  * as_app_validate:
  * @app: a #AsApp instance.
@@ -1589,6 +1618,9 @@ as_app_validate (AsApp *app, guint32 flags, GError **error)
 
 	/* icons */
 	as_app_validate_icons (app, helper);
+
+	/* launchables */
+	as_app_validate_launchables (app, helper);
 
 	/* releases */
 	if (!as_app_validate_releases (app, helper, error))

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2433,7 +2433,11 @@ as_test_app_validate_file_bad_func (void)
 				    "<release> timestamp is in the future");
 	as_test_app_validate_check (probs, AS_PROBLEM_KIND_MARKUP_INVALID,
 				    "<id> has invalid character");
-	g_assert_cmpint (probs->len, ==, 21);
+	as_test_app_validate_check (probs, AS_PROBLEM_KIND_ATTRIBUTE_INVALID,
+				    "<launchable> has invalid type attribute");
+	as_test_app_validate_check (probs, AS_PROBLEM_KIND_VALUE_MISSING,
+				    "<launchable> missing value");
+	g_assert_cmpint (probs->len, ==, 23);
 
 	/* again, harder */
 	probs2 = as_app_validate (app, AS_APP_VALIDATE_FLAG_STRICT, &error);
@@ -2441,7 +2445,7 @@ as_test_app_validate_file_bad_func (void)
 	g_assert (probs2 != NULL);
 	as_test_app_validate_check (probs2, AS_PROBLEM_KIND_TAG_INVALID,
 				    "XML data contains unknown tag");
-	g_assert_cmpint (probs2->len, ==, 35);
+	g_assert_cmpint (probs2->len, ==, 37);
 }
 
 static void


### PR DESCRIPTION
This adds in validation of the <launchable> tags on every validation mode (since the type field of a launchable tag is a required field if launchable is present).

It also adds a dependency to the readme that was missing (the configuration step wouldn't succeed until I installed that).

Fixes #368.