### PR TITLE
Create icons/64x64 folder also without --enable-hidpi

### DIFF
--- a/libappstream-builder/asb-context.c
+++ b/libappstream-builder/asb-context.c
@@ -510,6 +510,7 @@ asb_context_setup (AsbContext *ctx, GError **error)
 	g_autofree gchar *icons_dir = NULL;
 	g_autofree gchar *screenshot_dir1 = NULL;
 	g_autofree gchar *screenshot_dir2 = NULL;
+	g_autofree gchar *icons_dir_lodpi = NULL;
 
 	/* required stuff set */
 	if (priv->origin == NULL) {
@@ -565,12 +566,13 @@ asb_context_setup (AsbContext *ctx, GError **error)
 	/* icons is nuked; we can re-decompress from the -icons.tar.gz */
 	if (!asb_utils_ensure_exists (priv->icons_dir, error))
 		return FALSE;
+
+	icons_dir_lodpi = g_build_filename (priv->icons_dir, "64x64", NULL);
+	if (!asb_utils_ensure_exists (icons_dir_lodpi, error))
+		return FALSE;
+
 	if (priv->flags & ASB_CONTEXT_FLAG_HIDPI_ICONS) {
 		g_autofree gchar *icons_dir_hidpi = NULL;
-		g_autofree gchar *icons_dir_lodpi = NULL;
-		icons_dir_lodpi = g_build_filename (priv->icons_dir, "64x64", NULL);
-		if (!asb_utils_ensure_exists (icons_dir_lodpi, error))
-			return FALSE;
 		icons_dir_hidpi = g_build_filename (priv->icons_dir, "128x128", NULL);
 		if (!asb_utils_ensure_exists (icons_dir_hidpi, error))
 			return FALSE;


### PR DESCRIPTION
The icons are written into the folder, so make sure it exists. Without this,
appstream-builder fails if the temporary directory didn't have icons/64x64 yet.

I guess that previously icons didn't have width/height set, so they were written into the `icons` folder directly instead of the `64x64` subfolder.