### PR TITLE
Font screenshot additions and CDATA text

### DIFF
--- a/libappstream-builder/plugins/asb-plugin-font.c
+++ b/libappstream-builder/plugins/asb-plugin-font.c
@@ -295,10 +295,16 @@ asb_font_is_pixbuf_empty (const GdkPixbuf *pixbuf)
 	return TRUE;
 }
 
+typedef enum {
+	ENVIRONMENT_KIND_LIGHT,
+	ENVIRONMENT_KIND_DARK
+} EnvironmentKind;
+
 static GdkPixbuf *
 asb_font_get_pixbuf (FT_Face ft_face,
 		     guint width,
 		     guint height,
+		     EnvironmentKind env_kind,
 		     const gchar *text,
 		     GError **error)
 {
@@ -332,7 +338,10 @@ asb_font_get_pixbuf (FT_Face ft_face,
 	cairo_move_to (cr,
 		       (width / 2) - te.width / 2 - te.x_bearing,
 		       (height / 2) - te.height / 2 - te.y_bearing);
-	cairo_set_source_rgb (cr, 0.0, 0.0, 0.0);
+	if (env_kind == ENVIRONMENT_KIND_DARK)
+		cairo_set_source_rgb (cr, 1.0, 1.0, 1.0);
+	else
+		cairo_set_source_rgb (cr, 0.0, 0.0, 0.0);
 	cairo_show_text (cr, text);
 	pixbuf = gdk_pixbuf_get_from_surface (surface, 0, 0, (gint) width, (gint) height);
 	if (pixbuf == NULL) {
@@ -367,7 +376,7 @@ asb_font_get_caption (AsbApp *app)
 
 static gboolean
 asb_font_add_screenshot (AsbPlugin *plugin, AsbApp *app, FT_Face ft_face,
-			 const gchar *cache_id, GError **error)
+			 const gchar *cache_id, EnvironmentKind env_kind, GError **error)
 {
 	AsImage *im_tmp;
 	AsScreenshot *ss_tmp;
@@ -391,14 +400,15 @@ asb_font_add_screenshot (AsbPlugin *plugin, AsbApp *app, FT_Face ft_face,
 
 	/* is in the cache */
 	cache_dir = asb_context_get_cache_dir (plugin->ctx);
-	cache_fn = g_strdup_printf ("%s/screenshots/%s.png",
-				    cache_dir, cache_id);
+	cache_fn = g_strdup_printf ("%s/screenshots/%s%s.png",
+				    cache_dir, cache_id,
+				    env_kind == ENVIRONMENT_KIND_DARK ? "-dark" : "");
 	if (g_file_test (cache_fn, G_FILE_TEST_EXISTS)) {
 		pixbuf = gdk_pixbuf_new_from_file (cache_fn, error);
 		if (pixbuf == NULL)
 			return FALSE;
 	} else {
-		pixbuf = asb_font_get_pixbuf (ft_face, 640, 48, tmp, error);
+		pixbuf = asb_font_get_pixbuf (ft_face, 640, 48, env_kind, tmp, error);
 		if (pixbuf == NULL)
 			return FALSE;
 	}
@@ -422,8 +432,9 @@ asb_font_add_screenshot (AsbPlugin *plugin, AsbApp *app, FT_Face ft_face,
 	im = as_image_new ();
 	as_image_set_pixbuf (im, pixbuf);
 	as_image_set_kind (im, AS_IMAGE_KIND_SOURCE);
-	basename = g_strdup_printf ("%s-%s.png",
+	basename = g_strdup_printf ("%s%s-%s.png",
 				    as_app_get_id_filename (AS_APP (app)),
+				    env_kind == ENVIRONMENT_KIND_DARK ? "-dark" : "",
 				    as_image_get_md5 (im));
 	as_image_set_basename (im, basename);
 	url_tmp = g_build_filename ("file://",
@@ -463,6 +474,8 @@ asb_font_add_screenshot (AsbPlugin *plugin, AsbApp *app, FT_Face ft_face,
 	if (caption != NULL)
 		as_screenshot_set_caption (ss, NULL, caption);
 	as_app_add_screenshot (AS_APP (app), ss);
+	if (env_kind == ENVIRONMENT_KIND_DARK)
+		as_screenshot_set_environment (ss, "gnome:dark");
 
 	/* find screenshot priority */
 	tmp = as_app_get_metadata_item (AS_APP (app), "FontSubFamily");
@@ -639,7 +652,10 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 	asb_font_add_languages (app, pattern);
 	asb_font_add_metadata (app, ft_face);
 	asb_font_fix_metadata (app);
-	ret = asb_font_add_screenshot (plugin, app, ft_face, cache_id, error);
+	ret = asb_font_add_screenshot (plugin, app, ft_face, cache_id, ENVIRONMENT_KIND_LIGHT, error);
+	if (!ret)
+		goto out;
+	ret = asb_font_add_screenshot (plugin, app, ft_face, cache_id, ENVIRONMENT_KIND_DARK, error);
 	if (!ret)
 		goto out;
 
@@ -647,7 +663,7 @@ asb_plugin_font_app (AsbPlugin *plugin, AsbApp *app,
 	tmp = as_app_get_metadata_item (AS_APP (app), "FontIconText");
 	if (tmp != NULL) {
 		g_autoptr(AsIcon) icon = NULL;
-		pixbuf = asb_font_get_pixbuf (ft_face, 64, 64, tmp, error);
+		pixbuf = asb_font_get_pixbuf (ft_face, 64, 64, ENVIRONMENT_KIND_LIGHT, tmp, error);
 		if (pixbuf == NULL) {
 			ret = FALSE;
 			goto out;

--- a/libappstream-glib/as-node.c
+++ b/libappstream-glib/as-node.c
@@ -865,7 +865,7 @@ as_node_from_xml_internal (const gchar *data, gssize data_sz,
 	helper.current = root;
 	helper.locales = g_get_language_names ();
 	ctx = g_markup_parse_context_new (&parser,
-					  G_MARKUP_PREFIX_ERROR_POSITION,
+					  G_MARKUP_PREFIX_ERROR_POSITION | G_MARKUP_TREAT_CDATA_AS_TEXT,
 					  &helper,
 					  NULL);
 	ret = g_markup_parse_context_parse (ctx, data, data_sz, &error_local);
@@ -1043,7 +1043,7 @@ as_node_from_file (GFile *file,
 	helper.current = root;
 	helper.locales = g_get_language_names ();
 	ctx = g_markup_parse_context_new (&parser,
-					  G_MARKUP_PREFIX_ERROR_POSITION,
+					  G_MARKUP_PREFIX_ERROR_POSITION | G_MARKUP_TREAT_CDATA_AS_TEXT,
 					  &helper,
 					  NULL);
 

--- a/libappstream-glib/as-node.c
+++ b/libappstream-glib/as-node.c
@@ -1775,7 +1775,6 @@ GHashTable *
 as_node_get_localized (const AsNode *node, const gchar *key)
 {
 	AsNodeData *data;
-	AsRefString *data_unlocalized;
 	AsRefString *xml_lang;
 	GHashTable *hash = NULL;
 	AsNode *tmp;
@@ -1785,7 +1784,6 @@ as_node_get_localized (const AsNode *node, const gchar *key)
 	tmp = as_node_get_child_node (node, key, NULL, NULL);
 	if (tmp == NULL)
 		return NULL;
-	data_unlocalized = as_node_get_data_as_refstr (tmp);
 
 	/* find a node called name */
 	hash = g_hash_table_new_full (g_str_hash, g_str_equal,

--- a/libappstream-glib/as-screenshot.c
+++ b/libappstream-glib/as-screenshot.c
@@ -33,6 +33,7 @@ typedef struct
 	GHashTable		*captions;
 	GPtrArray		*images;
 	gint			 priority;
+	gchar			*environment;
 } AsScreenshotPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (AsScreenshot, as_screenshot, G_TYPE_OBJECT)
@@ -48,6 +49,7 @@ as_screenshot_finalize (GObject *object)
 	g_ptr_array_unref (priv->images);
 	if (priv->captions != NULL)
 		g_hash_table_unref (priv->captions);
+	g_free (priv->environment);
 
 	G_OBJECT_CLASS (as_screenshot_parent_class)->finalize (object);
 }
@@ -444,6 +446,8 @@ as_screenshot_node_insert (AsScreenshot *screenshot,
 	}
 	if (priv->priority != 0)
 		as_node_add_attribute_as_int (n, "priority", priv->priority);
+	if (priv->environment != NULL)
+		as_node_add_attribute (n, "environment", priv->environment);
 	for (i = 0; i < priv->images->len; i++) {
 		image = g_ptr_array_index (priv->images, i);
 		as_image_node_insert (image, n, ctx);
@@ -528,6 +532,11 @@ as_screenshot_node_parse (AsScreenshot *screenshot, GNode *node,
 		if (!as_image_node_parse (image, c, ctx, error))
 			return FALSE;
 		g_ptr_array_add (priv->images, g_object_ref (image));
+	}
+	/* add environment */
+	tmp = as_node_get_attribute (node, "environment");
+	if (tmp != NULL) {
+		as_screenshot_set_environment (screenshot, tmp);
 	}
 	return TRUE;
 }
@@ -618,6 +627,8 @@ as_screenshot_equal (AsScreenshot *screenshot1, AsScreenshot *screenshot2)
 	if (g_strcmp0 (as_screenshot_get_caption (screenshot1, NULL),
 		       as_screenshot_get_caption (screenshot2, NULL)) != 0)
 		return FALSE;
+	if (g_strcmp0 (priv1->environment, priv2->environment) != 0)
+		return FALSE;
 
 	/* check source images */
 	im1 = as_screenshot_get_source (screenshot1);
@@ -629,6 +640,50 @@ as_screenshot_equal (AsScreenshot *screenshot1, AsScreenshot *screenshot2)
 
 	/* success */
 	return TRUE;
+}
+
+/**
+ * as_screenshot_get_environment:
+ * @screenshot: an #AsScreenshot instance.
+ *
+ * Returns previously set environment value.
+ *
+ * Returns: environment value
+ *
+ * Since: 0.8.4
+ **/
+const gchar *
+as_screenshot_get_environment (AsScreenshot *screenshot)
+{
+	AsScreenshotPrivate *priv = GET_PRIVATE (screenshot);
+
+	g_return_val_if_fail (AS_IS_SCREENSHOT (screenshot), NULL);
+
+	return priv->environment;
+}
+
+/**
+ * as_screenshot_set_environment:
+ * @screenshot: an #AsScreenshot instance.
+ * @env_id: (nullable): an environment identificator.
+ *
+ * Set @env_id as an environment, for whichthe screenshot is suitable.
+ * A %NULL or empty @env_id unsets any previously set value.
+ *
+ * Since: 0.8.4
+ **/
+void
+as_screenshot_set_environment (AsScreenshot *screenshot,
+			       const gchar *env_id)
+{
+	AsScreenshotPrivate *priv = GET_PRIVATE (screenshot);
+
+	g_return_if_fail (AS_IS_SCREENSHOT (screenshot));
+
+	g_clear_pointer (&priv->environment, g_free);
+
+	if (env_id != NULL && *env_id != '\0')
+		priv->environment = g_strdup (env_id);
 }
 
 /**

--- a/libappstream-glib/as-screenshot.h
+++ b/libappstream-glib/as-screenshot.h
@@ -72,6 +72,7 @@ AsImage		*as_screenshot_get_image_for_locale (AsScreenshot	*screenshot,
 						 guint		 width,
 						 guint		 height);
 AsImage		*as_screenshot_get_source	(AsScreenshot	*screenshot);
+const gchar	*as_screenshot_get_environment	(AsScreenshot	*screenshot);
 
 /* setters */
 void		 as_screenshot_set_kind		(AsScreenshot	*screenshot,
@@ -83,6 +84,8 @@ void		 as_screenshot_set_caption	(AsScreenshot	*screenshot,
 						 const gchar	*caption);
 void		 as_screenshot_add_image	(AsScreenshot	*screenshot,
 						 AsImage	*image);
+void		 as_screenshot_set_environment	(AsScreenshot	*screenshot,
+						 const gchar	*env_id);
 gboolean	 as_screenshot_equal		(AsScreenshot	*screenshot1,
 						 AsScreenshot	*screenshot2);
 


### PR DESCRIPTION
This does couple things:
* the AppStream data with CDATA lost their text (related to https://github.com/hughsie/libxmlb/issues/290)
* add 'environment' property to AsScreenshot
* generate font screenshots for light and dark themes
* minor change, removal of an unused variable, spotted by the compiler