### PR TITLE
asb-plugin-font: Use Harfbuzz to deal with RTL text for icons/screenshots

### DIFF
--- a/libappstream-builder/plugins/asb-plugin-font.c
+++ b/libappstream-builder/plugins/asb-plugin-font.c
@@ -549,7 +549,7 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 	const gchar *tmp;
 	gboolean ret = TRUE;
 	guint i;
-	const FcPattern *pattern = NULL;
+	FcPattern *pattern = NULL;
 	g_autofree gchar *cache_id = NULL;
 	g_autofree gchar *comment = NULL;
 	g_autofree gchar *icon_filename = NULL;
@@ -580,7 +580,7 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 				     "FcConfigGetFonts failed");
 		goto out;
 	}
-	pattern = fonts->fonts[0];
+	pattern = FcPatternDuplicate (fonts->fonts[0]);
 
 	/* use the filename as the cache-id */
 	cache_id = g_path_get_basename (filename);
@@ -664,6 +664,8 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 		as_app_add_icon (AS_APP (app), icon);
 	}
 out:
+	if (pattern)
+		FcPatternDestroy (pattern);
 	FcConfigAppFontClear (config);
 	FcConfigDestroy (config);
 	return ret;

--- a/libappstream-builder/plugins/asb-plugin-font.c
+++ b/libappstream-builder/plugins/asb-plugin-font.c
@@ -10,10 +10,11 @@
 #include <gdk/gdk.h>
 
 #include <cairo/cairo.h>
-#include <cairo/cairo-ft.h>
 #include <pango/pango.h>
 #include <pango/pangofc-fontmap.h>
 #include <fontconfig/fontconfig.h>
+#include <hb.h>
+#include <hb-cairo.h>
 
 #include <asb-plugin.h>
 
@@ -280,6 +281,7 @@ asb_font_get_pixbuf (const FcPattern *pat,
 		     const gchar *text,
 		     GError **error)
 {
+	hb_face_t *hb_face;
 	cairo_font_face_t *font_face;
 	cairo_surface_t *surface;
 	cairo_t *cr;
@@ -287,12 +289,23 @@ asb_font_get_pixbuf (const FcPattern *pat,
 	GdkPixbuf *pixbuf;
 	guint text_size = 64;
 	guint border_width = 8;
+	const gchar *filename = NULL;
+	gint idx = -1;
 
 	/* set up font */
+	FcPatternGetString (pat, FC_FILE, 0, (FcChar8 **) &filename);
+	FcPatternGetInteger (pat, FC_INDEX, 0, &idx);
+	if (filename == NULL || idx == -1) {
+		g_set_error_literal (error, ASB_PLUGIN_ERROR, ASB_PLUGIN_ERROR_FAILED,
+				     "Unable to get filename or index from pattern");
+		return NULL;
+	}
+
+	hb_face = hb_face_create_from_file_or_fail (filename, idx);
+	font_face = hb_cairo_font_face_create_for_face (hb_face);
 	surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
 					      (gint) width, (gint) height);
 	cr = cairo_create (surface);
-	font_face = cairo_ft_font_face_create_for_pattern ((FcPattern *) pat);
 	cairo_set_font_face (cr, font_face);
 
 	/* calculate best font size */
@@ -307,9 +320,7 @@ asb_font_get_pixbuf (const FcPattern *pat,
 	}
 
 	/* center text and blit to a pixbuf */
-	cairo_move_to (cr,
-		       (width / 2) - te.width / 2 - te.x_bearing,
-		       (height / 2) - te.height / 2 - te.y_bearing);
+	cairo_move_to (cr, (width - te.width) / 2., (height - te.height) / 2. - te.y_bearing);
 	cairo_set_source_rgb (cr, 0.0, 0.0, 0.0);
 	cairo_show_text (cr, text);
 	pixbuf = gdk_pixbuf_get_from_surface (surface, 0, 0, (gint) width, (gint) height);
@@ -323,6 +334,7 @@ asb_font_get_pixbuf (const FcPattern *pat,
 	cairo_destroy (cr);
 	cairo_font_face_destroy (font_face);
 	cairo_surface_destroy (surface);
+	hb_face_destroy (hb_face);
 	return pixbuf;
 }
 

--- a/libappstream-builder/plugins/meson.build
+++ b/libappstream-builder/plugins/meson.build
@@ -120,7 +120,6 @@ if get_option('fonts')
     dependencies : [
       gdkpixbuf,
       gdk,
-      freetype,
       fontconfig,
     ],
     c_args : asb_plugins_cargs,

--- a/libappstream-builder/plugins/meson.build
+++ b/libappstream-builder/plugins/meson.build
@@ -121,6 +121,7 @@ if get_option('fonts')
       gdkpixbuf,
       gdk,
       fontconfig,
+      harfbuzz,
     ],
     c_args : asb_plugins_cargs,
     name_suffix: name_suffix,

--- a/meson.build
+++ b/meson.build
@@ -88,7 +88,6 @@ if get_option('builder')
   if get_option('fonts')
     gdk = dependency('gdk-3.0')
     conf.set('HAVE_FONTS', 1)
-    freetype = dependency('freetype2', version : '>= 9.10.0')
     fontconfig = dependency('fontconfig')
   endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,7 @@ if get_option('builder')
     gdk = dependency('gdk-3.0')
     conf.set('HAVE_FONTS', 1)
     fontconfig = dependency('fontconfig')
+    harfbuzz = dependency('harfbuzz-cairo')
   endif
 endif
 


### PR DESCRIPTION
Cairo doesn't support RTL text. So giving cairo_glyph_t instance through harfbuzz-cairo to cairo.

Checking with google-noto-fonts, the number of icon files without this patch was:
```
$ tar tvfa /tmp/repodata/example-icons.tar.gz| wc -l
292
```

and with this patch:
```
$ tar tvfa /tmp/repodata/example-icons.tar.gz| wc -l
296
```

Please note that this patch is based on https://github.com/hughsie/appstream-glib/pull/496