### PR TITLE
Don't ignore localized strings that are the same as original

### DIFF
--- a/libappstream-glib/as-node.c
+++ b/libappstream-glib/as-node.c
@@ -1721,7 +1721,6 @@ as_node_get_localized (const AsNode *node, const gchar *key)
 	AsNodeData *data;
 	AsRefString *data_unlocalized;
 	AsRefString *xml_lang;
-	const gchar *data_localized;
 	GHashTable *hash = NULL;
 	AsNode *tmp;
 	g_autoptr(AsRefString) xml_lang_c = as_ref_string_new_static ("C");
@@ -1747,13 +1746,9 @@ as_node_get_localized (const AsNode *node, const gchar *key)
 		if (g_strcmp0 (xml_lang, "x-test") == 0)
 			continue;
 
-		/* avoid storing identical strings */
-		data_localized = data->cdata;
-		if (xml_lang != NULL && g_strcmp0 (data_unlocalized, data_localized) == 0)
-			continue;
 		g_hash_table_insert (hash,
 				     as_ref_string_ref (xml_lang != NULL ? xml_lang : xml_lang_c),
-				     (gpointer) data_localized);
+				     (gpointer) data->cdata);
 	}
 	return hash;
 }


### PR DESCRIPTION
Avoiding storing identical strings is a clever measure to keep the
appstream file small and clean, but it ignores translation differences
between languages and their specific locales.

Applications tend to "fallback" from missing locales by picking a
translation of the same language but from a different locale.
For instance, when missing a "pt_BR" translation, some apps will
pick the "pt" translation instead. That usually works but there
are some cases when it doesn't, such as for international words:
Brazilian Portuguese (pt_BR) tends to use them, while European
Portuguese (pt) has a translation for everything.

This way, "GNOME Boxes" gets translated to "Caixas GNOME" in
European Portuguese (pt) but the same "GNOME Boxes" name is
expected in Brazilian Portuguese (pt_BR).

This was initially reported as a Flatpak issue in
https://lists.freedesktop.org/archives/flatpak/2019-May/001578.html
Because OP was seeing the wrong translations in Flathub and
GNOME Software.

Original commit was done by @felipeborges in his personal branch at
github, commit 54f97aadcd2c00f3d95b472db6e4dda1c0c9865b