### PR TITLE
Consider AppStream version as a string

### DIFF
--- a/client/as-util.c
+++ b/client/as-util.c
@@ -482,8 +482,7 @@ as_util_convert_appstream (GFile *file_input,
 	if (!as_store_from_file (store, file_input, NULL, NULL, error))
 		return FALSE;
 	/* TRANSLATORS: information message */
-	g_print ("%s: %.2f\n", _("Old API version"),
-		 as_store_get_api_version (store));
+	g_print (_("Old API version: %s\n"), as_store_get_version (store));
 
 	/* save file */
 	as_store_set_api_version (store, new_version);
@@ -494,7 +493,7 @@ as_util_convert_appstream (GFile *file_input,
 				NULL, error))
 		return FALSE;
 	/* TRANSLATORS: information message */
-	g_print ("%s: %.2f\n", _("New API version"), as_store_get_api_version (store));
+	g_print (_("New API version: %s\n"), as_store_get_version (store));
 	return TRUE;
 }
 

--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -4831,7 +4831,7 @@ as_app_node_insert (AsApp *app, GNode *parent, AsNodeContext *ctx)
 
 	/* <custom> or <metadata> */
 	if (g_hash_table_size (priv->metadata) > 0) {
-		tmp = as_node_context_get_version (ctx) > 0.9 ? "custom" : "metadata";
+		tmp = as_utils_vercmp (as_node_context_get_version (ctx), "0.9") > 0 ? "custom" : "metadata";
 		node_tmp = as_node_insert (node_app, tmp, NULL, 0, NULL);
 		as_node_insert_hash (node_tmp, "value", "key", priv->metadata, FALSE);
 	}
@@ -6463,7 +6463,7 @@ as_app_to_xml (AsApp *app, GError **error)
 {
 	g_autoptr(AsNodeContext) ctx = as_node_context_new ();
 	g_autoptr(AsNode) root = as_node_new ();
-	as_node_context_set_version (ctx, 1.0);
+	as_node_context_set_version (ctx, "1.0");
 	as_node_context_set_output (ctx, AS_FORMAT_KIND_APPDATA);
 	as_app_node_insert (app, root, ctx);
 	return as_node_to_xml (root,

--- a/libappstream-glib/as-node-private.h
+++ b/libappstream-glib/as-node-private.h
@@ -20,9 +20,9 @@ G_BEGIN_DECLS
 typedef struct _AsNodeContext	AsNodeContext;
 AsNodeContext	*as_node_context_new		(void);
 void		 as_node_context_free		(AsNodeContext	*ctx);
-gdouble		 as_node_context_get_version	(AsNodeContext	*ctx);
+const gchar	*as_node_context_get_version	(AsNodeContext	*ctx);
 void		 as_node_context_set_version	(AsNodeContext	*ctx,
-						 gdouble	 version);
+						 const gchar	*version);
 AsFormatKind	 as_node_context_get_format_kind (AsNodeContext	*ctx);
 void		 as_node_context_set_format_kind (AsNodeContext	*ctx,
 						 AsFormatKind	 format_kind);

--- a/libappstream-glib/as-node.c
+++ b/libappstream-glib/as-node.c
@@ -2166,7 +2166,7 @@ as_node_get_localized_unwrap (const AsNode *node, GError **error)
 struct _AsNodeContext {
 	AsFormatKind	 format_kind;
 	AsFormatKind	 output;
-	gdouble		 version;
+	gchar		*version;
 	gboolean	 output_trusted;
 	AsRefString	*media_base_url;
 };
@@ -2185,7 +2185,7 @@ as_node_context_new (void)
 {
 	AsNodeContext *ctx;
 	ctx = g_new0 (AsNodeContext, 1);
-	ctx->version = 0.f;
+	ctx->version = g_strdup ("0.0");
 	ctx->format_kind = AS_FORMAT_KIND_APPSTREAM;
 	ctx->output = AS_FORMAT_KIND_UNKNOWN;
 	return ctx;
@@ -2206,6 +2206,7 @@ as_node_context_free (AsNodeContext *ctx)
 		return;
 	if (ctx->media_base_url != NULL)
 		as_ref_string_unref (ctx->media_base_url);
+	g_clear_pointer (&ctx->version, g_free);
 	g_free (ctx);
 }
 
@@ -2215,11 +2216,11 @@ as_node_context_free (AsNodeContext *ctx)
  *
  * Gets the AppStream API version used when parsing or inserting nodes.
  *
- * Returns: version number
+ * Returns: the API version
  *
- * Since: 0.3.6
+ * Since: 0.7.19
  **/
-gdouble
+const gchar *
 as_node_context_get_version (AsNodeContext *ctx)
 {
 	return ctx->version;
@@ -2228,16 +2229,19 @@ as_node_context_get_version (AsNodeContext *ctx)
 /**
  * as_node_context_set_version: (skip)
  * @ctx: a #AsNodeContext.
- * @version: an API version number to target.
+ * @version: an API version to target.
  *
  * Sets the AppStream API version used when parsing or inserting nodes.
  *
- * Since: 0.3.6
+ * Since: 0.7.19
  **/
 void
-as_node_context_set_version (AsNodeContext *ctx, gdouble version)
+as_node_context_set_version (AsNodeContext *ctx, const gchar *version)
 {
-	ctx->version = version;
+	if (g_strcmp0 (ctx->version, version) != 0) {
+		g_free (ctx->version);
+		ctx->version = g_strdup (version);
+	}
 }
 
 /**

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -533,7 +533,7 @@ as_test_release_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_release_node_insert (release, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -604,7 +604,7 @@ as_test_provide_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_provide_node_insert (provide, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -646,7 +646,7 @@ as_test_launchable_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_launchable_node_insert (launchable, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -737,7 +737,7 @@ as_test_release_appstream_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 1.0);
+	as_node_context_set_version (ctx, "1.0");
 	as_node_context_set_format_kind (ctx, AS_FORMAT_KIND_APPSTREAM);
 	n = as_release_node_insert (release, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
@@ -1021,7 +1021,7 @@ as_test_icon_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_icon_node_insert (icon, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, "<icon type=\"cached\" height=\"64\" width=\"64\">app.png</icon>", &error);
@@ -1084,7 +1084,7 @@ as_test_icon_scale_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.9);
+	as_node_context_set_version (ctx, "0.9");
 	n = as_icon_node_insert (icon, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1136,7 +1136,7 @@ as_test_checksum_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_checksum_node_insert (csum, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1230,7 +1230,7 @@ as_test_icon_embedded_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_icon_node_insert (icon, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1291,7 +1291,7 @@ as_test_image_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_image_node_insert (image, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1369,7 +1369,7 @@ as_test_agreement_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_agreement_node_insert (agreement, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1431,7 +1431,7 @@ as_test_review_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_review_node_insert (review, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1497,7 +1497,7 @@ as_test_require_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_app_node_insert (app, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1577,7 +1577,7 @@ as_test_suggest_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_suggest_node_insert (suggest, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1622,7 +1622,7 @@ as_test_bundle_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_bundle_node_insert (bundle, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1665,7 +1665,7 @@ as_test_translation_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_translation_node_insert (translation, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1728,7 +1728,7 @@ as_test_screenshot_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.8);
+	as_node_context_set_version (ctx, "0.8");
 	n = as_screenshot_node_insert (screenshot, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -1794,7 +1794,7 @@ as_test_content_rating_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.8);
+	as_node_context_set_version (ctx, "0.8");
 	n = as_content_rating_node_insert (content_rating, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -2120,7 +2120,7 @@ as_test_app_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 1.0);
+	as_node_context_set_version (ctx, "1.0");
 	n = as_app_node_insert (app, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -2750,7 +2750,7 @@ as_test_app_no_markup_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_app_node_insert (app, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
 	ret = as_test_compare_lines (xml->str, src, &error);
@@ -3767,7 +3767,7 @@ as_test_store_demote_func (void)
 
 	/* add apps */
 	store = as_store_new ();
-	as_store_set_api_version (store, 0.8);
+	as_store_set_version (store, "0.8");
 	as_store_add_app (store, app_desktop);
 	as_store_add_app (store, app_appdata);
 
@@ -3950,7 +3950,7 @@ as_test_store_func (void)
 	g_assert_cmpstr (as_store_get_origin (store), ==, NULL);
 
 	/* check string output */
-	as_store_set_api_version (store, 0.6);
+	as_store_set_version (store, "0.6");
 	xml = as_store_to_xml (store, 0);
 	ret = as_test_compare_lines (xml->str,
 				     "<components version=\"0.6\">"
@@ -3972,7 +3972,7 @@ as_test_store_func (void)
 	as_store_remove_app (store, app);
 
 	/* check string output */
-	as_store_set_api_version (store, 0.6);
+	as_store_set_version (store, "0.6");
 	xml = as_store_to_xml (store, 0);
 	ret = as_test_compare_lines (xml->str,
 				     "<components version=\"0.6\">"
@@ -4159,7 +4159,7 @@ as_test_store_versions_func (void)
 	g_assert (as_app_get_format_by_kind (app, AS_FORMAT_KIND_APPSTREAM) != NULL);
 
 	/* test with latest features */
-	as_store_set_api_version (store, 0.6);
+	as_store_set_version (store, "0.6");
 	g_assert_cmpfloat (as_store_get_api_version (store), <, 0.6 + 0.01);
 	g_assert_cmpfloat (as_store_get_api_version (store), >, 0.6 - 0.01);
 	xml = as_store_to_xml (store, AS_NODE_TO_XML_FLAG_FORMAT_MULTILINE);
@@ -4323,7 +4323,7 @@ as_test_node_no_dup_c_func (void)
 
 	/* back to node */
 	root = as_node_new ();
-	as_node_context_set_version (ctx, 0.4);
+	as_node_context_set_version (ctx, "0.4");
 	n = as_app_node_insert (app, root, ctx);
 	xml = as_node_to_xml (n, AS_NODE_TO_XML_FLAG_NONE);
 	g_assert_cmpstr (xml->str, ==,

--- a/libappstream-glib/as-store.h
+++ b/libappstream-glib/as-store.h
@@ -258,6 +258,9 @@ void		 as_store_set_destdir		(AsStore	*store,
 gdouble		 as_store_get_api_version	(AsStore	*store);
 void		 as_store_set_api_version	(AsStore	*store,
 						 gdouble	 api_version);
+const gchar	*as_store_get_version		(AsStore	*store);
+void		 as_store_set_version		(AsStore	*store,
+						 const gchar	*api_version);
 guint32		 as_store_get_add_flags		(AsStore	*store);
 void		 as_store_set_add_flags		(AsStore	*store,
 						 guint32	 add_flags);


### PR DESCRIPTION
Always store the AppStream metadata version as a string and compare it
like any other version.
This allows to have 0.10 > 0.8 for instance.