### PR TITLE
Improve handling of <em> and <code> tags

### DIFF
--- a/libappstream-glib/as-node.c
+++ b/libappstream-glib/as-node.c
@@ -555,8 +555,8 @@ typedef struct {
 	AsNode			*current;
 	AsNodeFromXmlFlags	 flags;
 	const gchar * const	*locales;
-	guint8			 is_em_text;
-	guint8			 is_code_text;
+	guint8			 is_em_text:1;
+	guint8			 is_code_text:1;
 } AsNodeToXmlHelper;
 
 /**

--- a/libappstream-glib/as-node.c
+++ b/libappstream-glib/as-node.c
@@ -826,7 +826,7 @@ as_node_from_xml_internal (const gchar *data, gssize data_sz,
 			   AsNodeFromXmlFlags flags,
 			   GError **error)
 {
-	AsNodeToXmlHelper helper;
+	AsNodeToXmlHelper helper = {0};
 	AsNode *root = NULL;
 	gboolean ret;
 	g_autoptr(GError) error_local = NULL;
@@ -963,7 +963,7 @@ as_node_from_file (GFile *file,
 		   GCancellable *cancellable,
 		   GError **error)
 {
-	AsNodeToXmlHelper helper;
+	AsNodeToXmlHelper helper = {0};
 	GError *error_local = NULL;
 	AsNode *root = NULL;
 	const gchar *content_type = NULL;

--- a/libappstream-glib/as-self-test.c
+++ b/libappstream-glib/as-self-test.c
@@ -2870,6 +2870,15 @@ as_test_node_xml_func (void)
 			     "It now also supports <em>em</em> and <code>code</code> tags."
 			     "</p>"
 			     "</description>";
+	const gchar *valid_em_code_2 = "<description>"
+			     "<p><em>Emphasis</em> at the start of the paragraph</p>"
+			     "</description>";
+	const gchar *valid_em_code_empty = "<description>"
+			     "<p><em></em></p>"
+			     "</description>";
+	const gchar *valid_em_code_empty_2 = "<description>"
+			     "<p>empty <em></em> emphasis</p>"
+			     "</description>";
 	GError *error = NULL;
 	AsNode *n2;
 	AsNode *root;
@@ -2940,8 +2949,34 @@ as_test_node_xml_func (void)
 
 	n2 = as_node_find (root, "description/p");
 	g_assert (n2 != NULL);
-	printf ("<%s>\n", as_node_get_data (n2));
-	g_assert_cmpstr (as_node_get_data (n2), ==, "It now also supports<em>em</em> and <code>code</code> tags.");
+	g_assert_cmpstr (as_node_get_data (n2), ==, "It now also supports <em>em</em> and <code>code</code> tags.");
+	as_node_unref (root);
+
+	root = as_node_from_xml (valid_em_code_2, 0, &error);
+	g_assert_no_error (error);
+	g_assert (root != NULL);
+
+	n2 = as_node_find (root, "description/p");
+	g_assert (n2 != NULL);
+	g_assert_cmpstr (as_node_get_data (n2), ==, "<em>Emphasis</em> at the start of the paragraph");
+	as_node_unref (root);
+
+	root = as_node_from_xml (valid_em_code_empty, 0, &error);
+	g_assert_no_error (error);
+	g_assert (root != NULL);
+
+	n2 = as_node_find (root, "description/p");
+	g_assert (n2 != NULL);
+	g_assert_cmpstr (as_node_get_data (n2), ==, NULL);
+	as_node_unref (root);
+
+	root = as_node_from_xml (valid_em_code_empty_2, 0, &error);
+	g_assert_no_error (error);
+	g_assert (root != NULL);
+
+	n2 = as_node_find (root, "description/p");
+	g_assert (n2 != NULL);
+	g_assert_cmpstr (as_node_get_data (n2), ==, "empty  emphasis");
 	as_node_unref (root);
 
 	/* keep comments */


### PR DESCRIPTION
Three commits:
- [Properly initialize is_{em,code}_text fields](https://github.com/hughsie/appstream-glib/commit/9c0b92916dbadc16e66a4b782cfc773a8a041d35)
  Fixes: https://github.com/hughsie/appstream-glib/issues/445
- [trivial: Turn is_{em,code}_text fields into bitfields](https://github.com/hughsie/appstream-glib/commit/cbfa4a528c3e6eaee22475a98ee092269cbb0b95)
- [Improve handling of \<em\> and \<code\> tags](https://github.com/hughsie/appstream-glib/commit/bdebc8abfe0dbf5d9d5488af365b291f4b103ed0)

  This is still not great code but at least somewhat an improvement. Tests were expanded to showcase the new behavior.

  I think, ideally, we would append opening/closing tags to the ancestor `p` or `li` node's cdata as soon as we encounter the start/end of an `em` or `code` element. This would then also handle empty elements correctly.