### PR TITLE
Use memmove for update_contact demunging to fix RISC-V test failure

### DIFF
--- a/libappstream-glib/as-app.c
+++ b/libappstream-glib/as-app.c
@@ -2663,9 +2663,9 @@ as_app_set_update_contact (AsApp *app, const gchar *update_contact)
 					    replacements[i].search);
 			if (tmp != NULL) {
 				*tmp = replacements[i].replace;
-				(void)g_strlcpy (tmp + 1,
-					   tmp + strlen (replacements[i].search),
-					   len);
+				memmove (tmp + 1,
+					 tmp + strlen (replacements[i].search),
+					 strlen (tmp + strlen (replacements[i].search)) + 1);
 				done_replacement = TRUE;
 			}
 		}


### PR DESCRIPTION
g_strlcpy() with overlapping buffers is undefined behavior and causes the as-self-test to fail on RISC-V, where the optimized memcpy does not handle the overlap:

  "richard_at_hughsie_dot_co_dot_uk" -> "richard@hugh_ie.cot_ut_uk"

Use memmove() instead which handles overlapping regions correctly.