### PR TITLE
Include screenshot size in all error messages

### DIFF
--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -555,8 +555,8 @@ ai_app_validate_image_check (AsImage *im, AsAppValidateHelper *helper)
 	if (screenshot_height < ss_size_height_min) {
 		ai_app_validate_add (helper,
 				     AS_PROBLEM_KIND_ATTRIBUTE_INVALID,
-				     "<screenshot> height too small [%s] minimum is %upx",
-				     url, ss_size_height_min);
+				     "<screenshot> height (%u) too small [%s] minimum is %upx",
+				     screenshot_height, url, ss_size_height_min);
 	}
 	if (screenshot_width > ss_size_width_max) {
 		ai_app_validate_add (helper,

--- a/libappstream-glib/as-app-validate.c
+++ b/libappstream-glib/as-app-validate.c
@@ -561,14 +561,14 @@ ai_app_validate_image_check (AsImage *im, AsAppValidateHelper *helper)
 	if (screenshot_width > ss_size_width_max) {
 		ai_app_validate_add (helper,
 				     AS_PROBLEM_KIND_ATTRIBUTE_INVALID,
-				     "<screenshot> width too large [%s] maximum is %upx",
-				     url, ss_size_width_max);
+				     "<screenshot> width (%u) too large [%s] maximum is %upx",
+				     screenshot_width, url, ss_size_width_max);
 	}
 	if (screenshot_height > ss_size_height_max) {
 		ai_app_validate_add (helper,
 				     AS_PROBLEM_KIND_ATTRIBUTE_INVALID,
-				     "<screenshot> height too large [%s] maximum is %upx",
-				     url, ss_size_height_max);
+				     "<screenshot> height (%u) too large [%s] maximum is %upx",
+				     screenshot_height, url, ss_size_height_max);
 	}
 
 	/* check padding */


### PR DESCRIPTION
Screenshot validation includes checking the image size, i.e:
- whether the width isn't too small
- whether the height isn't too small
- whether the width isn't too large
- whether the height isn't too large

Currently, when the first check fails, the error message includes the actual screenshot width. This is not the case for other checks - they do not contain any information about the dimensions. This patch fixes this inconsistency by making all four checks include the relevant information in their error message.