### PR TITLE
builder: make directories as 0755 && umask

### DIFF
--- a/libappstream-builder/asb-utils.c
+++ b/libappstream-builder/asb-utils.c
@@ -99,7 +99,7 @@ asb_utils_ensure_exists (const gchar *directory, GError **error)
 {
 	if (g_file_test (directory, G_FILE_TEST_EXISTS))
 		return TRUE;
-	if (g_mkdir_with_parents (directory, 0700) != 0) {
+	if (g_mkdir_with_parents (directory, 0755) != 0) {
 		g_set_error (error,
 			     ASB_PLUGIN_ERROR,
 			     ASB_PLUGIN_ERROR_FAILED,

--- a/libappstream-glib/as-icon.c
+++ b/libappstream-glib/as-icon.c
@@ -975,7 +975,7 @@ as_icon_convert_to_kind (AsIcon *icon, AsIconKind kind, GError **error)
 		/* ensure the parent path exists */
 		size_str = g_strdup_printf ("%ux%u", priv->width, priv->height);
 		path = g_build_filename (priv->prefix, size_str, NULL);
-		if (g_mkdir_with_parents (path, 0700) != 0) {
+		if (g_mkdir_with_parents (path, 0755) != 0) {
 			g_set_error (error,
 				     AS_ICON_ERROR,
 				     AS_ICON_ERROR_FAILED,


### PR DESCRIPTION
Ideally only libappstream-builder would be fixed, but
asb_utils_ensure_exists is (transitively) called from builder too, so
fixing also that.

Fixes: #399
Merges: #400