### PR TITLE
meson: Check --version-script linker option before using.

### DIFF
--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -138,7 +138,9 @@ if platform_osx
   mapfile = 'appstream-glib.map.osx-clang'
   vflag = '-Wl,-exported_symbols_list,@0@/@1@'.format(meson.current_source_dir(), mapfile)
 else
-  vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+  vflag = cc.get_supported_link_arguments([
+    '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile),
+  ])
 endif
 
 asglib = shared_library(

--- a/meson.build
+++ b/meson.build
@@ -2,8 +2,10 @@ project('appstream-glib', 'c',
   version : '0.7.19',
   license : 'LGPL-2.1+',
   default_options : ['warning_level=1', 'c_std=c99'],
-  meson_version : '>=0.37.0'
+  meson_version : '>=0.46.0'
 )
+
+cc = meson.get_compiler('c')
 
 as_version = meson.project_version()
 varr = as_version.split('.')
@@ -105,7 +107,6 @@ endif
 
 # support stemming of search tokens
 if get_option('stemmer')
-  cc = meson.get_compiler('c')
   stemmer = cc.find_library('stemmer')
   conf.set('HAVE_LIBSTEMMER', 1)
 endif


### PR DESCRIPTION
mingw clang does not support --version-script linker option.