### PR TITLE
Don't emit legacy component type values

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -138,7 +138,7 @@ const gchar *
 as_app_kind_to_string (AsAppKind kind)
 {
 	if (kind == AS_APP_KIND_DESKTOP)
-		return "desktop";
+		return "desktop-application";
 	if (kind == AS_APP_KIND_CODEC)
 		return "codec";
 	if (kind == AS_APP_KIND_FONT)
@@ -146,7 +146,7 @@ as_app_kind_to_string (AsAppKind kind)
 	if (kind == AS_APP_KIND_INPUT_METHOD)
 		return "inputmethod";
 	if (kind == AS_APP_KIND_WEB_APP)
-		return "webapp";
+		return "web-application";
 	if (kind == AS_APP_KIND_SOURCE)
 		return "source";
 	if (kind == AS_APP_KIND_ADDON)


### PR DESCRIPTION
Emitting the old names was likely kept to not create any breakage and provide full backwards compatibility between different versions. However, asglib has supported the new names for years now and emitting the older ones actually causes problems now, in the case of `webapp`: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/899
This change also makes asglib emit `desktop-application` instead of `desktop`, which likely doesn't fix any real-world issues, as we'll keep the `desktop` alias forever, but it's nice to emit the full name for consistency.