### PR TITLE
asb-plugin-appdata: Never add default icons to firmware, IMs or codecs

### DIFF
--- a/libappstream-builder/plugins/asb-plugin-appdata.c
+++ b/libappstream-builder/plugins/asb-plugin-appdata.c
@@ -138,33 +138,14 @@ asb_plugin_process_filename (AsbPlugin *plugin,
 	/* fix up various components as required */
 	if (asb_context_get_flag (plugin->ctx, ASB_CONTEXT_FLAG_ADD_DEFAULT_ICONS)) {
 
-		/* add icon for firmware */
-		if (as_app_get_kind (AS_APP (app)) == AS_APP_KIND_FIRMWARE) {
-			g_autoptr(AsIcon) icon = NULL;
-			icon = as_icon_new ();
-			as_icon_set_kind (icon, AS_ICON_KIND_STOCK);
-			as_icon_set_name (icon, "application-x-executable");
-			as_app_add_icon (AS_APP (app), icon);
-		}
-
 		/* fix up input methods */
 		if (as_app_get_kind (AS_APP (app)) == AS_APP_KIND_INPUT_METHOD) {
-			g_autoptr(AsIcon) icon = NULL;
-			icon = as_icon_new ();
-			as_icon_set_kind (icon, AS_ICON_KIND_STOCK);
-			as_icon_set_name (icon, "system-run-symbolic");
-			as_app_add_icon (AS_APP (app), icon);
 			as_app_add_category (AS_APP (app), "Addons");
 			as_app_add_category (AS_APP (app), "InputSources");
 		}
 
 		/* fix up codecs */
 		if (as_app_get_kind (AS_APP (app)) == AS_APP_KIND_CODEC) {
-			g_autoptr(AsIcon) icon = NULL;
-			icon = as_icon_new ();
-			as_icon_set_kind (icon, AS_ICON_KIND_STOCK);
-			as_icon_set_name (icon, "application-x-addon");
-			as_app_add_icon (AS_APP (app), icon);
 			as_app_add_category (AS_APP (app), "Addons");
 			as_app_add_category (AS_APP (app), "Codecs");
 		}


### PR DESCRIPTION
Consumers of the appdata file are perfectly capable of adding their own default icons, and the specification doesn’t require icons to be present for any of these component types.

If appstream-builder provides a default icon, software centres cannot work out whether it’s provided by the component authors or by appstream-builder. This means software centres cannot override it with their own desktop-specific default icons.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

See: https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1483
Fixes: #419