### PR TITLE
misc: Port to libsoup3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
   - docker build -t appstream-glib-debian-buster -f contrib/ci/Dockerfile-debian-buster .
 
 script:
-  - docker run -t -v `pwd`:/build appstream-glib-fedora ./contrib/ci/build_and_test.sh -Drpm=true -Ddep11=false
-  - docker run -t -v `pwd`:/build appstream-glib-debian-buster ./contrib/ci/build_and_test.sh -Drpm=false -Ddep11=true
+  - docker run -t -v `pwd`:/build appstream-glib-fedora ./contrib/ci/build_and_test.sh -Drpm=true -Ddep11=false -Dsoup2=true
+  - docker run -t -v `pwd`:/build appstream-glib-debian-buster ./contrib/ci/build_and_test.sh -Drpm=false -Ddep11=true -Dsoup2=true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ copy. To do the latter just do:
                 libstemmer-devel libuuid-devel libyaml-devel \
                 meson rpm-devel
     mkdir build && cd build
-    meson .. --prefix=/opt -Dbuilder=false
+    meson .. --prefix=/opt -Dbuilder=false -Dsoup2=true
     ninja
 
 Hacking
@@ -92,7 +92,7 @@ binary and data files, or you can build a local copy. To do the latter just do:
                 libstemmer-devel libuuid-devel libyaml-devel \
                 meson rpm-devel rpm-devel
     mkdir build && cd build
-    meson .. --prefix=/opt -Dbuilder=true
+    meson .. --prefix=/opt -Dbuilder=true -Dsoup2=true
     ninja
 
 To actually run the extractor you can do:

--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -177,6 +177,9 @@ pkgg.generate(
   description : 'Objects and helper methods to help reading and writing AppStream metadata',
   filebase : 'appstream-glib',
   subdirs : 'libappstream-glib',
+  variables: [
+    'soupapiversion=' + soupapiversion,
+  ]
 )
 
 selftest = executable(

--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,13 @@ else
   uuid = dependency('uuid')
 endif
 libarchive = dependency('libarchive')
-soup = dependency('libsoup-2.4', version : '>= 2.51.92')
+if get_option('soup2')
+  soup = dependency('libsoup-2.4', version : '>= 2.51.92')
+  soupapiversion = '2.4'
+else
+  soup = dependency('libsoup-3.0', version : '>= 3.0.0')
+  soupapiversion = '3.0'
+endif
 json_glib = dependency('json-glib-1.0', version : '>= 1.1.2')
 gdkpixbuf = dependency('gdk-pixbuf-2.0', version : '>= 2.31.5')
 

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,17 @@ as_plugin_version = '5'
 lt_current = '8'
 lt_revision = '10'
 lt_age = '0'
+
+if get_option('soup2')
+  soup = dependency('libsoup-2.4', version : '>= 2.51.92')
+  soupapiversion = '2.4'
+  lt_age = '0'
+else
+  soup = dependency('libsoup-3.0', version : '>= 3.0.0')
+  soupapiversion = '3.0'
+  lt_age = '1'
+endif
+
 lt_version = '@0@.@1@.@2@'.format(lt_current, lt_age, lt_revision)
 
 # set plugindir for builder
@@ -74,13 +85,6 @@ else
   uuid = dependency('uuid')
 endif
 libarchive = dependency('libarchive')
-if get_option('soup2')
-  soup = dependency('libsoup-2.4', version : '>= 2.51.92')
-  soupapiversion = '2.4'
-else
-  soup = dependency('libsoup-3.0', version : '>= 3.0.0')
-  soupapiversion = '3.0'
-endif
 json_glib = dependency('json-glib-1.0', version : '>= 1.1.2')
 gdkpixbuf = dependency('gdk-pixbuf-2.0', version : '>= 2.31.5')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,3 +7,4 @@ option('stemmer', type : 'boolean', value : true, description : 'enable stemmer 
 option('man', type : 'boolean', value : true, description : 'generate man pages')
 option('gtk-doc', type : 'boolean', value : false, description : 'generate API reference')
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
+option('soup2', type: 'boolean', value: false, description: 'build with libsoup2')


### PR DESCRIPTION
Build for libsoup3 by default. Use -Dsoup2=true meson option to build
against libsoup2 instead. The libsoup API version is exposed in
the appstream-glib.pc file as well, thus the library users can check
they use the same libsoup API version as the appstream-glib library.