### PR TITLE
Tell CURL to follow http redirect

### DIFF
--- a/client/as-util.c
+++ b/client/as-util.c
@@ -3447,6 +3447,7 @@ as_util_mirror_screenshots_app_url (AsUtilPrivate *priv,
 		}
 		(void)curl_easy_setopt(priv->curl, CURLOPT_URL, url);
 		(void)curl_easy_setopt(priv->curl, CURLOPT_ERRORBUFFER, errbuf);
+		(void)curl_easy_setopt(priv->curl, CURLOPT_FOLLOWLOCATION, 1);
 		(void)curl_easy_setopt(priv->curl,
 				       CURLOPT_WRITEFUNCTION,
 				       as_util_download_write_callback_cb);


### PR DESCRIPTION
- This is issue https://github.com/flathub/org.flatpak.Builder/issues/108 and https://github.com/flathub/org.flatpak.Builder/issues/112

Explanation: the switch to curl seems to have missed the fact that by default curl doesn't follow redirects

And flatpak-builder with `--mirror-screenshots-url` did fail when screenshot were hosted (but no only) on github.