### PR TITLE
libappstream-builder: Fix file paths in icon tarball

### DIFF
--- a/libappstream-builder/asb-app.c
+++ b/libappstream-builder/asb-app.c
@@ -145,6 +145,7 @@ asb_app_save_resources (AsbApp *app, AsbAppSaveFlags save_flags, GError **error)
 		icons = as_app_get_icons (AS_APP (app));
 	for (i = 0; icons != NULL && i < icons->len; i++) {
 		const gchar *tmpdir;
+		g_autofree gchar *dir = NULL;
 		g_autofree gchar *filename = NULL;
 		g_autofree gchar *size_str = NULL;
 		g_autoptr(GError) error_local = NULL;
@@ -165,7 +166,9 @@ asb_app_save_resources (AsbApp *app, AsbAppSaveFlags save_flags, GError **error)
 
 		/* save to disk */
 		tmpdir = asb_package_get_config (priv->pkg, "IconsDir");
-		filename = g_build_filename (tmpdir,
+		dir = g_strdup_printf ("%ix%i", as_icon_get_width (icon),
+				       as_icon_get_height (icon));
+		filename = g_build_filename (tmpdir, dir,
 					     as_icon_get_name (icon),
 					     NULL);
 		if (!gdk_pixbuf_save (pixbuf, filename, "png", error, NULL))


### PR DESCRIPTION
dbd62f6e05 (#380) removed the WxH directory from the icon filenames, which were also
used as-is for the paths in the icons tarball. However, if width and height
are set on the icon, then it has to be inside a size-specific directory.
With HiDPI enabled, it did even overwrite the non-HiDPI icon it saved just
before because the filenames were the same.
Add the subdirectory back in the resource handling code.

CC @pwithnall

Before:

```
(appstream-builder:18724): Asb-DEBUG: 13:24:10.614: DEBUG:   Saved icon /tmp/tmp.wfYnMaboui/apb/icons/org.qbittorrent.qBittorrent.png
(appstream-builder:18724): Asb-DEBUG: 13:24:10.638: DEBUG:   Saved icon /tmp/tmp.wfYnMaboui/apb/icons/org.qbittorrent.qBittorrent.png
...
    <icon type="cached" height="64" width="64">org.qbittorrent.qBittorrent.png</icon>
    <icon type="cached" height="128" width="128">org.qbittorrent.qBittorrent.png</icon>
...
> tar tvf appdata-icons.tar.gz 
-rw-r--r-- 0/0            4983 1970-01-01 01:00 org.qbittorrent.qBittorrent.png
```

Now:
```
(appstream-builder:18837): Asb-DEBUG: 13:25:14.134: DEBUG:   Saved icon /tmp/tmp.wfYnMaboui/apb/icons/64x64/org.qbittorrent.qBittorrent.png
(appstream-builder:18837): Asb-DEBUG: 13:25:14.157: DEBUG:   Saved icon /tmp/tmp.wfYnMaboui/apb/icons/128x128/org.qbittorrent.qBittorrent.png
...
    <icon type="cached" height="64" width="64">org.qbittorrent.qBittorrent.png</icon>
    <icon type="cached" height="128" width="128">org.qbittorrent.qBittorrent.png</icon>
...
-rw-r--r-- 0/0            4983 1970-01-01 01:00 128x128/org.qbittorrent.qBittorrent.png
-rw-r--r-- 0/0            2957 1970-01-01 01:00 64x64/org.qbittorrent.qBittorrent.png
```