### PR TITLE
Port from libsoup to libcurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ copy. To do the latter just do:
 
     dnf install docbook-utils gettext-devel glib-devel \
                 gobject-introspection-devel gperf gtk-doc gtk3-devel \
-                json-glib-devel libarchive-devel libsoup-devel \
+                json-glib-devel libarchive-devel libcurl-devel \
                 libstemmer-devel libuuid-devel libyaml-devel \
                 meson rpm-devel
     mkdir build && cd build

--- a/client/meson.build
+++ b/client/meson.build
@@ -10,9 +10,9 @@ if get_option('builder')
       asbuilder_incdir,
     ],
     dependencies : [
-      glib,
+      gio,
       gdkpixbuf,
-      soup,
+      libcurl,
       libarchive
     ],
     link_with : [
@@ -33,9 +33,9 @@ appstream_util = executable(
     asglib_incdir,
   ],
   dependencies : [
-    glib,
+    gio,
     gdkpixbuf,
-    soup,
+    libcurl,
     libarchive,
   ],
   link_with : asglib,
@@ -52,9 +52,9 @@ appstream_compose = executable(
     asglib_incdir,
   ],
   dependencies : [
-    glib,
+    gio,
     gdkpixbuf,
-    soup,
+    libcurl,
     libarchive,
   ],
   link_with : asglib,

--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -15,7 +15,7 @@ RUN dnf -y install \
 	gtk-doc \
 	json-glib-devel \
 	libarchive-devel \
-	libsoup-devel \
+	libcurl-devel \
 	libstemmer-devel \
 	libuuid-devel \
 	libxslt \

--- a/contrib/libappstream-glib.spec.in
+++ b/contrib/libappstream-glib.spec.in
@@ -1,5 +1,4 @@
 %global glib2_version 2.45.8
-%global libsoup_version 2.51.92
 %global json_glib_version 1.1.1
 %global gdk_pixbuf_version 2.31.5
 %define alphatag                #ALPHATAG#
@@ -18,7 +17,7 @@ BuildRequires: gtk-doc
 BuildRequires: gobject-introspection-devel
 BuildRequires: gperf
 BuildRequires: libarchive-devel
-BuildRequires: libsoup-devel >= %{libsoup_version}
+BuildRequires: libcurl-devel
 BuildRequires: gdk-pixbuf2-devel >= %{gdk_pixbuf_version}
 BuildRequires: gtk3-devel
 BuildRequires: gettext
@@ -42,7 +41,6 @@ BuildRequires: docbook-style-xsl
 Requires: gdk-pixbuf2%{?_isa} >= %{gdk_pixbuf_version}
 Requires: glib2%{?_isa} >= %{glib2_version}
 Requires: json-glib%{?_isa} >= %{json_glib_version}
-Requires: libsoup%{?_isa} >= %{libsoup_version}
 
 # no longer required
 Obsoletes: appdata-tools < 0.1.9

--- a/libappstream-builder/meson.build
+++ b/libappstream-builder/meson.build
@@ -6,11 +6,10 @@ asbuilder_cargs = [
 ]
 
 deps = [
-  glib,
+  gio,
   gmodule,
   gdkpixbuf,
   libarchive,
-  soup,
 ]
 
 if get_option('dep11')
@@ -68,7 +67,7 @@ asb_self_test = executable(
     include_directories('..'),
     asglib_incdir,
   ],
-  dependencies : [glib, gdkpixbuf, soup],
+  dependencies : [gio, gdkpixbuf],
   c_args : cargs + [
     '-DTESTDIRSRC="@0@/../data/tests"'.format(meson.current_source_dir()),
     '-DTESTDIRBUILD="@0@/../data/tests"'.format(meson.current_build_dir()),

--- a/libappstream-glib/as-utils.c
+++ b/libappstream-glib/as-utils.c
@@ -21,7 +21,6 @@
 #include <string.h>
 #include <archive_entry.h>
 #include <archive.h>
-#include <libsoup/soup.h>
 #include <stdlib.h>
 #ifndef _WIN32
 #ifdef __APPLE__

--- a/libappstream-glib/meson.build
+++ b/libappstream-glib/meson.build
@@ -6,9 +6,9 @@ cargs = [
 
 deps = [
   gdkpixbuf,
-  glib,
+  gio,
   libarchive,
-  soup,
+  libcurl,
 ]
 
 if platform_win32

--- a/meson.build
+++ b/meson.build
@@ -63,7 +63,7 @@ plugindir = join_paths(get_option('prefix'),
                        'asb-plugins-' + as_plugin_version)
 
 glib_ver = '>= 2.58.0'
-glib = dependency('glib-2.0', version : glib_ver)
+gio = dependency('gio-2.0', version : glib_ver)
 gmodule = dependency('gmodule-2.0', version : glib_ver)
 if platform_win32
   giowindows = dependency('gio-windows-2.0', version : glib_ver)
@@ -74,7 +74,7 @@ else
   uuid = dependency('uuid')
 endif
 libarchive = dependency('libarchive')
-soup = dependency('libsoup-2.4', version : '>= 2.51.92')
+libcurl = dependency('libcurl', version : '>= 7.56.0')
 json_glib = dependency('json-glib-1.0', version : '>= 1.1.2')
 gdkpixbuf = dependency('gdk-pixbuf-2.0', version : '>= 2.31.5')
 


### PR DESCRIPTION
The former bumped ABI, and all sorts of crazy happens when you link in
libappstream-glib into a process with the 'other' ABI.

It seems the universe has settled on curl as a dep; do the same.