### PR TITLE
Do not veto the extension if the parent cannot be found

### DIFF
--- a/libappstream-builder/asb-context.c
+++ b/libappstream-builder/asb-context.c
@@ -857,10 +857,6 @@ asb_context_detect_missing_parents (AsbContext *ctx, GError **error)
 		found = g_hash_table_lookup (hash, tmp);
 		if (found != NULL)
 			continue;
-
-		/* do not add the addon */
-		as_app_add_veto (app, "%s has no parent of '%s'",
-				 as_app_get_id (app), tmp);
 		g_print ("WARNING: %s has no parent of '%s'\n",
 			 as_app_get_id (app), tmp);
 	}


### PR DESCRIPTION
Fixes https://github.com/hughsie/appstream-glib/issues/482