### PR TITLE
as-app: Print name of unknown app metadata tags

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -5366,6 +5366,7 @@ as_app_node_parse_child (AsApp *app, GNode *n, guint32 flags,
 			priv->problems |= AS_APP_PROBLEM_EXPECTED_CHILDREN;
 		break;
 	default:
+		g_warning ("Unknown tag: <%s>", as_node_get_name (n));
 		priv->problems |= AS_APP_PROBLEM_INVALID_XML_TAG;
 		break;
 	}


### PR DESCRIPTION
Currently, we just get a "XML data contains unknown tag" error message, without the actual tag name when running `"appstream-util validate-strict"`.

```
$ appstream-util validate-strict --nonet org.gnome.Nautilus.appdata.xml org.gnome.Nautilus.appdata.xml: FAILED:
..
• tag-invalid           : XML data contains unknown tag
..
Validation of files failed
```

With this commit, we now display a warning for each unknown tag.

```
(appstream-util:289727): As-WARNING **: 14:12:10.446: Unknown tag: <recommends>
```