### PR TITLE
asb-plugin-font: Make a priority for Regular style of fonts

### DIFF
--- a/libappstream-builder/plugins/asb-plugin-font.c
+++ b/libappstream-builder/plugins/asb-plugin-font.c
@@ -549,7 +549,7 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 	const gchar *tmp;
 	gboolean ret = TRUE;
 	guint i;
-	const FcPattern *pattern = NULL;
+	FcPattern *pattern = NULL;
 	g_autofree gchar *cache_id = NULL;
 	g_autofree gchar *comment = NULL;
 	g_autofree gchar *icon_filename = NULL;
@@ -580,7 +580,7 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 				     "FcConfigGetFonts failed");
 		goto out;
 	}
-	pattern = fonts->fonts[0];
+	pattern = FcPatternDuplicate (fonts->fonts[0]);
 
 	/* use the filename as the cache-id */
 	cache_id = g_path_get_basename (filename);
@@ -664,6 +664,8 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 		as_app_add_icon (AS_APP (app), icon);
 	}
 out:
+	if (pattern)
+		FcPatternDestroy (pattern);
 	FcConfigAppFontClear (config);
 	FcConfigDestroy (config);
 	return ret;

--- a/libappstream-builder/plugins/meson.build
+++ b/libappstream-builder/plugins/meson.build
@@ -120,7 +120,6 @@ if get_option('fonts')
     dependencies : [
       gdkpixbuf,
       gdk,
-      freetype,
       fontconfig,
     ],
     c_args : asb_plugins_cargs,

--- a/meson.build
+++ b/meson.build
@@ -88,7 +88,6 @@ if get_option('builder')
   if get_option('fonts')
     gdk = dependency('gdk-3.0')
     conf.set('HAVE_FONTS', 1)
-    freetype = dependency('freetype2', version : '>= 9.10.0')
     fontconfig = dependency('fontconfig')
   endif
 endif


### PR DESCRIPTION
This change aims to improve a text in summary and the order of screenshots for Regular style of fonts.

Removing a direct dependency to FreeType as a side-effect.

Fixes https://github.com/hughsie/appstream-glib/issues/493